### PR TITLE
fix: replace wait:true with callback_url+polling pattern in all skills

### DIFF
--- a/skills/acedatacloud-api/SKILL.md
+++ b/skills/acedatacloud-api/SKILL.md
@@ -99,11 +99,11 @@ curl -X POST https://api.acedata.cloud/face/analyze \
 
 Most generation APIs (images, video, music) are asynchronous:
 
-**Step 1:** Submit request
+**Step 1:** Submit with `callback_url` to force async and get a `task_id` immediately
 
 ```json
 POST /suno/audios
-{"prompt": "a jazz song", "wait": false}
+{"prompt": "a jazz song", "callback_url": "https://api.acedata.cloud/health"}
 → {"task_id": "abc123"}
 ```
 
@@ -115,7 +115,7 @@ POST /suno/tasks
 → {"state": "succeeded", "data": [...]}
 ```
 
-**Shortcut:** Pass `"wait": true` to block until completion (simpler but longer timeout).
+Poll every 3–5 seconds until `succeeded` or `failed`. Using `callback_url` avoids long-running HTTP connections that time out.
 
 ## Error Handling
 
@@ -160,7 +160,7 @@ Error response format:
 ## Gotchas
 
 - Tokens are **service-scoped** by default — create a global token if you need cross-service access
-- Async APIs return a `task_id` — you must poll to get the result
-- `wait: true` is convenient but has a timeout limit (typically 60–120s)
+- Async APIs return a `task_id` — always use `callback_url` to get the task_id immediately, then poll for results
+- Avoid `wait: true` — it blocks for the full generation duration and will time out for video/music tasks
 - Rate limits vary by service tier — upgrade your plan if hitting limits
 - All timestamps are in UTC

--- a/skills/flux-image/SKILL.md
+++ b/skills/flux-image/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/flux/images \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a cat wearing a space helmet, photorealistic", "model": "flux-dev", "wait": true}'
+  -d '{"prompt": "a cat wearing a space helmet, photorealistic", "model": "flux-dev", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/flux/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Models
@@ -75,6 +84,19 @@ POST /flux/images
 
 ## Task Polling
 
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /flux/images
+{
+  "prompt": "...",
+  "model": "flux-dev",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
+
 ```json
 POST /flux/tasks
 {"task_id": "your-task-id"}
@@ -96,4 +118,4 @@ Key tools: `flux_generate_image`, `flux_edit_image`
 - Editing requires kontext models (`flux-kontext-pro` or `flux-kontext-max`) — other models only support generation
 - `count` parameter generates multiple images in one request (increases cost proportionally)
 - Ultra model produces highest quality but is slowest — use dev for iteration, ultra for final output
-- All generation is async — use `"wait": true` or poll `/flux/tasks`
+- All generation is async — always set `"callback_url"` to get a `task_id` immediately, then poll `/flux/tasks`

