### PR TITLE
fix: use .env file for token setup instead of bare export

### DIFF
--- a/skills/_shared/authentication.md
+++ b/skills/_shared/authentication.md
@@ -2,17 +2,29 @@
 
 All AceDataCloud APIs use Bearer token authentication.
 
+## Get Your Token
+
+1. Register at [platform.acedata.cloud](https://platform.acedata.cloud)
+2. Subscribe to a service (most include free quota)
+3. Go to your service's **Credentials** page and create an API token
+
 ## Setup
 
+Create a `.env` file in your project root:
+
 ```bash
-export ACEDATACLOUD_API_TOKEN="your-token-here"
+ACEDATACLOUD_API_TOKEN=your_token_here
 ```
 
-Get your token at [platform.acedata.cloud](https://platform.acedata.cloud):
+Then load it before making API calls:
 
-1. Register an account
-2. Browse and subscribe to a service (most include free quota)
-3. Create an API credential (token)
+```bash
+source .env
+```
+
+> **Agent usage:** If you're running skills through Claude Code or another AI agent, the agent will automatically `source .env` from the project root before calling any API.
+
+> **Important:** Add `.env` to your `.gitignore` — never commit tokens to version control.
 
 ## Usage
 
@@ -23,9 +35,14 @@ curl -X POST https://api.acedata.cloud/<endpoint> \
   -d '{ ... }'
 ```
 
-### Token Types
+## Token Types
 
-| Type | Scope |
-|------|-------|
-| **Service Token** | Access to one subscribed service only |
-| **Global Token** | Access to all subscribed services |
+| Type | Scope | Use Case |
+|------|-------|----------|
+| **Service Token** | Single service | Default. Created per-subscription |
+| **Global Token** | All services | Create from the platform's global credentials page |
+
+## Gotchas
+
+- Tokens are **service-scoped** by default — if you get a 401 on a different service, create a global token or a token for that specific service
+- Tokens do not expire, but can be revoked from the platform

--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Works as a drop-in replacement for the OpenAI SDK.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Works as a drop-in replacement for the OpenAI SDK.
 ---
 
 # AI Chat — Unified LLM Gateway

--- a/skills/face-transform/SKILL.md
+++ b/skills/face-transform/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Face Transform

--- a/skills/fish-audio/SKILL.md
+++ b/skills/fish-audio/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Fish Audio — Voice & Audio Synthesis

--- a/skills/flux-image/SKILL.md
+++ b/skills/flux-image/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-flux-pro for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-flux-pro for tool-use.
 ---
 
 # Flux Image Generation

--- a/skills/google-search/SKILL.md
+++ b/skills/google-search/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-serp for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-serp for tool-use.
 ---
 
 # Google Search (SERP)

--- a/skills/hailuo-video/SKILL.md
+++ b/skills/hailuo-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Hailuo Video Generation

--- a/skills/kling-video/SKILL.md
+++ b/skills/kling-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Kling Video Generation

--- a/skills/luma-video/SKILL.md
+++ b/skills/luma-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-luma for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-luma for tool-use.
 ---
 
 # Luma Video Generation

--- a/skills/midjourney-image/SKILL.md
+++ b/skills/midjourney-image/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-midjourney for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-midjourney for tool-use.
 ---
 
 # Midjourney Image Generation

--- a/skills/nano-banana-image/SKILL.md
+++ b/skills/nano-banana-image/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-nano-banana for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-nano-banana for tool-use.
 ---
 
 # NanoBanana Image Generation

--- a/skills/producer-music/SKILL.md
+++ b/skills/producer-music/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Producer Music Generation

--- a/skills/seedance-video/SKILL.md
+++ b/skills/seedance-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-seedance for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-seedance for tool-use.
 ---
 
 # Seedance Video Generation

--- a/skills/seedream-image/SKILL.md
+++ b/skills/seedream-image/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-seedream for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-seedream for tool-use.
 ---
 
 # Seedream Image Generation

--- a/skills/short-url/SKILL.md
+++ b/skills/short-url/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-short-url for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-short-url for tool-use.
 ---
 
 # Short URL Service

--- a/skills/sora-video/SKILL.md
+++ b/skills/sora-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-sora for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-sora for tool-use.
 ---
 
 # Sora Video Generation

--- a/skills/suno-music/SKILL.md
+++ b/skills/suno-music/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-suno for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-suno for tool-use.
 ---
 
 # Suno Music Generation

--- a/skills/veo-video/SKILL.md
+++ b/skills/veo-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-veo for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-veo for tool-use.
 ---
 
 # Veo Video Generation

--- a/skills/wan-video/SKILL.md
+++ b/skills/wan-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable. Optionally pair with mcp-wan for tool-use.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md). Optionally pair with mcp-wan for tool-use.
 ---
 
 # Wan Video Generation

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-compatibility: Requires ACEDATACLOUD_API_TOKEN environment variable.
+compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md).
 ---
 
 # Template Skill


### PR DESCRIPTION
## Summary

- Updated `_shared/authentication.md` to instruct users to create a `.env` file in the project root instead of using bare `export` — more standard, persistent across sessions, and clear about file location
- Updated all 19 skill `compatibility` fields from "Requires ACEDATACLOUD_API_TOKEN environment variable" to "Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authentication.md)"
- Updated `template/SKILL.md` to match

## Test plan

- [ ] Verify `_shared/authentication.md` renders correctly on GitHub
- [ ] Confirm all skill SKILL.md files reference the new `.env` setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)