### PR TITLE
fix: standardize veo model name to veo31-fast-ingredients

### DIFF
--- a/skills/veo-video/SKILL.md
+++ b/skills/veo-video/SKILL.md
@@ -43,7 +43,7 @@ curl -X POST https://api.acedata.cloud/veo/tasks \
 | `veo3-fast` | Yes (native) | Faster audiovisual generation |
 | `veo31` | Yes (native) | Veo 3.1, highest quality |
 | `veo31-fast` | Yes (native) | Veo 3.1 fast variant |
-| `veo31-fast-ingredient` | Yes (native) | Veo 3.1 fast, ingredient mode |
+| `veo31-fast-ingredients` | Yes (native) | Veo 3.1 fast, ingredient mode |
 
 ## Workflows
 


### PR DESCRIPTION
## Summary
- Fix veo-video SKILL.md to use `veo31-fast-ingredients`

🤖 Generated with [Claude Code](https://claude.com/claude-code)