--- a/skills/luma-video/SKILL.md
+++ b/skills/luma-video/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/luma/videos \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a drone flying over a mountain lake at sunrise", "action": "generate", "wait": true}'
+  -d '{"prompt": "a drone flying over a mountain lake at sunrise", "action": "generate", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/luma/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Workflows
@@ -97,12 +106,25 @@ POST /luma/videos
 
 ## Task Polling
 
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /luma/videos
+{
+  "prompt": "...",
+  "action": "generate",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
+
 ```json
 POST /luma/tasks
 {"task_id": "your-task-id"}
 ```
 
-Poll every 5 seconds. States: `pending` → `completed` or `failed`.
+States: `pending` → `completed` or `failed`.
 
 ## MCP Server
 

--- a/skills/midjourney-image/SKILL.md
+++ b/skills/midjourney-image/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/midjourney/imagine \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a futuristic city at sunset, cyberpunk style --ar 16:9", "wait": true}'
+  -d '{"prompt": "a futuristic city at sunset, cyberpunk style --ar 16:9", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/midjourney/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Generation Modes
@@ -148,6 +157,18 @@ Append these to your prompt text:
 | `--seed` | `--seed 12345` | Reproducible generation |
 
 ## Task Polling
+
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /midjourney/imagine
+{
+  "prompt": "...",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
 
 ```json
 POST /midjourney/tasks

--- a/skills/seedance-video/SKILL.md
+++ b/skills/seedance-video/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/seedance/videos \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a dancer performing contemporary ballet in a misty forest", "model": "seedance-1.0", "wait": true}'
+  -d '{"prompt": "a dancer performing contemporary ballet in a misty forest", "model": "seedance-1.0", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/seedance/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Models
@@ -78,6 +87,19 @@ POST /seedance/videos
 | `seed` | integer | Seed for reproducible results |
 
 ## Task Polling
+
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /seedance/videos
+{
+  "prompt": "...",
+  "model": "doubao-seedance-1-0-pro-250528",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
 
 ```json
 POST /seedance/tasks

--- a/skills/sora-video/SKILL.md
+++ b/skills/sora-video/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/sora/videos \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a golden retriever running on a beach at sunset", "model": "sora-2", "wait": true}'
+  -d '{"prompt": "a golden retriever running on a beach at sunset", "model": "sora-2", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/sora/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Models
@@ -87,6 +96,19 @@ POST /sora/videos
 | `orientation` | `"landscape"` (16:9), `"portrait"` (9:16), `"square"` (1:1) | Video orientation |
 
 ## Task Polling
+
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /sora/videos
+{
+  "prompt": "...",
+  "model": "sora-2",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
 
 ```json
 POST /sora/tasks

--- a/skills/suno-music/SKILL.md
+++ b/skills/suno-music/SKILL.md
@@ -25,7 +25,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/suno/audios \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a happy pop song about coding", "model": "chirp-v4-5", "wait": true}'
+  -d '{"prompt": "a happy pop song about coding", "model": "chirp-v4-5", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/suno/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Available Models
@@ -127,14 +136,14 @@ For best results follow this multi-step workflow:
 
 ## Task Polling
 
-All generation is async. Either use `"wait": true` for synchronous mode, or poll:
+All generation is async. Submit with `"callback_url"` to get a `task_id` immediately, then poll:
 
 ```json
 POST /suno/tasks
 {"task_id": "your-task-id"}
 ```
 
-Poll every 3–5 seconds until `status` is `"complete"`.
+Poll every 3–5 seconds until `status` is `"complete"`. Always use `callback_url` to avoid blocking — passing `"callback_url": "https://api.acedata.cloud/health"` forces async submission even without a real webhook endpoint.
 
 ## Lyrics Format
 
@@ -168,7 +177,7 @@ Key tools: `suno_generate_music`, `suno_generate_custom_music`, `suno_extend_mus
 
 ## Gotchas
 
-- All generation is **async** — always poll `/suno/tasks` or use `"wait": true`
+- All generation is **async** — always set `"callback_url"` to get a `task_id` immediately, then poll `/suno/tasks`
 - Lyrics max ~3000 characters. For longer songs, use the **extend** workflow
 - Style tags are descriptive phrases, not enum values (e.g., "Synthwave, Electronic, Dreamy")
 - `vocal_gender` ("f"/"m") is only supported on v4.5+ models

--- a/skills/veo-video/SKILL.md
+++ b/skills/veo-video/SKILL.md
@@ -24,7 +24,16 @@ export ACEDATACLOUD_API_TOKEN="your-token-here"
 curl -X POST https://api.acedata.cloud/veo/videos \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "a whale breaching in slow motion at golden hour", "model": "veo-3", "wait": true}'
+  -d '{"prompt": "a whale breaching in slow motion at golden hour", "model": "veo-3", "callback_url": "https://api.acedata.cloud/health"}'
+```
+
+This returns a `task_id` immediately. Poll for the result:
+
+```bash
+curl -X POST https://api.acedata.cloud/veo/tasks \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"task_id": "<task_id from above>"}'
 ```
 
 ## Models
@@ -86,6 +95,19 @@ POST /veo/videos/1080p
 | `enhance_prompt` | `true` / `false` | Let the model expand your prompt for better results |
 
 ## Task Polling
+
+Always use `callback_url` to get a `task_id` immediately without blocking:
+
+```json
+POST /veo/videos
+{
+  "prompt": "...",
+  "model": "veo-3",
+  "callback_url": "https://api.acedata.cloud/health"
+}
+```
+
+Then poll every 5 seconds until complete:
 
 ```json
 POST /veo/tasks


### PR DESCRIPTION
Update Quick Start examples and Task Polling sections across 8 SKILL.md files to use callback_url for async submission instead of blocking wait:true. Affected: suno-music, midjourney-image, luma-video, flux-image, sora-video, veo-video, seedance-video, acedatacloud-api