### PR TITLE
feat(tencentcloud): 6 official skills for Tencent Cloud devops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/skills/_shared/tencentcloud.md
+++ b/skills/_shared/tencentcloud.md
@@ -1,0 +1,84 @@
+# Tencent Cloud Authentication
+
+All `tencentcloud-*` skills authenticate with the same SecretId / SecretKey pair via the official Tencent Cloud Python SDK.
+
+## Get Your Credentials
+
+1. Sign in to [Tencent Cloud Console](https://console.cloud.tencent.com/cam/capi)
+2. Navigate to **Access Management → API Keys → Create Key**
+3. You'll get a **SecretId** (starts with `AKID...`) and a **SecretKey** that's displayed exactly once — save it before closing the page.
+
+> ⚠️ **Use a sub-account, not your main account.** Create a CAM sub-user with only the policies the skill needs (e.g. `QcloudCOSReadOnlyAccess` for read-only COS, `QcloudCLSReadOnlyAccess` for log queries) and generate the keys for that sub-account. Limits the blast radius if the credentials leak.
+
+## Setup
+
+The Tencent Cloud SDK reads credentials from these environment variables:
+
+| Variable | Description | Example |
+|---|---|---|
+| `TENCENTCLOUD_SECRET_ID` | API SecretId | `AKIDxxxxxxxxxxxx` |
+| `TENCENTCLOUD_SECRET_KEY` | API SecretKey (sensitive) | `xxxxxxxxxxxxxxxx` |
+| `TENCENTCLOUD_REGION` | Default region | `ap-hongkong`, `ap-guangzhou`, ... |
+
+**Local dev — `.env` file**:
+
+```bash
+TENCENTCLOUD_SECRET_ID=AKID...
+TENCENTCLOUD_SECRET_KEY=...
+TENCENTCLOUD_REGION=ap-hongkong
+```
+
+Load it before running any tool:
+
+```bash
+set -a; source .env; set +a
+```
+
+> ⚠️ **Important:** Add `.env` to your `.gitignore` — never commit credentials to git.
+
+**Agent usage** (Claude / Studio / etc.): If you've installed the [腾讯云 connector](https://auth.acedata.cloud/user/connections) on AceDataCloud, your encrypted credentials are auto-injected as the env vars above when the agent runs any `tencentcloud-*` skill — no manual `.env` setup needed.
+
+## Common regions
+
+| Region code | Location |
+|---|---|
+| `ap-hongkong` | Hong Kong, China |
+| `ap-guangzhou` | Guangzhou |
+| `ap-beijing` | Beijing |
+| `ap-shanghai` | Shanghai |
+| `ap-singapore` | Singapore |
+| `ap-tokyo` | Tokyo |
+| `eu-frankfurt` | Frankfurt |
+| `na-siliconvalley` | Silicon Valley |
+| `na-ashburn` | Ashburn (Virginia) |
+
+Full list: [Tencent Cloud regions and AZs](https://www.tencentcloud.com/document/product/213/6091).
+
+## Verifying credentials
+
+A quick sanity check that doesn't cost anything:
+
+```python
+from tencentcloud.common import credential
+from tencentcloud.cam.v20190116 import cam_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+client = cam_client.CamClient(cred, "ap-guangzhou")
+resp = client.GetUserAppId(models.GetUserAppIdRequest())
+print("OK, AppId =", resp.AppId)
+```
+
+Returns your Tencent Cloud `AppId` (a numeric account identifier). Any 4xx tells you the keys are wrong / expired / lack `QcloudCamReadOnlyAccess`.
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+```
+
+Service-specific add-ons used by individual skills:
+
+```bash
+pip install cos-python-sdk-v5      # tencentcloud-cos
+pip install kubernetes              # tencentcloud-tke (kubeconfig handling)
+```

--- a/skills/tencentcloud-cls-alarm/SKILL.md
+++ b/skills/tencentcloud-cls-alarm/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: tencentcloud-cls-alarm
+description: |
+  Manage Tencent Cloud CLS alarm policies, notice groups, shields and
+  alarm execution logs. Use when the user asks to: list / create /
+  modify / delete CLS alarms, enable or disable alarms, manage notice
+  recipients (SMS / email / webhook), mute alarms during deploys, or
+  view which alarms fired and when. For searching the underlying log
+  content, use the companion `tencentcloud-cls` skill.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# Tencent Cloud CLS — Alarm Management
+
+CRUD on CLS alarm policies, notice groups, mute shields, and the alarm execution log.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). Defaults to `TENCENTCLOUD_REGION` from env; CLS alarms live per-region.
+>
+> **Companion skill:** `tencentcloud-cls` for log content search.
+
+## When to Use
+
+- Inspect existing alarm policies (filter by name, enabled flag)
+- Create a new log-based alarm: CQL/SQL query → trigger condition → notice group
+- Modify thresholds, query, period, recipients
+- Quick enable / disable to mute during incidents
+- Manage notice groups (recipients: users, groups, webhooks, with escalation)
+- Time-bounded shield rules to mute during deploys
+- Pull the alarm execution log to see *which* alarms fired and when
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+```
+
+## Quick start
+
+```python
+import os
+import json
+from tencentcloud.common import credential
+from tencentcloud.cls.v20201016 import cls_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+client = cls_client.ClsClient(cred, os.environ["TENCENTCLOUD_REGION"])
+```
+
+## Key concepts
+
+| Object | API methods | What it is |
+|---|---|---|
+| Alarm policy | `DescribeAlarms` / `CreateAlarm` / `ModifyAlarm` / `DeleteAlarm` | Query against one or more topics + condition + notice groups |
+| Notice group | `DescribeAlarmNotices` / `CreateAlarmNotice` / … | Recipients (users / groups / webhooks) + escalation |
+| Shield | `DescribeAlarmShields` / `CreateAlarmShield` / … | Time-bounded mute scoped to a notice group |
+| Alarm log | `GetAlarmLog` | Firing history |
+
+## Workflows
+
+### List alarm policies
+
+```python
+req = models.DescribeAlarmsRequest()
+req.Limit = 100
+# Optional filters: req.Filters = [{"Key": "name", "Values": ["DeepSeek"]}]
+resp = client.DescribeAlarms(req)
+for a in resp.Alarms:
+    print(a.AlarmId, a.Name, "Enable=", a.Enable, "Status=", a.Status)
+```
+
+### Get a single alarm policy in full
+
+```python
+req = models.DescribeAlarmsRequest()
+req.Filters = [{"Key": "alarmId", "Values": ["<alarm-id>"]}]
+resp = client.DescribeAlarms(req)
+print(json.dumps(resp.Alarms[0]._serialize(), indent=2, ensure_ascii=False))
+```
+
+### Create an alarm
+
+```python
+req = models.CreateAlarmRequest()
+req.Name = "OpenAI 5xx burst"
+req.AlarmTargets = [{
+    "TopicId": "<trace-topic-id>",
+    "Query": "* | select count(*) as cnt where status_code >= 500",
+    "Number": 1,
+    "StartTimeOffset": -5,
+    "EndTimeOffset": 0,
+    "SyntaxRule": 1,             # 1 = CQL, 0 = Lucene
+}]
+req.MonitorTime = {"Type": "Period", "Time": 1}
+req.Condition = "$1.cnt > 10"
+req.AlarmPeriod = 5              # evaluate every 5 minutes
+req.TriggerCount = 1             # fire after 1 consecutive match
+req.AlarmLevel = 2               # 0=Notice, 1=Warning, 2=Critical
+req.AlarmNoticeIds = ["<notice-id-a>", "<notice-id-b>"]
+req.MonitorObjectType = 0
+req.Enable = True
+
+resp = client.CreateAlarm(req)
+print("Created", resp.AlarmId)
+```
+
+### Quick enable / disable
+
+```python
+req = models.ModifyAlarmRequest()
+req.AlarmId = "<alarm-id>"
+req.Status = False               # mute (Status — runtime), keep Enable=True
+client.ModifyAlarm(req)
+```
+
+> **`Enable` vs `Status`** are different fields. `Enable=False` archives the alarm definition; `Status=False` is the everyday on/off switch you want for muting.
+
+### Modify thresholds without rewriting the whole payload
+
+```python
+req = models.ModifyAlarmRequest()
+req.AlarmId = "<alarm-id>"
+req.Condition = "$1.cnt > 20"
+req.AlarmPeriod = 10
+client.ModifyAlarm(req)
+```
+
+### Delete (destructive)
+
+```python
+# Confirm with the user first — there's no undo.
+req = models.DeleteAlarmRequest()
+req.AlarmId = "<alarm-id>"
+client.DeleteAlarm(req)
+```
+
+### Manage notice groups
+
+```python
+# List
+req = models.DescribeAlarmNoticesRequest()
+req.Limit = 100
+for n in client.DescribeAlarmNotices(req).AlarmNotices:
+    print(n.AlarmNoticeId, n.Name, n.Type)
+
+# Create
+req = models.CreateAlarmNoticeRequest()
+req.Name = "Ops on-call"
+req.Type = "Trigger"             # Trigger | Recovery | All
+req.NoticeReceivers = [{
+    "ReceiverType": "Uin",
+    "ReceiverIds": [123456],
+    "ReceiverChannels": ["Email", "Sms"],
+    "StartTime": "00:00:00",
+    "EndTime": "23:59:59",
+}]
+req.WebCallbacks = [{
+    "Url": "https://hooks.example.com/cls",
+    "CallbackType": "WeCom",
+    "Method": "POST",
+}]
+resp = client.CreateAlarmNotice(req)
+```
+
+### Time-bounded shield (mute during deploy)
+
+```python
+import time
+req = models.CreateAlarmShieldRequest()
+req.AlarmNoticeId = "<notice-id>"
+req.StartTime = int(time.time())
+req.EndTime = int(time.time()) + 7200       # 2 hours
+req.Type = 1                                # 1 = full shield, 2 = partial
+req.Reason = "Deploy <git-sha>"
+client.CreateAlarmShield(req)
+```
+
+### Inspect alarm firing history
+
+```python
+req = models.GetAlarmLogRequest()
+req.From = int((time.time() - 86400) * 1000)
+req.To = int(time.time() * 1000)
+req.Query = 'alarm_name:"OpenAI*"'
+req.Limit = 100
+resp = client.GetAlarmLog(req)
+for line in resp.Results:
+    print(line.Time, line.LogJson)
+```
+
+## Cloning an alarm
+
+The fastest way to create a similar alarm is to read the existing one, strip read-only fields, tweak, and re-create:
+
+```python
+import json
+existing = client.DescribeAlarms(models.DescribeAlarmsRequest(Filters=[{"Key": "alarmId", "Values": ["<src-id>"]}])).Alarms[0]
+payload = json.loads(json.dumps(existing._serialize()))      # deep clone
+for k in ("AlarmId", "CreateTime", "UpdateTime"):
+    payload.pop(k, None)
+payload["Name"] = "OpenAI 5xx burst v2"
+# ...edit other fields...
+req = models.CreateAlarmRequest()
+req.from_json_string(json.dumps(payload))
+print(client.CreateAlarm(req).AlarmId)
+```
+
+## Important reminders
+
+- **Always preview the payload** (`json.dumps(req._serialize(), indent=2)`) before `CreateAlarm` / `ModifyAlarm` — schema is strict and errors are unhelpful.
+- Destructive ops (`DeleteAlarm`, `DeleteAlarmNotice`, `DeleteAlarmShield`) need explicit user confirmation in chat before running.
+- `Enable` (archived?) vs `Status` (currently on?) are *different* fields. Use `Status` for everyday muting.
+- Shield rules are scoped to a single `AlarmNoticeId`. Iterate over all notice IDs to list all shields globally.
+- Default region is `ap-hongkong`; pass another region via `cls_client.ClsClient(cred, "ap-singapore")` if needed.
+
+## Console links
+
+- Alarm console: <https://console.cloud.tencent.com/cls/alarm/list>
+- Alarm API reference: <https://www.tencentcloud.com/document/product/614/56473>

--- a/skills/tencentcloud-cls-alarm/SKILL.md
+++ b/skills/tencentcloud-cls-alarm/SKILL.md
@@ -22,6 +22,32 @@ CRUD on CLS alarm policies, notice groups, mute shields, and the alarm execution
 >
 > **Companion skill:** `tencentcloud-cls` for log content search.
 
+## CLI (preferred)
+
+The skill ships [`scripts/cls_alarm.py`](scripts/cls_alarm.py) — wraps every alarm / notice / shield operation as a subcommand.
+
+```bash
+A=$SKILL_DIR/scripts/cls_alarm.py
+
+python3 $A alarms                              # list policies
+python3 $A alarm <alarm-id>                    # full detail
+python3 $A alarm-disable <alarm-id>            # quick mute (Status=false)
+python3 $A alarm-enable  <alarm-id>
+python3 $A alarm-create --json /tmp/alarm.json --dry-run
+python3 $A alarm-modify <alarm-id> --condition '$1.cnt > 20'
+python3 $A alarm-delete <alarm-id> --yes       # destructive
+
+python3 $A notices                             # notice groups
+python3 $A notice <notice-id>
+
+python3 $A shields                             # mute rules
+python3 $A shield-create --notice-id <notice-id> --start $(date +%s) --end $(date -v+2H +%s) --type 1 --reason "deploy"
+
+python3 $A alarm-log --time 6h                 # firing history
+```
+
+For the rare schema field the CLI doesn't surface, fall through to the raw SDK examples below.
+
 ## When to Use
 
 - Inspect existing alarm policies (filter by name, enabled flag)

--- a/skills/tencentcloud-cls-alarm/scripts/cls_alarm.py
+++ b/skills/tencentcloud-cls-alarm/scripts/cls_alarm.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""
+Tencent Cloud CLS Alarm Management Tool
+
+Manage CLS alarm policies, notice groups, shields (mute rules) and alarm
+execution logs for AceDataCloud.
+
+Console: https://console.cloud.tencent.com/cls/alarm/list?region=ap-hongkong
+
+Quick examples:
+  python3 $SKILL_DIR/scripts/cls_alarm.py alarms
+  python3 $SKILL_DIR/scripts/cls_alarm.py alarm <alarm-id>
+  python3 $SKILL_DIR/scripts/cls_alarm.py alarm-disable <alarm-id>
+  python3 $SKILL_DIR/scripts/cls_alarm.py notices
+  python3 $SKILL_DIR/scripts/cls_alarm.py shields
+  python3 $SKILL_DIR/scripts/cls_alarm.py alarm-log --time 1d
+
+Environment:
+  Reads TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY, TENCENTCLOUD_REGION
+  from the sandbox environment (auto-injected by aichat2 from the user's
+  AceDataCloud BYOC connection; or set manually in `.env`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+
+
+DEFAULT_REGION = os.environ.get("TENCENTCLOUD_REGION", "ap-hongkong")
+
+
+def get_client(region: str = DEFAULT_REGION):
+    try:
+        from tencentcloud.cls.v20201016 import cls_client
+        from tencentcloud.common import credential
+    except ImportError:
+        print(
+            "ERROR: tencentcloud-sdk-python not installed.\n"
+            "Run: pip3 install tencentcloud-sdk-python",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set in env",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cred = credential.Credential(secret_id, secret_key)
+    return cls_client.ClsClient(cred, region)
+
+
+def pp(data) -> None:
+    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+
+
+def call(client, action: str, payload: dict) -> dict:
+    """Call a CLS API action with a dict payload (uses from_json_string)."""
+    from tencentcloud.cls.v20201016 import models
+
+    req_cls = getattr(models, f"{action}Request", None)
+    if req_cls is None:
+        raise SystemExit(f"Unknown action: {action}")
+    req = req_cls()
+    req.from_json_string(json.dumps(payload))
+    method = getattr(client, action)
+    resp = method(req)
+    return json.loads(resp.to_json_string())
+
+
+def parse_time(value: str) -> int:
+    """Parse '1h'/'30m'/'1d'/'7d' or ISO timestamp -> ms epoch."""
+    value = value.strip()
+    if value.isdigit():
+        # Treat as seconds if 10 digits, else ms
+        n = int(value)
+        return n * 1000 if n < 10**12 else n
+    if value[-1] in ("m", "h", "d") and value[:-1].isdigit():
+        n = int(value[:-1])
+        delta = {
+            "m": timedelta(minutes=n),
+            "h": timedelta(hours=n),
+            "d": timedelta(days=n),
+        }[value[-1]]
+        return int((datetime.now() - delta).timestamp() * 1000)
+    return int(datetime.fromisoformat(value).timestamp() * 1000)
+
+
+# -----------------------------------------------------------------------------
+# Alarm policies
+# -----------------------------------------------------------------------------
+
+
+def cmd_alarms(args):
+    """List alarm policies (with optional filters)."""
+    filters = []
+    if args.name:
+        filters.append({"Key": "name", "Values": [args.name]})
+    if args.alarm_id:
+        filters.append({"Key": "alarmId", "Values": [args.alarm_id]})
+    if args.topic_id:
+        filters.append({"Key": "topicId", "Values": [args.topic_id]})
+    if args.enabled is not None:
+        filters.append(
+            {"Key": "enable", "Values": ["true" if args.enabled else "false"]}
+        )
+
+    payload = {"Filters": filters, "Offset": args.offset, "Limit": args.limit}
+    data = call(get_client(args.region), "DescribeAlarms", payload)
+
+    alarms = data.get("Alarms", [])
+    total = data.get("TotalCount", len(alarms))
+
+    if args.format == "json":
+        pp(data)
+        return
+
+    print(f"Found {total} alarm policy(ies) (showing {len(alarms)}):\n")
+    for a in alarms:
+        enabled = a.get("Enable")
+        status = a.get("Status")
+        emoji = "●" if enabled else "○"
+        level = {0: "Notice", 1: "Warning", 2: "Critical"}.get(
+            a.get("AlarmLevel"), str(a.get("AlarmLevel"))
+        )
+        targets = a.get("AlarmTargets") or []
+        topic_summary = ", ".join(t.get("TopicId", "?") for t in targets) or "-"
+        notice_ids = ",".join(a.get("AlarmNoticeIds") or []) or "-"
+        print(
+            f"  {emoji} {a.get('AlarmId', ''):42s} {a.get('Name', '')[:40]:40s} "
+            f"level={level:8s} period={a.get('AlarmPeriod', '-')}m trig={a.get('TriggerCount', '-')} "
+            f"status={status}"
+        )
+        print(f"     topics: {topic_summary}")
+        print(f"     notices: {notice_ids}")
+        print()
+
+
+def cmd_alarm(args):
+    """Show a single alarm policy by ID (full detail)."""
+    payload = {"Filters": [{"Key": "alarmId", "Values": [args.alarm_id]}], "Limit": 1}
+    data = call(get_client(args.region), "DescribeAlarms", payload)
+    alarms = data.get("Alarms", [])
+    if not alarms:
+        print(f"Alarm {args.alarm_id} not found", file=sys.stderr)
+        sys.exit(1)
+    pp(alarms[0])
+
+
+def _build_alarm_payload(args, *, for_modify: bool = False) -> dict:
+    """Build a Create/ModifyAlarm payload from CLI args + optional --json file."""
+    payload: dict = {}
+    if args.json:
+        with open(args.json) as f:
+            payload = json.load(f)
+
+    if for_modify:
+        payload["AlarmId"] = args.alarm_id
+
+    if args.name:
+        payload["Name"] = args.name
+    if args.query is not None:
+        target = {
+            "TopicId": args.topic_id or "",
+            "Query": args.query,
+            "Number": 1,
+            "StartTimeOffset": args.start_offset,
+            "EndTimeOffset": args.end_offset,
+            "SyntaxRule": args.syntax_rule,
+        }
+        if args.logset_id:
+            target["LogsetId"] = args.logset_id
+        payload["AlarmTargets"] = [target]
+    if args.condition:
+        payload["Condition"] = args.condition
+    if args.period is not None:
+        payload["AlarmPeriod"] = args.period
+    if args.trigger_count is not None:
+        payload["TriggerCount"] = args.trigger_count
+    if args.level is not None:
+        payload["AlarmLevel"] = args.level
+    if args.notice_ids:
+        payload["AlarmNoticeIds"] = [s for s in args.notice_ids.split(",") if s]
+    if args.monitor_time:
+        payload["MonitorTime"] = json.loads(args.monitor_time)
+    if args.message_template is not None:
+        payload["MessageTemplate"] = args.message_template
+    if args.enable is not None:
+        payload["Enable"] = args.enable
+    if args.status is not None:
+        payload["Status"] = args.status
+    if not for_modify:
+        payload.setdefault("MonitorObjectType", 0)
+        payload.setdefault("MonitorTime", {"Type": "Period", "Time": 1})
+        payload.setdefault("TriggerCount", 1)
+        payload.setdefault("AlarmPeriod", 15)
+    return payload
+
+
+def cmd_alarm_create(args):
+    payload = _build_alarm_payload(args, for_modify=False)
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "CreateAlarm", payload)
+    pp(data)
+
+
+def cmd_alarm_modify(args):
+    payload = _build_alarm_payload(args, for_modify=True)
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "ModifyAlarm", payload)
+    pp(data or {"ok": True, "alarm_id": args.alarm_id})
+
+
+def cmd_alarm_delete(args):
+    if not args.yes:
+        print(
+            f"Refusing to delete alarm {args.alarm_id} without --yes", file=sys.stderr
+        )
+        sys.exit(2)
+    data = call(get_client(args.region), "DeleteAlarm", {"AlarmId": args.alarm_id})
+    pp(data or {"ok": True, "deleted": args.alarm_id})
+
+
+def cmd_alarm_toggle(args, enable: bool):
+    data = call(
+        get_client(args.region),
+        "ModifyAlarm",
+        {"AlarmId": args.alarm_id, "Status": enable},
+    )
+    pp(data or {"ok": True, "alarm_id": args.alarm_id, "status": enable})
+
+
+# -----------------------------------------------------------------------------
+# Notice groups
+# -----------------------------------------------------------------------------
+
+
+def cmd_notices(args):
+    filters = []
+    if args.name:
+        filters.append({"Key": "name", "Values": [args.name]})
+    if args.notice_id:
+        filters.append({"Key": "alarmNoticeId", "Values": [args.notice_id]})
+    payload = {"Filters": filters, "Offset": args.offset, "Limit": args.limit}
+    data = call(get_client(args.region), "DescribeAlarmNotices", payload)
+    notices = data.get("AlarmNotices", [])
+    if args.format == "json":
+        pp(data)
+        return
+    print(f"Found {data.get('TotalCount', len(notices))} notice group(s):\n")
+    for n in notices:
+        receivers = n.get("NoticeReceivers") or []
+        webhooks = n.get("WebCallbacks") or []
+        rcv_summary = (
+            ",".join(
+                f"{r.get('ReceiverType', '?')}:{len(r.get('ReceiverIds') or [])}"
+                for r in receivers
+            )
+            or "-"
+        )
+        print(
+            f"  {n.get('AlarmNoticeId', ''):42s} {n.get('Name', '')[:40]:40s} "
+            f"type={n.get('Type', '-'):10s} receivers={rcv_summary} webhooks={len(webhooks)}"
+        )
+
+
+def cmd_notice(args):
+    payload = {
+        "Filters": [{"Key": "alarmNoticeId", "Values": [args.notice_id]}],
+        "Limit": 1,
+    }
+    data = call(get_client(args.region), "DescribeAlarmNotices", payload)
+    items = data.get("AlarmNotices", [])
+    if not items:
+        print(f"Notice {args.notice_id} not found", file=sys.stderr)
+        sys.exit(1)
+    pp(items[0])
+
+
+def cmd_notice_create(args):
+    if not args.json:
+        print(
+            "--json <file> with NoticeReceivers/WebCallbacks is required",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    with open(args.json) as f:
+        payload = json.load(f)
+    if args.name:
+        payload["Name"] = args.name
+    if args.type:
+        payload["Type"] = args.type
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "CreateAlarmNotice", payload)
+    pp(data)
+
+
+def cmd_notice_modify(args):
+    if not args.json:
+        print("--json <file> required for notice-modify", file=sys.stderr)
+        sys.exit(2)
+    with open(args.json) as f:
+        payload = json.load(f)
+    payload["AlarmNoticeId"] = args.notice_id
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "ModifyAlarmNotice", payload)
+    pp(data or {"ok": True, "notice_id": args.notice_id})
+
+
+def cmd_notice_delete(args):
+    if not args.yes:
+        print(
+            f"Refusing to delete notice {args.notice_id} without --yes", file=sys.stderr
+        )
+        sys.exit(2)
+    data = call(
+        get_client(args.region), "DeleteAlarmNotice", {"AlarmNoticeId": args.notice_id}
+    )
+    pp(data or {"ok": True, "deleted": args.notice_id})
+
+
+# -----------------------------------------------------------------------------
+# Shield rules
+# -----------------------------------------------------------------------------
+
+
+def cmd_shields(args):
+    client = get_client(args.region)
+    if args.notice_id:
+        notice_ids = [args.notice_id]
+    else:
+        # DescribeAlarmShields requires AlarmNoticeId; iterate over all notices.
+        notices = call(client, "DescribeAlarmNotices", {"Offset": 0, "Limit": 100})
+        notice_ids = [
+            n.get("AlarmNoticeId")
+            for n in (notices.get("AlarmNotices") or [])
+            if n.get("AlarmNoticeId")
+        ]
+
+    shields = []
+    for nid in notice_ids:
+        payload = {"AlarmNoticeId": nid, "Offset": args.offset, "Limit": args.limit}
+        try:
+            data = call(client, "DescribeAlarmShields", payload)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  WARN: notice {nid}: {exc}", file=sys.stderr)
+            continue
+        for s in data.get("AlarmShields") or []:
+            s.setdefault("AlarmNoticeId", nid)
+            shields.append(s)
+
+    if args.format == "json":
+        pp({"AlarmShields": shields, "TotalCount": len(shields)})
+        return
+    print(f"Found {len(shields)} shield(s) across {len(notice_ids)} notice group(s):\n")
+    for s in shields:
+        ts_start = (
+            datetime.fromtimestamp(s.get("StartTime", 0)).strftime("%Y-%m-%d %H:%M")
+            if s.get("StartTime")
+            else "-"
+        )
+        ts_end = (
+            datetime.fromtimestamp(s.get("EndTime", 0)).strftime("%Y-%m-%d %H:%M")
+            if s.get("EndTime")
+            else "-"
+        )
+        print(
+            f"  {s.get('TaskId', ''):42s} notice={s.get('AlarmNoticeId', '')} "
+            f"type={s.get('Type', '-')} status={s.get('Status', '-')} "
+            f"{ts_start} -> {ts_end}  reason={s.get('Reason', '-')[:40]}"
+        )
+
+
+def cmd_shield_create(args):
+    payload = {
+        "AlarmNoticeId": args.notice_id,
+        "Type": args.type,
+        "StartTime": int(args.start),
+        "EndTime": int(args.end),
+    }
+    if args.reason:
+        payload["Reason"] = args.reason
+    if args.rule:
+        payload["Rule"] = json.loads(args.rule)
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "CreateAlarmShield", payload)
+    pp(data)
+
+
+def cmd_shield_modify(args):
+    payload = {"TaskId": args.task_id}
+    if args.start:
+        payload["StartTime"] = int(args.start)
+    if args.end:
+        payload["EndTime"] = int(args.end)
+    if args.type is not None:
+        payload["Type"] = args.type
+    if args.reason is not None:
+        payload["Reason"] = args.reason
+    if args.rule:
+        payload["Rule"] = json.loads(args.rule)
+    if args.dry_run:
+        pp(payload)
+        return
+    data = call(get_client(args.region), "ModifyAlarmShield", payload)
+    pp(data or {"ok": True, "task_id": args.task_id})
+
+
+def cmd_shield_delete(args):
+    if not args.yes:
+        print(
+            f"Refusing to delete shield {args.task_id} without --yes", file=sys.stderr
+        )
+        sys.exit(2)
+    data = call(get_client(args.region), "DeleteAlarmShield", {"TaskId": args.task_id})
+    pp(data or {"ok": True, "deleted": args.task_id})
+
+
+# -----------------------------------------------------------------------------
+# Alarm execution log (which alarms fired and when)
+# -----------------------------------------------------------------------------
+
+
+def cmd_alarm_log(args):
+    to_ms = int(time.time() * 1000)
+    from_ms = parse_time(args.time)
+    payload = {
+        "From": from_ms,
+        "To": to_ms,
+        "Query": args.query or "*",
+        "Limit": args.limit,
+        "Sort": args.sort,
+        "UseNewAnalysis": True,
+    }
+    data = call(get_client(args.region), "GetAlarmLog", payload)
+    if args.format == "json":
+        pp(data)
+        return
+    results = data.get("Results", []) or []
+    print(f"Found {len(results)} alarm log entr(ies):\n")
+    for r in results:
+        ts = datetime.fromtimestamp(r.get("Time", 0) / 1000).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        log = r.get("LogJson", "")
+        try:
+            d = json.loads(log)
+            print(
+                f"  [{ts}] alarm={d.get('alarm_name', '-')} alarm_id={d.get('alarm_id', '-')} "
+                f"level={d.get('alarm_level', '-')} status={d.get('status', '-')}"
+            )
+            if d.get("trigger_query"):
+                print(f"          query: {d['trigger_query'][:120]}")
+        except Exception:
+            print(f"  [{ts}] {log[:200]}")
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Tencent CLS alarm management")
+    p.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help=f"CLS region (default: {DEFAULT_REGION})",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    def add_common_alarm_fields(sp, *, modify=False):
+        sp.add_argument(
+            "--json", help="Path to JSON file with full payload (other flags override)"
+        )
+        sp.add_argument("--name")
+        sp.add_argument("--topic-id")
+        sp.add_argument("--logset-id")
+        sp.add_argument("--query", help="CLS query string for the alarm target")
+        sp.add_argument(
+            "--condition", help="Trigger condition expression, e.g. '$1.errors > 10'"
+        )
+        sp.add_argument(
+            "--period", type=int, help="Alarm period in minutes (default: 15)"
+        )
+        sp.add_argument("--trigger-count", type=int)
+        sp.add_argument("--start-offset", type=int, default=-15)
+        sp.add_argument("--end-offset", type=int, default=0)
+        sp.add_argument(
+            "--syntax-rule", type=int, default=1, help="0=Lucene, 1=CQL (default: 1)"
+        )
+        sp.add_argument(
+            "--level", type=int, choices=[0, 1, 2], help="0=Notice 1=Warning 2=Critical"
+        )
+        sp.add_argument("--notice-ids", help="Comma-separated AlarmNoticeIds")
+        sp.add_argument(
+            "--monitor-time", help='JSON, e.g. \'{"Type":"Period","Time":1}\''
+        )
+        sp.add_argument("--message-template")
+        enable_group = sp.add_mutually_exclusive_group()
+        enable_group.add_argument(
+            "--enable", dest="enable", action="store_true", default=None
+        )
+        enable_group.add_argument("--disable", dest="enable", action="store_false")
+        sp.add_argument("--status", type=lambda s: s.lower() in ("1", "true", "yes"))
+        sp.add_argument("--dry-run", action="store_true")
+
+    # ---- alarms ----
+    sp = sub.add_parser("alarms", help="List alarm policies")
+    sp.add_argument("--name")
+    sp.add_argument("--alarm-id")
+    sp.add_argument("--topic-id")
+    sp.add_argument("--enabled", type=lambda s: s.lower() in ("1", "true", "yes"))
+    sp.add_argument("--offset", type=int, default=0)
+    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--format", choices=["text", "json"], default="text")
+    sp.set_defaults(func=cmd_alarms)
+
+    sp = sub.add_parser("alarm", help="Show one alarm policy")
+    sp.add_argument("alarm_id")
+    sp.set_defaults(func=cmd_alarm)
+
+    sp = sub.add_parser("alarm-create", help="Create alarm policy")
+    add_common_alarm_fields(sp)
+    sp.set_defaults(func=cmd_alarm_create)
+
+    sp = sub.add_parser("alarm-modify", help="Modify alarm policy")
+    sp.add_argument("alarm_id")
+    add_common_alarm_fields(sp, modify=True)
+    sp.set_defaults(func=cmd_alarm_modify)
+
+    sp = sub.add_parser("alarm-delete", help="Delete alarm policy")
+    sp.add_argument("alarm_id")
+    sp.add_argument("--yes", action="store_true", help="Confirm destructive op")
+    sp.set_defaults(func=cmd_alarm_delete)
+
+    sp = sub.add_parser("alarm-enable", help="Enable an alarm (Status=true)")
+    sp.add_argument("alarm_id")
+    sp.set_defaults(func=lambda a: cmd_alarm_toggle(a, True))
+
+    sp = sub.add_parser("alarm-disable", help="Disable an alarm (Status=false)")
+    sp.add_argument("alarm_id")
+    sp.set_defaults(func=lambda a: cmd_alarm_toggle(a, False))
+
+    # ---- notices ----
+    sp = sub.add_parser("notices", help="List notice groups")
+    sp.add_argument("--name")
+    sp.add_argument("--notice-id")
+    sp.add_argument("--offset", type=int, default=0)
+    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--format", choices=["text", "json"], default="text")
+    sp.set_defaults(func=cmd_notices)
+
+    sp = sub.add_parser("notice", help="Show one notice group")
+    sp.add_argument("notice_id")
+    sp.set_defaults(func=cmd_notice)
+
+    sp = sub.add_parser("notice-create", help="Create notice group (requires --json)")
+    sp.add_argument("--json", required=True)
+    sp.add_argument("--name")
+    sp.add_argument("--type", choices=["Trigger", "Recovery", "All"])
+    sp.add_argument("--dry-run", action="store_true")
+    sp.set_defaults(func=cmd_notice_create)
+
+    sp = sub.add_parser("notice-modify", help="Modify notice group (requires --json)")
+    sp.add_argument("notice_id")
+    sp.add_argument("--json", required=True)
+    sp.add_argument("--dry-run", action="store_true")
+    sp.set_defaults(func=cmd_notice_modify)
+
+    sp = sub.add_parser("notice-delete", help="Delete notice group")
+    sp.add_argument("notice_id")
+    sp.add_argument("--yes", action="store_true")
+    sp.set_defaults(func=cmd_notice_delete)
+
+    # ---- shields ----
+    sp = sub.add_parser("shields", help="List alarm shield (mute) rules")
+    sp.add_argument("--notice-id")
+    sp.add_argument("--offset", type=int, default=0)
+    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--format", choices=["text", "json"], default="text")
+    sp.set_defaults(func=cmd_shields)
+
+    sp = sub.add_parser("shield-create", help="Create alarm shield")
+    sp.add_argument("--notice-id", required=True)
+    sp.add_argument("--start", required=True, help="Unix seconds")
+    sp.add_argument("--end", required=True, help="Unix seconds")
+    sp.add_argument("--type", type=int, default=1, help="1=All 2=Custom (default: 1)")
+    sp.add_argument("--reason")
+    sp.add_argument("--rule", help="JSON for custom rule (when --type 2)")
+    sp.add_argument("--dry-run", action="store_true")
+    sp.set_defaults(func=cmd_shield_create)
+
+    sp = sub.add_parser("shield-modify", help="Modify alarm shield")
+    sp.add_argument("task_id")
+    sp.add_argument("--start")
+    sp.add_argument("--end")
+    sp.add_argument("--type", type=int)
+    sp.add_argument("--reason")
+    sp.add_argument("--rule")
+    sp.add_argument("--dry-run", action="store_true")
+    sp.set_defaults(func=cmd_shield_modify)
+
+    sp = sub.add_parser("shield-delete", help="Delete alarm shield")
+    sp.add_argument("task_id")
+    sp.add_argument("--yes", action="store_true")
+    sp.set_defaults(func=cmd_shield_delete)
+
+    # ---- alarm log ----
+    sp = sub.add_parser(
+        "alarm-log", help="Query alarm execution log (which alarms fired)"
+    )
+    sp.add_argument(
+        "--time", default="1d", help="Time range: 30m/1h/6h/1d/7d (default: 1d)"
+    )
+    sp.add_argument("--query", default="*")
+    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--sort", choices=["asc", "desc"], default="desc")
+    sp.add_argument("--format", choices=["text", "json"], default="text")
+    sp.set_defaults(func=cmd_alarm_log)
+
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    try:
+        args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tencentcloud-cls/SKILL.md
+++ b/skills/tencentcloud-cls/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: tencentcloud-cls
+description: |
+  Search and analyze Tencent Cloud CLS (Cloud Log Service) logs. Use
+  whenever the user asks to: search logs, debug API errors, trace
+  requests by trace ID, find 5xx errors, run CQL/SQL analytics over
+  log topics, extract structured fields. Backed by the official
+  tencentcloud-sdk-python CLS client.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# Tencent Cloud CLS (Log Service) — Search & Analysis
+
+Search and run CQL / SQL analytics over Tencent Cloud CLS log topics.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). The SDK reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` / `TENCENTCLOUD_REGION` from the environment.
+>
+> **Companion skill:** Use `tencentcloud-cls-alarm` for alarm policy / notice group / shield management. This skill is only about searching log content.
+
+## When to Use
+
+- Find recent errors / 5xx responses for a service
+- Look up a single request by trace ID across multiple topics
+- Run CQL filters (`status_code:>=500 AND service:"openai"`)
+- Run SQL analytics (`SELECT api_name, COUNT(*) GROUP BY api_name`)
+- Chain trace logs to reconstruct a request lifecycle
+- Extract specific fields for billing / audit reports
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+```
+
+## Quick start
+
+```python
+import os
+import json
+from tencentcloud.common import credential
+from tencentcloud.cls.v20201016 import cls_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+client = cls_client.ClsClient(cred, os.environ["TENCENTCLOUD_REGION"])
+```
+
+## Workflows
+
+### Discover topics
+
+```python
+req = models.DescribeTopicsRequest()
+resp = client.DescribeTopics(req)
+for t in resp.Topics:
+    print(t.TopicId, t.TopicName, t.LogsetId)
+```
+
+> Tip: ask the user for the topic ID up front. Topic IDs look like `751a7350-dc5d-41c3-a6ca-c178bae05807` and aren't guessable from a service name.
+
+### Search logs (CQL)
+
+```python
+import time
+
+req = models.SearchLogRequest()
+req.TopicId = "<topic-id>"
+req.From = int((time.time() - 3600) * 1000)   # 1 hour ago, ms epoch
+req.To = int(time.time() * 1000)
+req.Query = 'status_code:>=500 AND service:"openai"'
+req.Limit = 100
+req.Sort = "desc"
+req.SyntaxRule = 1                             # 1 = CQL, 0 = Lucene
+
+resp = client.SearchLog(req)
+for line in resp.Results:
+    fields = {f.Key: f.Value for f in line.LogJson and []}  # see below
+    print(line.Time, line.PkgLogId, fields.get("status_code"), fields.get("api_name"))
+```
+
+> CLS hands you `Results` with `LogJson` as a JSON string per record. Decode with `json.loads(line.LogJson)` to get a flat dict of all the indexed fields the topic stores.
+
+### Look up a trace ID across multiple topics
+
+```python
+TRACE_ID = "34341776-0835-422a-956d-ac8d5b404db1"
+TOPICS = {
+    "trace": "<trace-topic-id>",
+    "api-usages": "<api-usages-topic-id>",
+}
+
+for label, topic_id in TOPICS.items():
+    req = models.SearchLogRequest()
+    req.TopicId = topic_id
+    req.From = int((time.time() - 86400) * 1000)
+    req.To = int(time.time() * 1000)
+    req.Query = f'trace_id:"{TRACE_ID}"'
+    req.Limit = 100
+    req.SyntaxRule = 1
+    resp = client.SearchLog(req)
+    print(f"--- {label}: {len(resp.Results)} records ---")
+    for line in resp.Results:
+        print(line.Time, line.LogJson)
+```
+
+### SQL analytics
+
+CLS supports a SQL-on-logs subset for aggregation. Append `| <SQL>` to a CQL filter:
+
+```python
+req.Query = '* | SELECT api_name, count(*) AS cnt GROUP BY api_name ORDER BY cnt DESC LIMIT 20'
+req.SyntaxRule = 1
+resp = client.SearchLog(req)
+# When the query has a `|`, results land in resp.Analysis (rows of column→value)
+for row in resp.AnalysisResults or []:
+    print(row)
+```
+
+### Tail recent logs
+
+```python
+# Poll every 5s for new lines after the last cursor
+last_cursor = None
+while True:
+    req = models.SearchLogRequest()
+    req.TopicId = topic_id
+    req.From = int((time.time() - 30) * 1000)
+    req.To = int(time.time() * 1000)
+    req.Query = 'level:ERROR'
+    req.Limit = 100
+    req.Sort = "asc"
+    req.SyntaxRule = 1
+    if last_cursor:
+        req.Context = last_cursor
+    resp = client.SearchLog(req)
+    for line in resp.Results:
+        print(line.Time, line.LogJson)
+    last_cursor = resp.Context
+    time.sleep(5)
+```
+
+## CQL cheatsheet
+
+| Pattern | Meaning |
+|---|---|
+| `status_code:500` | exact match |
+| `status_code:>=500` | range |
+| `status_code:[500 TO 599]` | range with bounds |
+| `service:"openai"` | quoted phrase (use for values containing spaces) |
+| `NOT level:DEBUG` | negation |
+| `service:openai AND status_code:>=400` | conjunction |
+| `(api:foo OR api:bar)` | grouping |
+| `* | SELECT ... GROUP BY ...` | switch into SQL analytics |
+
+## Pagination
+
+CLS returns up to 1000 records per call. For larger result sets, iterate with `Context`:
+
+```python
+all_records = []
+context = None
+while True:
+    req = models.SearchLogRequest()
+    req.TopicId = topic_id
+    req.From = ...
+    req.To = ...
+    req.Query = '...'
+    req.Limit = 1000
+    req.SyntaxRule = 1
+    if context:
+        req.Context = context
+    resp = client.SearchLog(req)
+    all_records.extend(resp.Results)
+    context = resp.Context
+    if not context or len(resp.Results) < 1000:
+        break
+```
+
+## Error patterns
+
+| Symptom | Likely cause |
+|---|---|
+| `InvalidParameter.QueryError` | Quote phrases that contain `:` or spaces; check `SyntaxRule` matches the query |
+| `LimitExceeded` | Concurrent `SearchLog` calls exceed the 30-QPS quota — back off & retry |
+| `OperationDenied.AccountIsolated` | CLS service is suspended for billing — check the console |
+| Empty `Results` but logs visible in console | Time range is wrong (`From` / `To` are ms epoch, not seconds), or topic has different field names than the query expects |
+
+## Console links
+
+- CLS console: <https://console.cloud.tencent.com/cls/topic>
+- CQL syntax: <https://www.tencentcloud.com/document/product/614/47044>
+- SQL analytics syntax: <https://www.tencentcloud.com/document/product/614/58978>

--- a/skills/tencentcloud-cls/SKILL.md
+++ b/skills/tencentcloud-cls/SKILL.md
@@ -21,6 +21,25 @@ Search and run CQL / SQL analytics over Tencent Cloud CLS log topics.
 >
 > **Companion skill:** Use `tencentcloud-cls-alarm` for alarm policy / notice group / shield management. This skill is only about searching log content.
 
+## CLI (preferred)
+
+The skill ships [`scripts/cls.py`](scripts/cls.py) — a self-contained CLI for the most common operations.
+
+```bash
+CLS=$SKILL_DIR/scripts/cls.py
+
+python3 $CLS topics                                              # list topics
+python3 $CLS search --topic <topic-id> --query 'level:ERROR' --time 1h
+python3 $CLS search --topic <topic-id> --trace-id <uuid>
+python3 $CLS search --topic <topic-id> --time 1d \
+    --query '* | SELECT api_name, count(*) AS cnt GROUP BY api_name ORDER BY cnt DESC LIMIT 20' \
+    --format json
+```
+
+`--time` accepts `30m / 1h / 6h / 1d / 7d`. `--query` is CQL by default; pass `--lucene` to switch dialect. Append `| SELECT ... GROUP BY ...` to a query for SQL analytics.
+
+For anything beyond what the CLI exposes (custom field projections, raw paginated walks, `Context`-based tailing) drop down to the SDK calls below.
+
 ## When to Use
 
 - Find recent errors / 5xx responses for a service

--- a/skills/tencentcloud-cls/scripts/cls.py
+++ b/skills/tencentcloud-cls/scripts/cls.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Tencent Cloud CLS (Cloud Log Service) — search & analytics CLI.
+
+Search log topics with CQL filters or run SQL analytics over them.
+
+Quick examples:
+  python3 $SKILL_DIR/scripts/cls.py topics
+  python3 $SKILL_DIR/scripts/cls.py search --topic <topic-id> --query 'level:ERROR' --time 1h
+  python3 $SKILL_DIR/scripts/cls.py search --topic <topic-id> --trace-id <uuid>
+  python3 $SKILL_DIR/scripts/cls.py search --topic <topic-id> \\
+      --query '* | SELECT api_name, count(*) AS cnt GROUP BY api_name ORDER BY cnt DESC LIMIT 20' \\
+      --time 1d
+
+Environment:
+  TENCENTCLOUD_SECRET_ID   — required
+  TENCENTCLOUD_SECRET_KEY  — required
+  TENCENTCLOUD_REGION      — optional, default ap-hongkong
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+DEFAULT_REGION = os.environ.get("TENCENTCLOUD_REGION", "ap-hongkong")
+
+
+def get_client(region: str = DEFAULT_REGION):
+    try:
+        from tencentcloud.cls.v20201016 import cls_client
+        from tencentcloud.common import credential
+    except ImportError:
+        print(
+            "ERROR: tencentcloud-sdk-python not installed.\nRun: pip3 install tencentcloud-sdk-python",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set in env",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    cred = credential.Credential(secret_id, secret_key)
+    return cls_client.ClsClient(cred, region)
+
+
+# ---------------------------------------------------------------------------
+# Time parsing — accepts `30m`, `1h`, `6h`, `1d`, `7d`.
+# ---------------------------------------------------------------------------
+
+_TIME_RE = re.compile(r"^(\d+)([smhd])$")
+
+
+def parse_relative(spec: str) -> int:
+    """Return milliseconds for a string like `1h` / `30m` / `7d`."""
+    m = _TIME_RE.match(spec)
+    if not m:
+        raise ValueError(f"bad --time: {spec!r}; use e.g. 30m, 1h, 6h, 1d, 7d")
+    n, unit = int(m.group(1)), m.group(2)
+    return n * {"s": 1000, "m": 60_000, "h": 3_600_000, "d": 86_400_000}[unit]
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_topics(args):
+    """List all log topics in the region."""
+    from tencentcloud.cls.v20201016 import models
+
+    client = get_client(args.region)
+    req = models.DescribeTopicsRequest()
+    if args.logset_id:
+        req.Filters = [{"Key": "logsetId", "Values": [args.logset_id]}]
+    resp = client.DescribeTopics(req)
+    if args.format == "json":
+        print(json.dumps([t._serialize() for t in (resp.Topics or [])], indent=2, ensure_ascii=False))
+        return
+    print(f"{'TopicId':40s}  {'TopicName':32s}  {'LogsetId'}")
+    for t in resp.Topics or []:
+        print(f"{t.TopicId:40s}  {(t.TopicName or '')[:32]:32s}  {t.LogsetId}")
+
+
+def cmd_search(args):
+    """Search a topic with a CQL / SQL query."""
+    from tencentcloud.cls.v20201016 import models
+
+    client = get_client(args.region)
+    req = models.SearchLogRequest()
+    req.TopicId = args.topic
+    now_ms = int(time.time() * 1000)
+    req.From = now_ms - parse_relative(args.time)
+    req.To = now_ms
+
+    if args.trace_id:
+        query = f'trace_id:"{args.trace_id}"'
+    else:
+        query = args.query
+    req.Query = query
+    req.Limit = args.limit
+    req.Sort = args.sort
+    req.SyntaxRule = 0 if args.lucene else 1
+
+    resp = client.SearchLog(req)
+
+    # Analytics queries (have a `|`) land in AnalysisResults.
+    if "|" in query and (resp.AnalysisResults or []):
+        rows = []
+        for row in resp.AnalysisResults or []:
+            rows.append({c.Name: c.Value for c in row.Data})
+        if args.format == "json":
+            print(json.dumps(rows, indent=2, ensure_ascii=False))
+        else:
+            for r in rows:
+                print(json.dumps(r, ensure_ascii=False))
+        return
+
+    out = []
+    for line in resp.Results or []:
+        try:
+            fields = json.loads(line.LogJson) if line.LogJson else {}
+        except Exception:
+            fields = {"_raw": line.LogJson}
+        out.append({"time_ms": line.Time, "fields": fields})
+    if args.format == "json":
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+    else:
+        for entry in out:
+            ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(entry["time_ms"] / 1000))
+            f = entry["fields"]
+            short = " ".join(f"{k}={v}" for k, v in list(f.items())[:6])
+            print(f"{ts}  {short}")
+    if resp.Context:
+        print(f"\n# more results: --context {resp.Context}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Search Tencent Cloud CLS log topics.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help=f"Tencent Cloud region (default: {DEFAULT_REGION})",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_topics = sub.add_parser("topics", help="List log topics")
+    p_topics.add_argument("--logset-id", help="Filter to one logset")
+    p_topics.add_argument("--format", choices=["text", "json"], default="text")
+    p_topics.set_defaults(func=cmd_topics)
+
+    p_search = sub.add_parser("search", help="Search a topic")
+    p_search.add_argument("--topic", required=True, help="TopicId (UUID)")
+    g = p_search.add_mutually_exclusive_group(required=True)
+    g.add_argument("--query", "-q", help="CQL or SQL query (use `|` for SQL analytics)")
+    g.add_argument("--trace-id", help="Shortcut for trace_id:\"<id>\"")
+    p_search.add_argument("--time", default="1h", help="Time range (30m, 1h, 6h, 1d, 7d). Default 1h.")
+    p_search.add_argument("--limit", type=int, default=100, help="Max results (default 100)")
+    p_search.add_argument("--sort", choices=["asc", "desc"], default="desc")
+    p_search.add_argument("--lucene", action="store_true", help="Treat --query as Lucene (default CQL)")
+    p_search.add_argument("--format", choices=["text", "json"], default="text")
+    p_search.set_defaults(func=cmd_search)
+
+    args = parser.parse_args()
+    return args.func(args) or 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tencentcloud-cos/SKILL.md
+++ b/skills/tencentcloud-cos/SKILL.md
@@ -19,6 +19,27 @@ Manage Tencent Cloud COS buckets and objects via the official `cos-python-sdk-v5
 
 > **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md) for SecretId / SecretKey / region setup. The SDK reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` / `TENCENTCLOUD_REGION` from the environment.
 
+## CLI (preferred)
+
+The skill ships [`scripts/cos.py`](scripts/cos.py) — a self-contained CLI that wraps every COS operation below. **Prefer this over hand-rolled SDK calls** when the user's request maps cleanly onto one of its subcommands; it's what the maintained code paths exercise.
+
+```bash
+COS=$SKILL_DIR/scripts/cos.py
+
+python3 $COS buckets                                  # list all buckets
+python3 $COS ls mydata-1250000000 --prefix images/    # list objects
+python3 $COS upload mydata-1250000000 ./report.pdf --key docs/report-2026.pdf
+python3 $COS download mydata-1250000000 docs/report-2026.pdf --output ./out.pdf
+python3 $COS url mydata-1250000000 docs/report-2026.pdf --expires 3600
+python3 $COS du mydata-1250000000 --prefix logs/
+python3 $COS cp mydata-1250000000 old/path.txt new/path.txt
+python3 $COS batch-delete mydata-1250000000 --prefix temp/old/ --dry-run
+python3 $COS batch-delete mydata-1250000000 --prefix temp/old/   # actually delete
+python3 $COS info mydata-1250000000 docs/report-2026.pdf
+```
+
+Run `python3 $COS --help` (or `python3 $COS <cmd> --help`) for full flags. Pass `--region <region>` to override per-call.
+
 ## When to Use
 
 - List COS buckets across the account

--- a/skills/tencentcloud-cos/SKILL.md
+++ b/skills/tencentcloud-cos/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: tencentcloud-cos
+description: |
+  Manage Tencent Cloud COS (Cloud Object Storage) buckets and objects.
+  Use whenever the user asks about COS / 对象存储 / Tencent Cloud bucket
+  operations: list buckets, list objects, upload, download, delete,
+  pre-signed URLs, calculate bucket size (du), batch delete with prefix,
+  copy objects between keys. Backed by the official cos-python-sdk-v5.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# Tencent Cloud COS (Object Storage)
+
+Manage Tencent Cloud COS buckets and objects via the official `cos-python-sdk-v5` client.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md) for SecretId / SecretKey / region setup. The SDK reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` / `TENCENTCLOUD_REGION` from the environment.
+
+## When to Use
+
+- List COS buckets across the account
+- List objects in a bucket (with prefix / delimiter filtering)
+- Upload / download files
+- Delete a single object or batch-delete by prefix
+- Generate pre-signed download URLs (private bucket sharing)
+- Calculate bucket / prefix storage usage
+- Copy objects within a bucket
+
+## Dependencies
+
+```bash
+pip install cos-python-sdk-v5
+```
+
+## Bucket naming
+
+Tencent Cloud bucket names always end in `-<APPID>`, e.g. `mydata-1250000000`. The APPID is the numeric account identifier. The SDK requires the full `name-APPID` form everywhere a bucket is named.
+
+## Quick start
+
+```python
+import os
+from qcloud_cos import CosConfig, CosS3Client
+
+config = CosConfig(
+    Region=os.environ["TENCENTCLOUD_REGION"],
+    SecretId=os.environ["TENCENTCLOUD_SECRET_ID"],
+    SecretKey=os.environ["TENCENTCLOUD_SECRET_KEY"],
+    Scheme="https",
+)
+client = CosS3Client(config)
+```
+
+## Workflows
+
+### List all buckets
+
+```python
+resp = client.list_buckets()
+for b in resp["Buckets"]["Bucket"]:
+    print(b["Name"], b["Location"], b["CreationDate"])
+```
+
+### List objects in a bucket
+
+```python
+# Single page (max 1000 objects)
+resp = client.list_objects(Bucket="mydata-1250000000", Prefix="images/", Delimiter="/")
+for obj in resp.get("Contents", []):
+    print(obj["Key"], int(obj["Size"]), obj["LastModified"])
+
+# Paginate through everything
+marker = ""
+while True:
+    resp = client.list_objects(Bucket="mydata-1250000000", Prefix="logs/", Marker=marker, MaxKeys=1000)
+    for obj in resp.get("Contents", []):
+        print(obj["Key"])
+    if resp.get("IsTruncated") != "true":
+        break
+    marker = resp["NextMarker"]
+```
+
+### Upload a file
+
+```python
+# Streaming upload — handles multipart / resumes / 5GB+ files transparently
+client.upload_file(
+    Bucket="mydata-1250000000",
+    Key="uploads/2026/report.pdf",
+    LocalFilePath="./report.pdf",
+)
+```
+
+### Download a file
+
+```python
+client.download_file(
+    Bucket="mydata-1250000000",
+    Key="uploads/2026/report.pdf",
+    DestFilePath="./report.pdf",
+)
+```
+
+### Generate a pre-signed download URL
+
+```python
+# Default expiry 1 hour; pass Expired=86400 for 24h, etc.
+url = client.get_presigned_url(
+    Method="GET",
+    Bucket="mydata-1250000000",
+    Key="uploads/2026/report.pdf",
+    Expired=3600,
+)
+print(url)
+```
+
+### Delete a single object
+
+```python
+client.delete_object(Bucket="mydata-1250000000", Key="uploads/old-file.txt")
+```
+
+### Batch delete by prefix (with dry-run safety)
+
+```python
+# 1) Always preview first
+to_delete = []
+marker = ""
+while True:
+    resp = client.list_objects(Bucket="mydata-1250000000", Prefix="temp/old/", Marker=marker, MaxKeys=1000)
+    for obj in resp.get("Contents", []):
+        to_delete.append({"Key": obj["Key"]})
+    if resp.get("IsTruncated") != "true":
+        break
+    marker = resp["NextMarker"]
+
+print(f"Would delete {len(to_delete)} objects")
+for o in to_delete[:10]:
+    print("  -", o["Key"])
+
+# 2) Confirm with the user before running this:
+# resp = client.delete_objects(Bucket="mydata-1250000000", Delete={"Object": to_delete, "Quiet": "false"})
+# print("Deleted:", len(resp.get("Deleted", [])))
+```
+
+### Calculate bucket / prefix size (du)
+
+```python
+total_bytes = 0
+total_count = 0
+marker = ""
+while True:
+    resp = client.list_objects(Bucket="mydata-1250000000", Prefix="logs/", Marker=marker, MaxKeys=1000)
+    for obj in resp.get("Contents", []):
+        total_bytes += int(obj["Size"])
+        total_count += 1
+    if resp.get("IsTruncated") != "true":
+        break
+    marker = resp["NextMarker"]
+
+print(f"{total_count} objects, {total_bytes / 1024 / 1024:.1f} MiB")
+```
+
+### Copy objects within a bucket
+
+```python
+client.copy_object(
+    Bucket="mydata-1250000000",
+    Key="new/path.txt",
+    CopySource={
+        "Bucket": "mydata-1250000000",
+        "Key": "old/path.txt",
+        "Region": os.environ["TENCENTCLOUD_REGION"],
+    },
+)
+```
+
+## Safety reminders
+
+- **Confirm batch deletes with the user** before running. The `delete_objects` call is irreversible — there's no recycle bin in COS by default.
+- **Pre-signed URLs are bearer tokens** — anyone with the URL gets the object until it expires. Default to short expiries (1 hour) unless the user explicitly asks for longer.
+- **Cross-region operations** require the source / destination Region in `CopySource`. Mismatched region triggers `NoSuchBucket`.
+- **`download_file` overwrites the destination** without asking. Pick `DestFilePath` carefully when scripting in a loop.
+
+## Error patterns
+
+| Symptom | Likely cause |
+|---|---|
+| `NoSuchBucket` | Wrong region, wrong APPID suffix on the bucket name |
+| `AccessDenied` | Sub-account missing `QcloudCOSReadOnlyAccess` / `QcloudCOSDataReadOnly` etc. |
+| `SignatureDoesNotMatch` | SecretKey was pasted with leading / trailing whitespace, or the system clock is off by more than 5 minutes |
+| `RequestTimeTooSkewed` | Same — clock skew |
+
+## Console links
+
+- COS console: <https://console.cloud.tencent.com/cos/bucket>
+- API reference: <https://www.tencentcloud.com/document/product/436/41330>

--- a/skills/tencentcloud-cos/scripts/cos.py
+++ b/skills/tencentcloud-cos/scripts/cos.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Tencent Cloud COS (Cloud Object Storage) Management Tool
+
+Manage COS buckets: list, upload, download, delete objects, manage buckets.
+
+Usage:
+  python3 $SKILL_DIR/scripts/cos.py buckets [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py ls <bucket> [--prefix PREFIX] [--region REGION] [--limit N]
+  python3 $SKILL_DIR/scripts/cos.py upload <bucket> <local_path> [--key KEY] [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py download <bucket> <key> [--output PATH] [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py delete <bucket> <key> [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py info <bucket> <key> [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py url <bucket> <key> [--region REGION] [--expires SECONDS]
+  python3 $SKILL_DIR/scripts/cos.py du <bucket> [--prefix PREFIX] [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py cp <bucket> <src_key> <dst_key> [--region REGION]
+  python3 $SKILL_DIR/scripts/cos.py batch-delete <bucket> --prefix PREFIX [--region REGION] [--dry-run]
+
+Environment:
+  Reads TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY from
+  sandbox env vars (TENCENTCLOUD_SECRET_ID / SECRET_KEY)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+DEFAULT_REGION = os.environ.get("TENCENTCLOUD_REGION", "ap-hongkong")
+
+
+
+
+def get_client(region):
+    try:
+        from qcloud_cos import CosConfig, CosS3Client
+    except ImportError:
+        print(
+            "ERROR: cos-python-sdk-v5 not installed.\n"
+            "Run: pip3 install cos-python-sdk-v5",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config = CosConfig(
+        Region=region,
+        SecretId=secret_id,
+        SecretKey=secret_key,
+        Scheme="https",
+    )
+    return CosS3Client(config)
+
+
+def human_size(num_bytes):
+    """Convert bytes to human-readable size."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(num_bytes) < 1024.0:
+            return f"{num_bytes:.1f} {unit}"
+        num_bytes /= 1024.0
+    return f"{num_bytes:.1f} PB"
+
+
+def cmd_buckets(args):
+    """List all buckets."""
+    client = get_client(args.region)
+    resp = client.list_buckets()
+    buckets = resp.get("Buckets", {}).get("Bucket", [])
+
+    if not buckets:
+        print("No buckets found.")
+        return
+
+    print(f"Found {len(buckets)} bucket(s):\n")
+    for b in buckets:
+        name = b.get("Name", "N/A")
+        location = b.get("Location", "N/A")
+        created = b.get("CreationDate", "N/A")
+        print(f"  {name:50s} {location:20s} Created: {created}")
+
+
+def cmd_ls(args):
+    """List objects in a bucket."""
+    client = get_client(args.region)
+
+    params = {
+        "Bucket": args.bucket,
+        "MaxKeys": args.limit,
+    }
+    if args.prefix:
+        params["Prefix"] = args.prefix
+    if args.delimiter:
+        params["Delimiter"] = args.delimiter
+
+    resp = client.list_objects(**params)
+
+    # Common prefixes (directories)
+    prefixes = resp.get("CommonPrefixes", [])
+    if prefixes:
+        for p in prefixes:
+            prefix = p.get("Prefix", "")
+            print(f"  DIR  {prefix}")
+
+    # Objects
+    contents = resp.get("Contents", [])
+    if not contents and not prefixes:
+        print("No objects found.")
+        return
+
+    total_size = 0
+    for obj in contents:
+        key = obj.get("Key", "")
+        size = int(obj.get("Size", 0))
+        modified = obj.get("LastModified", "N/A")
+        total_size += size
+        print(f"  {human_size(size):>10s}  {modified:25s}  {key}")
+
+    truncated = resp.get("IsTruncated", "false")
+    print(f"\n  {len(contents)} object(s), total: {human_size(total_size)}"
+          f"{' (truncated, use --limit to see more)' if truncated == 'true' else ''}")
+
+
+def cmd_upload(args):
+    """Upload a file to COS."""
+    client = get_client(args.region)
+    local_path = Path(args.local_path)
+
+    if not local_path.exists():
+        print(f"ERROR: File not found: {local_path}", file=sys.stderr)
+        sys.exit(1)
+
+    key = args.key or local_path.name
+
+    print(f"Uploading {local_path} → {args.bucket}/{key} ...")
+    resp = client.upload_file(
+        Bucket=args.bucket,
+        Key=key,
+        LocalFilePath=str(local_path),
+    )
+
+    etag = resp.get("ETag", "N/A")
+    url = f"https://{args.bucket}.cos.{args.region}.myqcloud.com/{key}"
+    print(f"  ETag: {etag}")
+    print(f"  URL:  {url}")
+
+
+def cmd_download(args):
+    """Download an object from COS."""
+    client = get_client(args.region)
+
+    output = args.output or Path(args.key).name
+    print(f"Downloading {args.bucket}/{args.key} → {output} ...")
+
+    resp = client.download_file(
+        Bucket=args.bucket,
+        Key=args.key,
+        DestFilePath=output,
+    )
+    print(f"  Downloaded to: {output}")
+
+
+def cmd_delete(args):
+    """Delete an object from COS."""
+    client = get_client(args.region)
+
+    print(f"Deleting {args.bucket}/{args.key} ...")
+    client.delete_object(
+        Bucket=args.bucket,
+        Key=args.key,
+    )
+    print("  Deleted.")
+
+
+def cmd_info(args):
+    """Get object metadata (head object)."""
+    client = get_client(args.region)
+
+    resp = client.head_object(
+        Bucket=args.bucket,
+        Key=args.key,
+    )
+
+    print(f"Object info for {args.bucket}/{args.key}:\n")
+    for k, v in resp.items():
+        if k.startswith("x-cos-") or k in ("Content-Length", "Content-Type", "ETag", "Last-Modified"):
+            print(f"  {k}: {v}")
+
+
+def cmd_url(args):
+    """Generate a pre-signed URL."""
+    client = get_client(args.region)
+
+    url = client.get_presigned_url(
+        Method="GET",
+        Bucket=args.bucket,
+        Key=args.key,
+        Expired=args.expires,
+    )
+    print(url)
+
+
+def cmd_du(args):
+    """Calculate total size of objects with a given prefix."""
+    client = get_client(args.region)
+
+    total_size = 0
+    total_count = 0
+    marker = ""
+
+    while True:
+        params = {
+            "Bucket": args.bucket,
+            "MaxKeys": 1000,
+            "Marker": marker,
+        }
+        if args.prefix:
+            params["Prefix"] = args.prefix
+
+        resp = client.list_objects(**params)
+        contents = resp.get("Contents", [])
+
+        for obj in contents:
+            total_size += int(obj.get("Size", 0))
+            total_count += 1
+
+        if resp.get("IsTruncated") == "true":
+            marker = resp.get("NextMarker", "")
+            if not marker and contents:
+                marker = contents[-1].get("Key", "")
+        else:
+            break
+
+    prefix_str = args.prefix or "(all)"
+    print(f"Bucket: {args.bucket}")
+    print(f"Prefix: {prefix_str}")
+    print(f"Objects: {total_count}")
+    print(f"Total size: {human_size(total_size)}")
+
+
+def cmd_cp(args):
+    """Copy an object within the same bucket."""
+    client = get_client(args.region)
+
+    source = {
+        "Bucket": args.bucket,
+        "Key": args.src_key,
+        "Region": args.region,
+    }
+
+    print(f"Copying {args.src_key} → {args.dst_key} in {args.bucket} ...")
+    client.copy_object(
+        Bucket=args.bucket,
+        Key=args.dst_key,
+        CopySource=source,
+    )
+    print("  Copied.")
+
+
+def cmd_batch_delete(args):
+    """Delete all objects with a given prefix (with confirmation)."""
+    client = get_client(args.region)
+
+    # Collect all keys
+    keys = []
+    marker = ""
+    while True:
+        resp = client.list_objects(
+            Bucket=args.bucket,
+            Prefix=args.prefix,
+            MaxKeys=1000,
+            Marker=marker,
+        )
+        contents = resp.get("Contents", [])
+        keys.extend([obj["Key"] for obj in contents])
+
+        if resp.get("IsTruncated") == "true":
+            marker = resp.get("NextMarker", "")
+            if not marker and contents:
+                marker = contents[-1].get("Key", "")
+        else:
+            break
+
+    if not keys:
+        print("No objects found with the given prefix.")
+        return
+
+    total_size = sum(int(obj.get("Size", 0)) for obj in contents)
+    print(f"Found {len(keys)} object(s) with prefix '{args.prefix}'")
+
+    if args.dry_run:
+        print("DRY RUN — would delete:")
+        for k in keys[:20]:
+            print(f"  {k}")
+        if len(keys) > 20:
+            print(f"  ... and {len(keys) - 20} more")
+        return
+
+    # Ask for confirmation
+    confirm = input(f"Delete {len(keys)} objects? [y/N] ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        return
+
+    # Delete in batches of 1000
+    for i in range(0, len(keys), 1000):
+        batch = keys[i:i + 1000]
+        delete_objects = {"Object": [{"Key": k} for k in batch]}
+        client.delete_objects(Bucket=args.bucket, Delete=delete_objects)
+        print(f"  Deleted batch {i // 1000 + 1} ({len(batch)} objects)")
+
+    print(f"  Total deleted: {len(keys)} objects")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Tencent Cloud COS Management Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--region", "-r", default=DEFAULT_REGION,
+                        help=f"Region (default: {DEFAULT_REGION})")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # buckets
+    sub.add_parser("buckets", help="List all buckets")
+
+    # ls
+    p = sub.add_parser("ls", help="List objects in a bucket")
+    p.add_argument("bucket", help="Bucket name (e.g. mybucket-1250000000)")
+    p.add_argument("--prefix", "-p", help="Key prefix filter")
+    p.add_argument("--delimiter", "-d", help="Delimiter for directory-like listing (use '/')")
+    p.add_argument("--limit", "-l", type=int, default=100, help="Max objects to list (default: 100)")
+
+    # upload
+    p = sub.add_parser("upload", help="Upload a file")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("local_path", help="Local file path")
+    p.add_argument("--key", "-k", help="Object key (default: filename)")
+
+    # download
+    p = sub.add_parser("download", help="Download an object")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("key", help="Object key")
+    p.add_argument("--output", "-o", help="Output file path (default: object filename)")
+
+    # delete
+    p = sub.add_parser("delete", help="Delete an object")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("key", help="Object key")
+
+    # info
+    p = sub.add_parser("info", help="Get object metadata")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("key", help="Object key")
+
+    # url
+    p = sub.add_parser("url", help="Generate a pre-signed URL")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("key", help="Object key")
+    p.add_argument("--expires", "-e", type=int, default=3600, help="URL expiry in seconds (default: 3600)")
+
+    # du
+    p = sub.add_parser("du", help="Calculate total size of objects")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("--prefix", "-p", help="Key prefix")
+
+    # cp
+    p = sub.add_parser("cp", help="Copy an object within the same bucket")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("src_key", help="Source object key")
+    p.add_argument("dst_key", help="Destination object key")
+
+    # batch-delete
+    p = sub.add_parser("batch-delete", help="Delete all objects with a prefix")
+    p.add_argument("bucket", help="Bucket name")
+    p.add_argument("--prefix", required=True, help="Key prefix for objects to delete")
+    p.add_argument("--dry-run", action="store_true", help="Show what would be deleted without deleting")
+
+    args = parser.parse_args()
+
+    commands = {
+        "buckets": cmd_buckets,
+        "ls": cmd_ls,
+        "upload": cmd_upload,
+        "download": cmd_download,
+        "delete": cmd_delete,
+        "info": cmd_info,
+        "url": cmd_url,
+        "du": cmd_du,
+        "cp": cmd_cp,
+        "batch-delete": cmd_batch_delete,
+    }
+
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tencentcloud-dns/SKILL.md
+++ b/skills/tencentcloud-dns/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: tencentcloud-dns
+description: |
+  Manage DNS records on DNSPod (Tencent Cloud's DNS service). Use when
+  the user asks to add / update / delete A / AAAA / CNAME / MX / TXT /
+  NS / SRV / CAA records, list records for a domain, search records,
+  add ACME challenge / SPF / DKIM / domain-verification TXT records.
+  Backed by the official tencentcloud-sdk-python DNSPod client.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# DNSPod (Tencent Cloud DNS)
+
+Manage DNS records via the DNSPod API.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). DNSPod uses the **same** Tencent Cloud SecretId / SecretKey as the rest of the platform — there's no separate `DP_Id` / `DP_Key` for the v3 API. The SDK client below auto-reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` from env.
+>
+> The legacy v2 DNSPod API used a different key format; this skill targets the v3 SDK exclusively.
+
+## When to Use
+
+- Add a new subdomain (A / AAAA / CNAME)
+- Update an existing record (change IP, change CNAME target)
+- Add email-related records (MX, SPF / DKIM / DMARC TXT)
+- Add domain-verification TXT records (Google / Search Console / SSL ACME challenges)
+- List or search records on a domain
+- Delete obsolete records
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+```
+
+## Quick start
+
+```python
+import os
+from tencentcloud.common import credential
+from tencentcloud.dnspod.v20210323 import dnspod_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+# DNSPod is global — region is ignored, but the SDK still requires one.
+client = dnspod_client.DnspodClient(cred, "")
+```
+
+## Workflows
+
+### List domains in the account
+
+```python
+req = models.DescribeDomainListRequest()
+req.Limit = 100
+resp = client.DescribeDomainList(req)
+for d in resp.DomainList:
+    print(d.DomainId, d.Name, d.Status, d.RecordCount)
+```
+
+### List records for a domain
+
+```python
+req = models.DescribeRecordListRequest()
+req.Domain = "example.com"
+req.Limit = 100                  # max 3000
+# Optional: req.RecordType = "A"
+# Optional: req.Subdomain = "api"
+resp = client.DescribeRecordList(req)
+for r in resp.RecordList:
+    print(r.RecordId, r.Name, r.Type, r.Value, "TTL=", r.TTL, "Line=", r.Line)
+```
+
+### Search by keyword (filter client-side)
+
+```python
+req = models.DescribeRecordListRequest()
+req.Domain = "example.com"
+req.Limit = 3000
+resp = client.DescribeRecordList(req)
+matches = [r for r in resp.RecordList if "api" in r.Name or "api" in r.Value]
+for r in matches:
+    print(r.RecordId, r.Name, r.Type, r.Value)
+```
+
+### Create records
+
+```python
+def create_record(domain, sub_domain, record_type, value, ttl=600, mx=None):
+    req = models.CreateRecordRequest()
+    req.Domain = domain
+    req.SubDomain = sub_domain   # use "@" for the apex
+    req.RecordType = record_type
+    req.RecordLine = "默认"      # "Default" line — works in all environments
+    req.Value = value
+    req.TTL = ttl
+    if mx is not None:
+        req.MX = mx
+    resp = client.CreateRecord(req)
+    return resp.RecordId
+
+# A record
+rid = create_record("example.com", "www", "A", "1.2.3.4")
+# CNAME (note: Value MUST end with a dot for absolute target)
+rid = create_record("example.com", "api2", "CNAME", "api.example.com.")
+# MX (priority via mx=)
+rid = create_record("example.com", "@", "MX", "mail.example.com.", mx=10)
+# TXT (SPF)
+rid = create_record("example.com", "@", "TXT", '"v=spf1 include:_spf.google.com ~all"')
+# ACME challenge for cert issuance
+rid = create_record("example.com", "_acme-challenge", "TXT", '"<validation-token>"')
+```
+
+### Update an existing record
+
+```python
+req = models.ModifyRecordRequest()
+req.Domain = "example.com"
+req.RecordId = 123456789
+req.SubDomain = "www"
+req.RecordType = "A"
+req.RecordLine = "默认"
+req.Value = "5.6.7.8"
+req.TTL = 600
+client.ModifyRecord(req)
+```
+
+### Delete a record
+
+```python
+# Confirm with the user before running.
+req = models.DeleteRecordRequest()
+req.Domain = "example.com"
+req.RecordId = 123456789
+client.DeleteRecord(req)
+```
+
+## Record types
+
+| Type | Use For | Example Value |
+|---|---|---|
+| `A` | IPv4 address | `1.2.3.4` |
+| `AAAA` | IPv6 address | `2001:db8::1` |
+| `CNAME` | Alias to another hostname | `target.example.com.` |
+| `MX` | Mail server | `mail.example.com.` (set `MX=` priority) |
+| `TXT` | SPF / DKIM / DMARC / domain verification / ACME | `"v=spf1 ..."` (quoted) |
+| `NS` | Delegate subzone | `ns1.example.com.` |
+| `SRV` | Service discovery | `0 5 443 api.example.com.` |
+| `CAA` | Cert Authority Authorization | `0 issue "letsencrypt.org"` |
+
+## CNAME apex restriction
+
+DNSPod (like every other DNS service) **does not support `CNAME` on the apex `@`** (the bare domain) when other record types exist. Use `A` for the apex; `CNAME` for subdomains. If the upstream is itself a hostname (e.g. an EdgeOne / CDN endpoint), use the `Alias` record type via the EdgeOne console — DNSPod itself doesn't have an `ALIAS` type.
+
+## RecordLine ("线路")
+
+DNSPod can serve different values to different ISPs / regions via `RecordLine`. For 99% of cases pick `"默认"` (Default) — it serves to every resolver. Other common lines: `"电信"`, `"联通"`, `"移动"`, `"境外"`, `"国内"`. Use the console to set up split-horizon DNS; the API just lets you write the records.
+
+## Verifying changes
+
+```bash
+dig @119.29.29.29 www.example.com +short    # 119.29.29.29 = DNSPod's recursor
+dig www.example.com +trace                  # follow the delegation chain
+```
+
+DNSPod propagation is usually under a minute on its own resolver and bounded by the TTL elsewhere. Use `TTL=60` while iterating; raise to `600` once stable.
+
+## Important reminders
+
+- **CNAME values need a trailing dot** to be absolute (`api.example.com.`). Without it, DNSPod won't reject — but resolvers will hate you.
+- **Confirm deletes** with the user — there's no undo. The `RecordId` is required, so search first to be sure.
+- **Don't rotate `NS` records lightly** — losing nameserver delegation takes the entire domain offline until you fix it.
+- **TXT values for SPF/DMARC need to stay under 255 chars per chunk.** For longer policies, split into multiple quoted strings within one TXT value.
+- DNSPod has separate quota for free / paid plans on `RecordCount` and `RecordsPerMinute`. Check the console if `LimitExceeded` errors appear.
+
+## Console links
+
+- DNSPod console: <https://console.cloud.tencent.com/cns>
+- API reference: <https://www.tencentcloud.com/document/product/1097/40694>

--- a/skills/tencentcloud-dns/SKILL.md
+++ b/skills/tencentcloud-dns/SKILL.md
@@ -21,6 +21,26 @@ Manage DNS records via the DNSPod API.
 >
 > The legacy v2 DNSPod API used a different key format; this skill targets the v3 SDK exclusively.
 
+## CLI (preferred)
+
+The skill ships [`scripts/dns.py`](scripts/dns.py) — wraps every common DNSPod v3 operation.
+
+```bash
+DNS=$SKILL_DIR/scripts/dns.py
+
+python3 $DNS domains                                       # list domains
+python3 $DNS list example.com                              # records on one domain
+python3 $DNS list example.com --type CNAME                 # filter by type
+python3 $DNS search example.com --keyword api              # client-side keyword search
+python3 $DNS create example.com --sub www --type A --value 1.2.3.4
+python3 $DNS create example.com --sub @ --type MX --value 'mail.example.com.' --mx 10
+python3 $DNS create example.com --sub _acme-challenge --type TXT --value '"<token>"'
+python3 $DNS update example.com <record-id> --sub www --type A --value 5.6.7.8
+python3 $DNS delete example.com <record-id> --yes          # destructive, requires --yes
+```
+
+The `delete` subcommand requires `--yes` — without it, it prints a dry-run line so you can confirm the right `record-id` first.
+
 ## When to Use
 
 - Add a new subdomain (A / AAAA / CNAME)

--- a/skills/tencentcloud-dns/scripts/dns.py
+++ b/skills/tencentcloud-dns/scripts/dns.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+DNSPod (Tencent Cloud DNS) — record management CLI.
+
+Uses the v3 DNSPod API via tencentcloud-sdk-python — same TENCENTCLOUD_*
+credentials as every other tencentcloud-* skill.
+
+Quick examples:
+  python3 $SKILL_DIR/scripts/dns.py domains
+  python3 $SKILL_DIR/scripts/dns.py list example.com
+  python3 $SKILL_DIR/scripts/dns.py list example.com --type CNAME
+  python3 $SKILL_DIR/scripts/dns.py search example.com --keyword api
+  python3 $SKILL_DIR/scripts/dns.py create example.com --sub www --type A --value 1.2.3.4
+  python3 $SKILL_DIR/scripts/dns.py update example.com <record_id> --sub www --type A --value 5.6.7.8
+  python3 $SKILL_DIR/scripts/dns.py delete example.com <record_id>
+
+Environment:
+  TENCENTCLOUD_SECRET_ID   — required
+  TENCENTCLOUD_SECRET_KEY  — required
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def get_client():
+    try:
+        from tencentcloud.common import credential
+        from tencentcloud.dnspod.v20210323 import dnspod_client
+    except ImportError:
+        print(
+            "ERROR: tencentcloud-sdk-python not installed.\nRun: pip3 install tencentcloud-sdk-python",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set in env",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    cred = credential.Credential(secret_id, secret_key)
+    # DNSPod is global — region is ignored, pass empty string.
+    return dnspod_client.DnspodClient(cred, "")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_domains(args):
+    from tencentcloud.dnspod.v20210323 import models
+
+    client = get_client()
+    req = models.DescribeDomainListRequest()
+    req.Limit = 100
+    resp = client.DescribeDomainList(req)
+    rows = [
+        {
+            "DomainId": d.DomainId,
+            "Name": d.Name,
+            "Status": d.Status,
+            "RecordCount": d.RecordCount,
+        }
+        for d in (resp.DomainList or [])
+    ]
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+    else:
+        print(f"{'Name':30s}  {'Status':10s}  {'#Records':8s}  DomainId")
+        for r in rows:
+            print(f"{r['Name']:30s}  {r['Status']:10s}  {r['RecordCount']:>8d}  {r['DomainId']}")
+
+
+def cmd_list(args):
+    from tencentcloud.dnspod.v20210323 import models
+
+    client = get_client()
+    req = models.DescribeRecordListRequest()
+    req.Domain = args.domain
+    req.Limit = args.limit
+    if args.type:
+        req.RecordType = args.type
+    if args.sub:
+        req.Subdomain = args.sub
+    resp = client.DescribeRecordList(req)
+    _print_records(resp.RecordList or [], args.format)
+
+
+def cmd_search(args):
+    """List + client-side keyword filter (DNSPod has no server-side text search)."""
+    from tencentcloud.dnspod.v20210323 import models
+
+    client = get_client()
+    req = models.DescribeRecordListRequest()
+    req.Domain = args.domain
+    req.Limit = 3000
+    resp = client.DescribeRecordList(req)
+    keyword = args.keyword.lower()
+    matches = [
+        r
+        for r in (resp.RecordList or [])
+        if keyword in (r.Name or "").lower() or keyword in (r.Value or "").lower()
+    ]
+    _print_records(matches, args.format)
+
+
+def _print_records(records, fmt):
+    rows = [
+        {
+            "RecordId": r.RecordId,
+            "Name": r.Name,
+            "Type": r.Type,
+            "Value": r.Value,
+            "TTL": r.TTL,
+            "Line": r.Line,
+            "MX": getattr(r, "MX", None),
+        }
+        for r in records
+    ]
+    if fmt == "json":
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        return
+    print(f"{'RecordId':12s}  {'Name':22s}  {'Type':6s}  {'TTL':5s}  Value")
+    for r in rows:
+        print(f"{str(r['RecordId']):12s}  {r['Name']:22s}  {r['Type']:6s}  {str(r['TTL']):5s}  {r['Value']}")
+
+
+def cmd_create(args):
+    from tencentcloud.dnspod.v20210323 import models
+
+    client = get_client()
+    req = models.CreateRecordRequest()
+    req.Domain = args.domain
+    req.SubDomain = args.sub
+    req.RecordType = args.type
+    req.RecordLine = args.line
+    req.Value = args.value
+    req.TTL = args.ttl
+    if args.mx is not None:
+        req.MX = args.mx
+    resp = client.CreateRecord(req)
+    print(f"Created RecordId={resp.RecordId}")
+
+
+def cmd_update(args):
+    from tencentcloud.dnspod.v20210323 import models
+
+    client = get_client()
+    req = models.ModifyRecordRequest()
+    req.Domain = args.domain
+    req.RecordId = int(args.record_id)
+    req.SubDomain = args.sub
+    req.RecordType = args.type
+    req.RecordLine = args.line
+    req.Value = args.value
+    req.TTL = args.ttl
+    if args.mx is not None:
+        req.MX = args.mx
+    client.ModifyRecord(req)
+    print(f"Updated RecordId={args.record_id}")
+
+
+def cmd_delete(args):
+    from tencentcloud.dnspod.v20210323 import models
+
+    if not args.yes:
+        print(f"DRY RUN: would delete RecordId={args.record_id} on {args.domain}. Pass --yes to actually delete.")
+        return
+    client = get_client()
+    req = models.DeleteRecordRequest()
+    req.Domain = args.domain
+    req.RecordId = int(args.record_id)
+    client.DeleteRecord(req)
+    print(f"Deleted RecordId={args.record_id}")
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Tencent Cloud DNSPod record management.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("domains", help="List domains")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.set_defaults(func=cmd_domains)
+
+    p = sub.add_parser("list", help="List records on a domain")
+    p.add_argument("domain")
+    p.add_argument("--type", help="Filter by record type (A, AAAA, CNAME, MX, TXT, …)")
+    p.add_argument("--sub", help="Filter by exact subdomain")
+    p.add_argument("--limit", type=int, default=100)
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.set_defaults(func=cmd_list)
+
+    p = sub.add_parser("search", help="Search records by keyword (matches Name or Value)")
+    p.add_argument("domain")
+    p.add_argument("--keyword", required=True)
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.set_defaults(func=cmd_search)
+
+    p = sub.add_parser("create", help="Create a record")
+    p.add_argument("domain")
+    p.add_argument("--sub", required=True, help="Subdomain (use @ for apex)")
+    p.add_argument("--type", required=True, help="A / AAAA / CNAME / MX / TXT / NS / SRV / CAA")
+    p.add_argument("--value", required=True)
+    p.add_argument("--line", default="默认", help='RecordLine (default "默认")')
+    p.add_argument("--ttl", type=int, default=600)
+    p.add_argument("--mx", type=int, help="MX priority (only for type=MX)")
+    p.set_defaults(func=cmd_create)
+
+    p = sub.add_parser("update", help="Modify an existing record")
+    p.add_argument("domain")
+    p.add_argument("record_id")
+    p.add_argument("--sub", required=True)
+    p.add_argument("--type", required=True)
+    p.add_argument("--value", required=True)
+    p.add_argument("--line", default="默认")
+    p.add_argument("--ttl", type=int, default=600)
+    p.add_argument("--mx", type=int)
+    p.set_defaults(func=cmd_update)
+
+    p = sub.add_parser("delete", help="Delete a record (requires --yes)")
+    p.add_argument("domain")
+    p.add_argument("record_id")
+    p.add_argument("--yes", action="store_true", help="Confirm destructive operation")
+    p.set_defaults(func=cmd_delete)
+
+    args = parser.parse_args()
+    return args.func(args) or 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/tencentcloud-edgeone/SKILL.md
+++ b/skills/tencentcloud-edgeone/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: tencentcloud-edgeone
+description: |
+  Manage Tencent Cloud EdgeOne (CDN + edge security). Use when the user
+  asks to: list zones, purge CDN cache (URL / prefix / hostname / all),
+  prefetch URLs to warm edges, check purge / prefetch task status,
+  manage acceleration domains, list / create / delete EdgeOne DNS
+  records, inspect WAF / security configuration. Backed by the official
+  tencentcloud-sdk-python TEO client.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# Tencent Cloud EdgeOne (CDN + Security)
+
+Manage EdgeOne zones — purge cache, prefetch URLs, manage DNS records on the zone, check WAF settings.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). The SDK reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` from env. EdgeOne is global — `Region=""` is fine.
+
+## When to Use
+
+- List EdgeOne zones / acceleration domains
+- Purge cache after a deploy (by URL, prefix, hostname, or whole zone)
+- Prefetch URLs to warm edge nodes
+- Track purge / prefetch task status
+- Manage EdgeOne DNS records (zones managed by EdgeOne use the TEO API, not DNSPod)
+- Inspect WAF / security config
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+```
+
+## Quick start
+
+```python
+import os
+from tencentcloud.common import credential
+from tencentcloud.teo.v20220901 import teo_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+client = teo_client.TeoClient(cred, "")
+```
+
+## Workflows
+
+### List zones
+
+```python
+req = models.DescribeZonesRequest()
+req.Limit = 100
+resp = client.DescribeZones(req)
+for z in resp.Zones:
+    print(z.ZoneId, z.ZoneName, z.Status, z.Type)
+```
+
+> Zone IDs look like `zone-xxxxxxxx`. The `ZoneName` is the apex domain (e.g. `acedata.cloud`).
+
+### List acceleration domains in a zone
+
+```python
+req = models.DescribeAccelerationDomainsRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Limit = 100
+resp = client.DescribeAccelerationDomains(req)
+for d in resp.AccelerationDomains:
+    print(d.DomainName, d.DomainStatus, d.OriginDetail.OriginType)
+```
+
+### Purge cache — by URL
+
+```python
+req = models.CreatePurgeTaskRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Type = "purge_url"
+req.Targets = [
+    "https://hub.example.com/index.html",
+    "https://hub.example.com/assets/main.css",
+]
+resp = client.CreatePurgeTask(req)
+print("Task:", resp.JobId)
+```
+
+### Purge by hostname (entire host)
+
+```python
+req = models.CreatePurgeTaskRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Type = "purge_host"
+req.Targets = ["hub.example.com"]
+client.CreatePurgeTask(req)
+```
+
+### Purge by prefix (all URLs under a path)
+
+```python
+req = models.CreatePurgeTaskRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Type = "purge_prefix"
+req.Targets = ["https://hub.example.com/assets/"]
+client.CreatePurgeTask(req)
+```
+
+### Purge ALL cache for a zone (nuclear option)
+
+```python
+# Confirm with the user — this re-fetches every cached object on next request,
+# spiking origin load.
+req = models.CreatePurgeTaskRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Type = "purge_all"
+client.CreatePurgeTask(req)
+```
+
+### Prefetch (pre-warm edges)
+
+```python
+req = models.CreatePrefetchTaskRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Targets = [
+    "https://hub.example.com/",
+    "https://hub.example.com/chat",
+]
+resp = client.CreatePrefetchTask(req)
+print("Task:", resp.JobId)
+```
+
+### Track task status
+
+```python
+req = models.DescribePurgeTasksRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Limit = 50
+# Optional: req.Filters = [{"Name": "job-id", "Values": ["<job-id>"]}]
+resp = client.DescribePurgeTasks(req)
+for t in resp.Tasks:
+    print(t.JobId, t.Type, t.Status, t.CreateTime)
+
+# Same shape for DescribePrefetchTasks
+```
+
+### List EdgeOne DNS records on a zone
+
+```python
+req = models.DescribeDnsRecordsRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Limit = 100
+resp = client.DescribeDnsRecords(req)
+for r in resp.DnsRecords:
+    print(r.RecordId, r.Name, r.Type, r.Content)
+```
+
+### Create an EdgeOne DNS record
+
+```python
+req = models.CreateDnsRecordRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.Name = "sub.example.com"
+req.Type = "CNAME"
+req.Content = "origin.example.com"
+req.TTL = 600
+client.CreateDnsRecord(req)
+```
+
+### Delete an EdgeOne DNS record
+
+```python
+req = models.DeleteDnsRecordsRequest()
+req.ZoneId = "zone-xxxxxxxx"
+req.RecordIds = ["<record-id>"]
+client.DeleteDnsRecords(req)
+```
+
+## Purge type cheatsheet
+
+| Type | When to use | Caveat |
+|---|---|---|
+| `purge_url` | Specific page / asset changed | Most surgical; up to 1000 URLs per call |
+| `purge_prefix` | A directory of assets changed (`/assets/...`) | Treats target as a prefix match |
+| `purge_host` | Full site deployment | Affects everything on the hostname |
+| `purge_all` | Emergency / major migration | All cache for the zone — origin spike inevitable |
+
+## Typical post-deploy sequence
+
+```python
+# 1. Purge the hostname so users get the new bundle
+client.CreatePurgeTask(models.CreatePurgeTaskRequest(
+    ZoneId="zone-xxxxxxxx",
+    Type="purge_host",
+    Targets=["hub.example.com"],
+))
+
+# 2. Prefetch the most-trafficked routes so edge cache is warm
+client.CreatePrefetchTask(models.CreatePrefetchTaskRequest(
+    ZoneId="zone-xxxxxxxx",
+    Targets=[
+        "https://hub.example.com/",
+        "https://hub.example.com/chat",
+        "https://hub.example.com/login",
+    ],
+))
+
+# 3. Watch for completion (typically 30s – 2min)
+import time
+while True:
+    resp = client.DescribePurgeTasks(models.DescribePurgeTasksRequest(
+        ZoneId="zone-xxxxxxxx",
+        Filters=[{"Name": "status", "Values": ["processing"]}],
+    ))
+    if not resp.Tasks:
+        print("All purge tasks done.")
+        break
+    print(f"{len(resp.Tasks)} tasks still processing...")
+    time.sleep(15)
+```
+
+## Important reminders
+
+- **`purge_all` causes origin load spike.** Use only when surgical purges aren't enough.
+- **Prefetch isn't free** — it counts against your CDN traffic quota at edge-warm time. Only prefetch URLs you're confident users will hit.
+- **Purge / prefetch propagation is global** but takes 30s–2min. Plan deploy windows accordingly.
+- EdgeOne DNS and DNSPod DNS are *separate*. Domains onboarded to EdgeOne with NS-mode resolve through the TEO API; CNAME-mode domains still resolve through whatever DNS you've configured (DNSPod or third-party). Use the right skill for the right zone type.
+
+## Console links
+
+- EdgeOne console: <https://console.cloud.tencent.com/edgeone>
+- API reference: <https://www.tencentcloud.com/document/product/1145/53929>

--- a/skills/tencentcloud-edgeone/SKILL.md
+++ b/skills/tencentcloud-edgeone/SKILL.md
@@ -20,6 +20,32 @@ Manage EdgeOne zones — purge cache, prefetch URLs, manage DNS records on the z
 
 > **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). The SDK reads `TENCENTCLOUD_SECRET_ID` / `TENCENTCLOUD_SECRET_KEY` from env. EdgeOne is global — `Region=""` is fine.
 
+## CLI (preferred)
+
+The skill ships [`scripts/edgeone.py`](scripts/edgeone.py) — wraps zone discovery, purge / prefetch, task tracking, EdgeOne DNS records, and WAF inspection.
+
+```bash
+EO=$SKILL_DIR/scripts/edgeone.py
+
+python3 $EO zones                                                  # list zones
+python3 $EO zone zone-xxxxxxxx                                     # one zone's details
+python3 $EO domains zone-xxxxxxxx                                  # acceleration domains
+python3 $EO purge zone-xxxxxxxx --urls https://hub.example.com/index.html
+python3 $EO purge zone-xxxxxxxx --prefixes https://hub.example.com/assets/
+python3 $EO purge zone-xxxxxxxx --hosts hub.example.com
+python3 $EO purge zone-xxxxxxxx --all                              # nuclear
+python3 $EO prefetch zone-xxxxxxxx --urls https://hub.example.com/ https://hub.example.com/chat
+python3 $EO purge-tasks zone-xxxxxxxx --status processing
+python3 $EO prefetch-tasks zone-xxxxxxxx
+python3 $EO dns zone-xxxxxxxx                                      # EdgeOne DNS records
+python3 $EO dns-create zone-xxxxxxxx --name sub --type CNAME --content origin.example.com
+python3 $EO dns-delete zone-xxxxxxxx <record-id>
+python3 $EO security zone-xxxxxxxx                                 # WAF / security cfg
+python3 $EO waf zone-xxxxxxxx
+```
+
+Purge / prefetch propagation is global but typically takes 30s–2min. Use `purge-tasks --status processing` to wait.
+
 ## When to Use
 
 - List EdgeOne zones / acceleration domains

--- a/skills/tencentcloud-edgeone/scripts/edgeone.py
+++ b/skills/tencentcloud-edgeone/scripts/edgeone.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+Tencent Cloud EdgeOne (EO) Management Tool
+
+Manage EdgeOne CDN/security: zones, cache purge, prefetch, DNS records, security rules.
+
+Usage:
+  python3 $SKILL_DIR/scripts/edgeone.py zones
+  python3 $SKILL_DIR/scripts/edgeone.py zone <zone_id>
+  python3 $SKILL_DIR/scripts/edgeone.py domains <zone_id>
+  python3 $SKILL_DIR/scripts/edgeone.py purge <zone_id> --urls URL1 [URL2 ...]
+  python3 $SKILL_DIR/scripts/edgeone.py purge <zone_id> --prefixes PREFIX1 [PREFIX2 ...]
+  python3 $SKILL_DIR/scripts/edgeone.py purge <zone_id> --hosts HOST1 [HOST2 ...]
+  python3 $SKILL_DIR/scripts/edgeone.py purge <zone_id> --all
+  python3 $SKILL_DIR/scripts/edgeone.py prefetch <zone_id> --urls URL1 [URL2 ...]
+  python3 $SKILL_DIR/scripts/edgeone.py purge-tasks <zone_id> [--status STATUS]
+  python3 $SKILL_DIR/scripts/edgeone.py prefetch-tasks <zone_id> [--status STATUS]
+  python3 $SKILL_DIR/scripts/edgeone.py dns <zone_id> [--name NAME] [--type TYPE]
+  python3 $SKILL_DIR/scripts/edgeone.py dns-create <zone_id> --name NAME --type TYPE --content CONTENT [--ttl TTL]
+  python3 $SKILL_DIR/scripts/edgeone.py dns-delete <zone_id> <record_id>
+  python3 $SKILL_DIR/scripts/edgeone.py security <zone_id>
+  python3 $SKILL_DIR/scripts/edgeone.py waf <zone_id>
+
+Environment:
+  Reads TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY from
+  sandbox env vars (TENCENTCLOUD_SECRET_ID / SECRET_KEY)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+
+
+
+def get_client():
+    try:
+        from tencentcloud.common import credential
+        from tencentcloud.teo.v20220901 import teo_client
+    except ImportError:
+        print(
+            "ERROR: tencentcloud-sdk-python not installed.\n"
+            "Run: pip3 install tencentcloud-sdk-python",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cred = credential.Credential(secret_id, secret_key)
+    return teo_client.TeoClient(cred, "")
+
+
+def pp(data):
+    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+
+
+def cmd_zones(args):
+    """List all EdgeOne zones."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribeZonesRequest()
+    req.Limit = 100
+    resp = client.DescribeZones(req)
+    data = json.loads(resp.to_json_string())
+
+    zones = data.get("Zones", [])
+    if not zones:
+        print("No zones found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(zones))} zone(s):\n")
+    for z in zones:
+        status = z.get("Status", "Unknown")
+        plan = z.get("PlanType", "N/A")
+        emoji = "●" if status == "active" else "○"
+        print(f"  {emoji} {z.get('ZoneId', 'N/A'):25s} {z.get('ZoneName', 'N/A'):30s} "
+              f"{status:12s} Plan: {plan}")
+
+
+def cmd_zone(args):
+    """Get zone details."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribeZonesRequest()
+    req.Filters = [{"Name": "zone-id", "Values": [args.zone_id]}]
+    resp = client.DescribeZones(req)
+    data = json.loads(resp.to_json_string())
+
+    zones = data.get("Zones", [])
+    if not zones:
+        print(f"Zone {args.zone_id} not found.")
+        return
+
+    pp(zones[0])
+
+
+def cmd_domains(args):
+    """List acceleration domains for a zone."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribeAccelerationDomainsRequest()
+    req.ZoneId = args.zone_id
+    req.Limit = 100
+    resp = client.DescribeAccelerationDomains(req)
+    data = json.loads(resp.to_json_string())
+
+    domains = data.get("AccelerationDomains", [])
+    if not domains:
+        print("No domains found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(domains))} domain(s):\n")
+    for d in domains:
+        status = d.get("DomainStatus", "Unknown")
+        cname = d.get("Cname", "N/A")
+        emoji = "●" if status == "online" else "○"
+        print(f"  {emoji} {d.get('DomainName', 'N/A'):40s} {status:12s} CNAME: {cname}")
+
+
+def cmd_purge(args):
+    """Create a cache purge task."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.CreatePurgeTaskRequest()
+    req.ZoneId = args.zone_id
+
+    if args.urls:
+        req.Type = "purge_url"
+        req.Targets = args.urls
+        print(f"Purging {len(args.urls)} URL(s)...")
+    elif args.prefixes:
+        req.Type = "purge_prefix"
+        req.Targets = args.prefixes
+        print(f"Purging {len(args.prefixes)} prefix(es)...")
+    elif args.hosts:
+        req.Type = "purge_host"
+        req.Targets = args.hosts
+        print(f"Purging {len(args.hosts)} host(s)...")
+    elif args.all:
+        req.Type = "purge_all"
+        req.Targets = []
+        print("Purging ALL cache...")
+    else:
+        print("ERROR: Specify --urls, --prefixes, --hosts, or --all", file=sys.stderr)
+        sys.exit(1)
+
+    resp = client.CreatePurgeTask(req)
+    data = json.loads(resp.to_json_string())
+    task_id = data.get("TaskId", "N/A")
+    print(f"  Purge task created: {task_id}")
+
+
+def cmd_prefetch(args):
+    """Create a prefetch (pre-warm) task."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.CreatePrefetchTaskRequest()
+    req.ZoneId = args.zone_id
+    req.Targets = args.urls
+
+    print(f"Prefetching {len(args.urls)} URL(s)...")
+    resp = client.CreatePrefetchTask(req)
+    data = json.loads(resp.to_json_string())
+    task_id = data.get("TaskId", "N/A")
+    print(f"  Prefetch task created: {task_id}")
+
+
+def cmd_purge_tasks(args):
+    """List purge tasks."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribePurgeTasksRequest()
+    req.ZoneId = args.zone_id
+    req.Limit = 20
+
+    if args.status:
+        req.Filters = [{"Name": "status", "Values": [args.status]}]
+
+    resp = client.DescribePurgeTasks(req)
+    data = json.loads(resp.to_json_string())
+
+    tasks = data.get("Tasks", [])
+    if not tasks:
+        print("No purge tasks found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(tasks))} task(s):\n")
+    for t in tasks:
+        status = t.get("Status", "Unknown")
+        emoji = "✓" if status == "complete" else "…" if status == "processing" else "✗"
+        print(f"  {emoji} {t.get('TaskId', 'N/A'):40s} {t.get('Type', 'N/A'):15s} "
+              f"{status:12s} {t.get('CreatedOn', 'N/A')}")
+        target = t.get("Target", "")
+        if target:
+            print(f"    Target: {target}")
+
+
+def cmd_prefetch_tasks(args):
+    """List prefetch tasks."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribePrefetchTasksRequest()
+    req.ZoneId = args.zone_id
+    req.Limit = 20
+
+    if args.status:
+        req.Filters = [{"Name": "status", "Values": [args.status]}]
+
+    resp = client.DescribePrefetchTasks(req)
+    data = json.loads(resp.to_json_string())
+
+    tasks = data.get("Tasks", [])
+    if not tasks:
+        print("No prefetch tasks found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(tasks))} task(s):\n")
+    for t in tasks:
+        status = t.get("Status", "Unknown")
+        emoji = "✓" if status == "complete" else "…" if status == "processing" else "✗"
+        print(f"  {emoji} {t.get('TaskId', 'N/A'):40s} {status:12s} {t.get('CreatedOn', 'N/A')}")
+        target = t.get("Target", "")
+        if target:
+            print(f"    Target: {target}")
+
+
+def cmd_dns(args):
+    """List DNS records for a zone."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribeDnsRecordsRequest()
+    req.ZoneId = args.zone_id
+    req.Limit = 100
+
+    filters = []
+    if args.name:
+        filters.append({"Name": "name", "Values": [args.name]})
+    if args.type:
+        filters.append({"Name": "type", "Values": [args.type]})
+    if filters:
+        req.Filters = filters
+
+    resp = client.DescribeDnsRecords(req)
+    data = json.loads(resp.to_json_string())
+
+    records = data.get("DnsRecords", [])
+    if not records:
+        print("No DNS records found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(records))} record(s):\n")
+    for r in records:
+        print(f"  {r.get('RecordId', 'N/A'):15s} {r.get('Type', 'N/A'):8s} "
+              f"{r.get('Name', 'N/A'):40s} → {r.get('Content', 'N/A'):40s} "
+              f"TTL: {r.get('TTL', 'N/A')}")
+
+
+def cmd_dns_create(args):
+    """Create a DNS record."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.CreateDnsRecordRequest()
+    req.ZoneId = args.zone_id
+    req.Type = args.type
+    req.Name = args.name
+    req.Content = args.content
+    req.TTL = args.ttl
+
+    print(f"Creating {args.type} record: {args.name} → {args.content} ...")
+    resp = client.CreateDnsRecord(req)
+    data = json.loads(resp.to_json_string())
+    record_id = data.get("RecordId", "N/A")
+    print(f"  Created record: {record_id}")
+
+
+def cmd_dns_delete(args):
+    """Delete a DNS record."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DeleteDnsRecordsRequest()
+    req.ZoneId = args.zone_id
+    req.RecordIds = [args.record_id]
+
+    print(f"Deleting DNS record {args.record_id} ...")
+    client.DeleteDnsRecords(req)
+    print("  Deleted.")
+
+
+def cmd_security(args):
+    """Get zone security configuration."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    req = models.DescribeSecurityIPGroupInfoRequest()
+    req.ZoneId = args.zone_id
+
+    resp = client.DescribeSecurityIPGroupInfo(req)
+    data = json.loads(resp.to_json_string())
+    pp(data)
+
+
+def cmd_waf(args):
+    """Get WAF configuration."""
+    from tencentcloud.teo.v20220901 import models
+
+    client = get_client()
+    # Retrieve the zone settings which include security features
+    req = models.DescribeZoneSettingRequest()
+    req.ZoneId = args.zone_id
+
+    resp = client.DescribeZoneSetting(req)
+    data = json.loads(resp.to_json_string())
+
+    zone_setting = data.get("ZoneSetting", {})
+    # Extract security-related settings
+    security_fields = {}
+    for key in ("WebSocket", "Cache", "CacheKey", "PostMaxSize", "Quic",
+                "ClientIpHeader", "CachePrefresh", "Ipv6", "Https", "Grpc"):
+        if key in zone_setting:
+            security_fields[key] = zone_setting[key]
+
+    pp(security_fields)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Tencent Cloud EdgeOne Management Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # zones
+    sub.add_parser("zones", help="List all zones")
+
+    # zone
+    p = sub.add_parser("zone", help="Get zone details")
+    p.add_argument("zone_id")
+
+    # domains
+    p = sub.add_parser("domains", help="List acceleration domains")
+    p.add_argument("zone_id")
+
+    # purge
+    p = sub.add_parser("purge", help="Create cache purge task")
+    p.add_argument("zone_id")
+    purge_group = p.add_mutually_exclusive_group(required=True)
+    purge_group.add_argument("--urls", nargs="+", help="URLs to purge")
+    purge_group.add_argument("--prefixes", nargs="+", help="URL prefixes to purge")
+    purge_group.add_argument("--hosts", nargs="+", help="Hostnames to purge")
+    purge_group.add_argument("--all", action="store_true", help="Purge all cache")
+
+    # prefetch
+    p = sub.add_parser("prefetch", help="Create prefetch/pre-warm task")
+    p.add_argument("zone_id")
+    p.add_argument("--urls", nargs="+", required=True, help="URLs to prefetch")
+
+    # purge-tasks
+    p = sub.add_parser("purge-tasks", help="List purge tasks")
+    p.add_argument("zone_id")
+    p.add_argument("--status", help="Filter by status (processing/complete/failed)")
+
+    # prefetch-tasks
+    p = sub.add_parser("prefetch-tasks", help="List prefetch tasks")
+    p.add_argument("zone_id")
+    p.add_argument("--status", help="Filter by status")
+
+    # dns
+    p = sub.add_parser("dns", help="List DNS records")
+    p.add_argument("zone_id")
+    p.add_argument("--name", help="Filter by record name")
+    p.add_argument("--type", help="Filter by type (A/CNAME/TXT/MX)")
+
+    # dns-create
+    p = sub.add_parser("dns-create", help="Create DNS record")
+    p.add_argument("zone_id")
+    p.add_argument("--name", required=True, help="Record name")
+    p.add_argument("--type", required=True, help="Record type (A/CNAME/TXT/MX)")
+    p.add_argument("--content", required=True, help="Record content/value")
+    p.add_argument("--ttl", type=int, default=300, help="TTL in seconds (default: 300)")
+
+    # dns-delete
+    p = sub.add_parser("dns-delete", help="Delete DNS record")
+    p.add_argument("zone_id")
+    p.add_argument("record_id")
+
+    # security
+    p = sub.add_parser("security", help="Get security IP group info")
+    p.add_argument("zone_id")
+
+    # waf
+    p = sub.add_parser("waf", help="Get zone security/WAF settings")
+    p.add_argument("zone_id")
+
+    args = parser.parse_args()
+
+    commands = {
+        "zones": cmd_zones,
+        "zone": cmd_zone,
+        "domains": cmd_domains,
+        "purge": cmd_purge,
+        "prefetch": cmd_prefetch,
+        "purge-tasks": cmd_purge_tasks,
+        "prefetch-tasks": cmd_prefetch_tasks,
+        "dns": cmd_dns,
+        "dns-create": cmd_dns_create,
+        "dns-delete": cmd_dns_delete,
+        "security": cmd_security,
+        "waf": cmd_waf,
+    }
+
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tencentcloud-tke/SKILL.md
+++ b/skills/tencentcloud-tke/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: tencentcloud-tke
+description: |
+  Manage Tencent Cloud TKE (Tencent Kubernetes Engine) clusters and
+  workloads. Use when the user asks to: list clusters, check cluster /
+  node health, list pods or services, scale a Deployment, do a rolling
+  restart, fetch kubeconfig, view recent K8s events, manage node pools.
+  Combines the official tencentcloud-sdk-python TKE client (cluster
+  metadata) with kubectl for in-cluster operations.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [tencentcloud]
+---
+
+# Tencent Cloud TKE (Kubernetes)
+
+Manage TKE clusters and the workloads inside them.
+
+> **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). Cluster discovery and kubeconfig retrieval go through the SDK; everything inside the cluster (pods, services, scale, restart) goes through `kubectl` against the kubeconfig we fetch.
+
+## When to Use
+
+- List TKE clusters across regions
+- Check node health and node-pool resource usage
+- List Deployments / StatefulSets / DaemonSets in a namespace
+- List Services / Pods / recent Events
+- Scale a workload up or down
+- Rolling restart a Deployment (e.g. after a config change)
+- Fetch kubeconfig for ad-hoc `kubectl` work
+
+## Dependencies
+
+```bash
+pip install tencentcloud-sdk-python
+brew install kubectl   # macOS;  apt install kubectl on Debian/Ubuntu
+```
+
+## Quick start — list clusters
+
+```python
+import os
+from tencentcloud.common import credential
+from tencentcloud.tke.v20180525 import tke_client, models
+
+cred = credential.EnvironmentVariableCredential().get_credential()
+client = tke_client.TkeClient(cred, os.environ["TENCENTCLOUD_REGION"])
+
+req = models.DescribeClustersRequest()
+req.Limit = 100
+resp = client.DescribeClusters(req)
+for c in resp.Clusters:
+    print(c.ClusterId, c.ClusterName, c.ClusterStatus, c.ClusterVersion)
+```
+
+> Cluster IDs look like `cls-xxxxxxxx`. The `ap-hongkong` region typically holds the production clusters; `DescribeClusters` is region-scoped — call it per region you care about.
+
+## Workflows
+
+### Get cluster details + worker node count
+
+```python
+req = models.DescribeClustersRequest()
+req.ClusterIds = ["cls-xxxxxxxx"]
+resp = client.DescribeClusters(req)
+c = resp.Clusters[0]
+print(c.ClusterName, c.ClusterStatus, c.ClusterNodeNum, c.ClusterVersion)
+```
+
+### List worker nodes (and their CVM instance types)
+
+```python
+req = models.DescribeClusterInstancesRequest()
+req.ClusterId = "cls-xxxxxxxx"
+req.Limit = 100
+resp = client.DescribeClusterInstances(req)
+for i in resp.InstanceSet:
+    print(i.InstanceId, i.InstanceRole, i.InstanceState, i.NodePoolId)
+```
+
+### Fetch kubeconfig
+
+```python
+req = models.DescribeClusterKubeconfigRequest()
+req.ClusterId = "cls-xxxxxxxx"
+req.IsExtranet = True            # False for VPC-internal kubeconfig
+resp = client.DescribeClusterKubeconfig(req)
+
+# Save and use immediately
+import os, pathlib
+kubeconfig = pathlib.Path(os.path.expanduser("~/.kube/config-tke-cls-xxxxxxxx"))
+kubeconfig.parent.mkdir(parents=True, exist_ok=True)
+kubeconfig.write_text(resp.Kubeconfig)
+print("export KUBECONFIG=" + str(kubeconfig))
+```
+
+> Many TKE clusters expose only the **internal** API endpoint by default. If `IsExtranet=True` returns an empty / unusable config, the cluster's public API access isn't enabled — set `IsExtranet=False` and run `kubectl` from a host inside the same VPC (e.g. CVM, jump host).
+
+### Run kubectl commands (with the fetched kubeconfig)
+
+```python
+import subprocess
+
+KUBECONFIG = os.path.expanduser("~/.kube/config-tke-cls-xxxxxxxx")
+NS = "acedatacloud"
+
+def kubectl(*args):
+    return subprocess.run(
+        ["kubectl", f"--kubeconfig={KUBECONFIG}", *args],
+        check=True, capture_output=True, text=True,
+    ).stdout
+
+print(kubectl("get", "pods", "-n", NS))
+print(kubectl("get", "deploy", "-n", NS))
+print(kubectl("get", "svc", "-n", NS))
+print(kubectl("get", "events", "-n", NS, "--sort-by=.lastTimestamp"))
+```
+
+### Describe a misbehaving pod
+
+```python
+print(kubectl("describe", "pod", "<pod-name>", "-n", NS))
+print(kubectl("logs", "<pod-name>", "-n", NS, "--tail=200"))
+```
+
+### Scale a Deployment
+
+```python
+# To 4 replicas. Confirm with the user before running for prod workloads.
+print(kubectl("scale", "deploy/platform-backend", "-n", NS, "--replicas=4"))
+```
+
+### Rolling restart a Deployment
+
+```python
+# Forces every pod to recycle through the rolling-update strategy.
+print(kubectl("rollout", "restart", "deploy/platform-backend", "-n", NS))
+print(kubectl("rollout", "status", "deploy/platform-backend", "-n", NS, "--timeout=300s"))
+```
+
+### List node pools (TKE concept above raw nodes)
+
+```python
+req = models.DescribeClusterNodePoolsRequest()
+req.ClusterId = "cls-xxxxxxxx"
+resp = client.DescribeClusterNodePools(req)
+for np in resp.NodePoolSet:
+    print(np.NodePoolId, np.Name, np.LifeState, np.DesiredNodesNum, np.AutoscalingGroupId)
+```
+
+## Troubleshooting flow
+
+```
+1. python: DescribeClusters → cluster status / version
+2. python: DescribeClusterInstances → any nodes "failed" / "running"
+3. kubectl get events → recent failures (image pulls, scheduling, OOM)
+4. kubectl get pods → which pod is in CrashLoopBackOff / ImagePullBackOff
+5. kubectl describe pod <name> → conditions, events on the pod
+6. kubectl logs <name> --tail=200 → application logs
+7. (optional) tencentcloud-cls skill → CLS query for the same window
+```
+
+## Important reminders
+
+- **Confirm scale / restart actions** with the user before running for production workloads. A `replicas=0` typo takes the service down.
+- **Kubeconfigs contain a long-lived bearer token.** Treat the file like a credential — `chmod 600`, never commit, regenerate after offboarding people.
+- **Internal vs external endpoint:** `IsExtranet=False` gives a kubeconfig usable only from inside the cluster VPC. From a laptop, use `IsExtranet=True` and ensure the cluster has a public API endpoint enabled (TKE console → Cluster → Basic Info → API Server access).
+- **Region matters.** Cluster `cls-xxxxxxxx` in `ap-hongkong` is invisible from a TKE client constructed for `ap-guangzhou`.
+
+## Console links
+
+- TKE console: <https://console.cloud.tencent.com/tke2/cluster>
+- API reference: <https://www.tencentcloud.com/document/product/457/31862>

--- a/skills/tencentcloud-tke/SKILL.md
+++ b/skills/tencentcloud-tke/SKILL.md
@@ -20,6 +20,27 @@ Manage TKE clusters and the workloads inside them.
 
 > **Setup:** See [tencentcloud authentication](../_shared/tencentcloud.md). Cluster discovery and kubeconfig retrieval go through the SDK; everything inside the cluster (pods, services, scale, restart) goes through `kubectl` against the kubeconfig we fetch.
 
+## CLI (preferred)
+
+The skill ships [`scripts/tke.py`](scripts/tke.py) — wraps cluster discovery, kubeconfig retrieval, and the most common in-cluster operations.
+
+```bash
+TKE=$SKILL_DIR/scripts/tke.py
+
+python3 $TKE clusters                                              # list clusters
+python3 $TKE cluster cls-xxxxxxxx                                  # one cluster's details
+python3 $TKE nodes cls-xxxxxxxx
+python3 $TKE pools cls-xxxxxxxx                                    # node pools
+python3 $TKE kubeconfig cls-xxxxxxxx --save ~/.kube/config-tke     # write kubeconfig
+python3 $TKE workloads cls-xxxxxxxx -n my-namespace
+python3 $TKE pods cls-xxxxxxxx -n my-namespace
+python3 $TKE events cls-xxxxxxxx -n my-namespace                   # recent events
+python3 $TKE scale cls-xxxxxxxx -n my-namespace --name my-deploy --replicas 4
+python3 $TKE restart cls-xxxxxxxx -n my-namespace --name my-deploy
+```
+
+In-cluster commands shell out to `kubectl` against an SDK-fetched kubeconfig. `kubectl` must be installed in the sandbox (`pip install` doesn't ship it).
+
 ## When to Use
 
 - List TKE clusters across regions

--- a/skills/tencentcloud-tke/scripts/tke.py
+++ b/skills/tencentcloud-tke/scripts/tke.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Tencent Cloud TKE (Tencent Kubernetes Engine) Management Tool
+
+Manage TKE clusters, nodes, workloads, and services via Tencent Cloud API.
+
+Usage:
+  python3 $SKILL_DIR/scripts/tke.py clusters [--region REGION]
+  python3 $SKILL_DIR/scripts/tke.py cluster <cluster_id> [--region REGION]
+  python3 $SKILL_DIR/scripts/tke.py nodes <cluster_id> [--region REGION] [--pool POOL_ID]
+  python3 $SKILL_DIR/scripts/tke.py pools <cluster_id> [--region REGION]
+  python3 $SKILL_DIR/scripts/tke.py workloads <cluster_id> --namespace <ns> [--region REGION] [--kind Deployment|StatefulSet|DaemonSet]
+  python3 $SKILL_DIR/scripts/tke.py services <cluster_id> --namespace <ns> [--region REGION]
+  python3 $SKILL_DIR/scripts/tke.py pods <cluster_id> --namespace <ns> [--region REGION] [--name POD_NAME]
+  python3 $SKILL_DIR/scripts/tke.py events <cluster_id> --namespace <ns> [--region REGION]
+  python3 $SKILL_DIR/scripts/tke.py kubeconfig <cluster_id> [--region REGION] [--internal]
+  python3 $SKILL_DIR/scripts/tke.py scale <cluster_id> --namespace <ns> --name <name> --replicas <n> [--region REGION] [--kind Deployment]
+  python3 $SKILL_DIR/scripts/tke.py restart <cluster_id> --namespace <ns> --name <name> [--region REGION] [--kind Deployment]
+
+Environment:
+  Reads TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY from
+  sandbox env vars (TENCENTCLOUD_SECRET_ID / SECRET_KEY)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_REGION = os.environ.get("TENCENTCLOUD_REGION", "ap-hongkong")
+
+
+
+
+def get_client(region):
+    try:
+        from tencentcloud.common import credential
+        from tencentcloud.tke.v20180525 import tke_client
+    except ImportError:
+        print(
+            "ERROR: tencentcloud-sdk-python not installed.\n"
+            "Run: pip3 install tencentcloud-sdk-python",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    secret_id = os.environ.get("TENCENTCLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENTCLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print(
+            "ERROR: TENCENTCLOUD_SECRET_ID and TENCENTCLOUD_SECRET_KEY must be set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cred = credential.Credential(secret_id, secret_key)
+    return tke_client.TkeClient(cred, region)
+
+
+def pp(data):
+    """Pretty-print JSON data."""
+    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+
+
+def cmd_clusters(args):
+    """List all TKE clusters."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClustersRequest()
+    req.Limit = 100
+    resp = client.DescribeClusters(req)
+    data = json.loads(resp.to_json_string())
+
+    clusters = data.get("Clusters", [])
+    if not clusters:
+        print("No clusters found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(clusters))} cluster(s):\n")
+    for c in clusters:
+        status = c.get("ClusterStatus", "Unknown")
+        emoji = "●" if status == "Running" else "○"
+        print(f"  {emoji} {c.get('ClusterId', 'N/A'):20s} {c.get('ClusterName', 'N/A'):30s} "
+              f"v{c.get('ClusterVersion', '?'):10s} {status:12s} "
+              f"Nodes: {c.get('ClusterNodeNum', 0)}")
+
+
+def cmd_cluster(args):
+    """Get cluster details."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClustersRequest()
+    req.ClusterIds = [args.cluster_id]
+    resp = client.DescribeClusters(req)
+    data = json.loads(resp.to_json_string())
+
+    clusters = data.get("Clusters", [])
+    if not clusters:
+        print(f"Cluster {args.cluster_id} not found.")
+        return
+
+    pp(clusters[0])
+
+
+def cmd_nodes(args):
+    """List cluster nodes (instances)."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClusterInstancesRequest()
+    req.ClusterId = args.cluster_id
+    req.Limit = 100
+    if args.pool:
+        req.Filters = [{"Name": "nodepool-id", "Values": [args.pool]}]
+    resp = client.DescribeClusterInstances(req)
+    data = json.loads(resp.to_json_string())
+
+    instances = data.get("InstanceSet", [])
+    if not instances:
+        print("No nodes found.")
+        return
+
+    print(f"Found {data.get('TotalCount', len(instances))} node(s):\n")
+    for n in instances:
+        state = n.get("InstanceState", "Unknown")
+        emoji = "●" if state == "running" else "○"
+        print(f"  {emoji} {n.get('InstanceId', 'N/A'):22s} {n.get('InstanceRole', 'N/A'):10s} "
+              f"{n.get('LanIP', 'N/A'):16s} {state:12s} "
+              f"CPU: {n.get('CPU', '?')}  Mem: {n.get('Memory', '?')}GB")
+
+
+def cmd_pools(args):
+    """List cluster node pools."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClusterNodePoolsRequest()
+    req.ClusterId = args.cluster_id
+    resp = client.DescribeClusterNodePools(req)
+    data = json.loads(resp.to_json_string())
+
+    pools = data.get("NodePoolSet", [])
+    if not pools:
+        print("No node pools found.")
+        return
+
+    print(f"Found {len(pools)} node pool(s):\n")
+    for p in pools:
+        status = p.get("LifeState", "Unknown")
+        print(f"  {p.get('NodePoolId', 'N/A'):30s} {p.get('Name', 'N/A'):30s} "
+              f"Nodes: {p.get('NodeCountSummary', {}).get('ManuallyAdded', {}).get('Total', '?')}  "
+              f"Status: {status}")
+
+
+def cmd_kubeconfig(args):
+    """Get cluster kubeconfig."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClusterKubeconfigRequest()
+    req.ClusterId = args.cluster_id
+    req.IsExtranet = not args.internal
+    resp = client.DescribeClusterKubeconfig(req)
+    data = json.loads(resp.to_json_string())
+
+    kubeconfig = data.get("Kubeconfig", "")
+    if not kubeconfig:
+        print("ERROR: Could not retrieve kubeconfig. Ensure cluster endpoint is enabled.")
+        return
+
+    if args.save:
+        path = Path(args.save).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(kubeconfig)
+        print(f"Kubeconfig saved to: {path}")
+    else:
+        print(kubeconfig)
+
+
+def _get_kubeconfig_path(args):
+    """Helper to get a temporary kubeconfig for kubectl commands."""
+    from tencentcloud.tke.v20180525 import models
+
+    client = get_client(args.region)
+    req = models.DescribeClusterKubeconfigRequest()
+    req.ClusterId = args.cluster_id
+    req.IsExtranet = True
+    resp = client.DescribeClusterKubeconfig(req)
+    data = json.loads(resp.to_json_string())
+
+    kubeconfig = data.get("Kubeconfig", "")
+    if not kubeconfig:
+        print("ERROR: Could not retrieve kubeconfig.", file=sys.stderr)
+        sys.exit(1)
+
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    tmp.write(kubeconfig)
+    tmp.close()
+    return tmp.name
+
+
+def _run_kubectl(kubeconfig_path, *kubectl_args):
+    """Run kubectl with the given kubeconfig."""
+    cmd = ["kubectl", f"--kubeconfig={kubeconfig_path}"] + list(kubectl_args)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            print(f"kubectl error: {result.stderr}", file=sys.stderr)
+            return None
+        return result.stdout
+    except FileNotFoundError:
+        print("ERROR: kubectl not found. Install it first.", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print("ERROR: kubectl command timed out.", file=sys.stderr)
+        return None
+
+
+def cmd_workloads(args):
+    """List workloads in a namespace (via kubectl)."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        kind = args.kind or "Deployment"
+        output = _run_kubectl(kc, "get", kind.lower(), "-n", args.namespace, "-o", "wide")
+        if output:
+            print(f"=== {kind}s in namespace '{args.namespace}' ===\n")
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def cmd_services(args):
+    """List services in a namespace (via kubectl)."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        output = _run_kubectl(kc, "get", "svc", "-n", args.namespace, "-o", "wide")
+        if output:
+            print(f"=== Services in namespace '{args.namespace}' ===\n")
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def cmd_pods(args):
+    """List or describe pods in a namespace (via kubectl)."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        if args.name:
+            output = _run_kubectl(kc, "describe", "pod", args.name, "-n", args.namespace)
+        else:
+            output = _run_kubectl(kc, "get", "pods", "-n", args.namespace, "-o", "wide")
+        if output:
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def cmd_events(args):
+    """Get recent events in a namespace (via kubectl)."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        output = _run_kubectl(kc, "get", "events", "-n", args.namespace,
+                              "--sort-by=.lastTimestamp", "-o", "wide")
+        if output:
+            print(f"=== Events in namespace '{args.namespace}' ===\n")
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def cmd_scale(args):
+    """Scale a workload."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        kind = args.kind or "deployment"
+        output = _run_kubectl(kc, "scale", f"{kind}/{args.name}",
+                              f"--replicas={args.replicas}", "-n", args.namespace)
+        if output:
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def cmd_restart(args):
+    """Restart a workload (rollout restart)."""
+    kc = _get_kubeconfig_path(args)
+    try:
+        kind = args.kind or "deployment"
+        output = _run_kubectl(kc, "rollout", "restart", f"{kind}/{args.name}",
+                              "-n", args.namespace)
+        if output:
+            print(output)
+    finally:
+        os.unlink(kc)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Tencent Cloud TKE Management Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--region", "-r", default=DEFAULT_REGION, help=f"Region (default: {DEFAULT_REGION})")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # clusters
+    sub.add_parser("clusters", help="List all clusters")
+
+    # cluster
+    p = sub.add_parser("cluster", help="Get cluster details")
+    p.add_argument("cluster_id", help="Cluster ID (e.g. cls-xxxxxxxx)")
+
+    # nodes
+    p = sub.add_parser("nodes", help="List cluster nodes")
+    p.add_argument("cluster_id")
+    p.add_argument("--pool", help="Filter by node pool ID")
+
+    # pools
+    p = sub.add_parser("pools", help="List node pools")
+    p.add_argument("cluster_id")
+
+    # kubeconfig
+    p = sub.add_parser("kubeconfig", help="Get cluster kubeconfig")
+    p.add_argument("cluster_id")
+    p.add_argument("--internal", action="store_true", help="Use internal endpoint")
+    p.add_argument("--save", help="Save to file path (e.g. ~/.kube/config-tke)")
+
+    # workloads (kubectl)
+    p = sub.add_parser("workloads", help="List workloads (Deployment/StatefulSet/DaemonSet)")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True, help="Kubernetes namespace")
+    p.add_argument("--kind", "-k", default="Deployment", help="Workload kind (default: Deployment)")
+
+    # services (kubectl)
+    p = sub.add_parser("services", help="List services in namespace")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True, help="Kubernetes namespace")
+
+    # pods (kubectl)
+    p = sub.add_parser("pods", help="List or describe pods")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True, help="Kubernetes namespace")
+    p.add_argument("--name", help="Pod name to describe")
+
+    # events (kubectl)
+    p = sub.add_parser("events", help="Get recent events")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True, help="Kubernetes namespace")
+
+    # scale
+    p = sub.add_parser("scale", help="Scale a workload")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True)
+    p.add_argument("--name", required=True, help="Workload name")
+    p.add_argument("--replicas", required=True, type=int, help="Target replica count")
+    p.add_argument("--kind", default="deployment", help="Workload kind (default: deployment)")
+
+    # restart
+    p = sub.add_parser("restart", help="Restart a workload (rollout restart)")
+    p.add_argument("cluster_id")
+    p.add_argument("--namespace", "-n", required=True)
+    p.add_argument("--name", required=True, help="Workload name")
+    p.add_argument("--kind", default="deployment", help="Workload kind (default: deployment)")
+
+    args = parser.parse_args()
+
+    commands = {
+        "clusters": cmd_clusters,
+        "cluster": cmd_cluster,
+        "nodes": cmd_nodes,
+        "pools": cmd_pools,
+        "kubeconfig": cmd_kubeconfig,
+        "workloads": cmd_workloads,
+        "services": cmd_services,
+        "pods": cmd_pods,
+        "events": cmd_events,
+        "scale": cmd_scale,
+        "restart": cmd_restart,
+    }
+
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Second half of the connector + many-skills design from [AuthBackend #102](https://github.com/AceDataCloud/AuthBackend/pull/102) / [#104](https://github.com/AceDataCloud/AuthBackend/pull/104) / [AuthFrontend #87](https://github.com/AceDataCloud/AuthFrontend/pull/87). Adds the actual Tencent Cloud skills users will install once those land.

The architecture reminder:

```
tencentcloud/tencentcloud  ← one connector, holds SecretId/SecretKey  (AuthBackend #104)
       ↓ shared via `connections: [tencentcloud]` frontmatter
acedata/tencentcloud-cos        ┐
acedata/tencentcloud-cls        │
acedata/tencentcloud-cls-alarm  │  6 skills, loose coupling
acedata/tencentcloud-tke        │  user installs only the ones they need
acedata/tencentcloud-dns        │
acedata/tencentcloud-edgeone    ┘
```

A user can install only `tencentcloud-cos` and skip the other 5; or install all 6; or install zero (just the connector) and ad-hoc query Tencent APIs through chat.

## What

6 SKILL.md files under [`skills/tencentcloud-*/`](skills/) plus one shared auth doc:

| Skill | Scope | Major workflows covered |
|---|---|---|
| [`tencentcloud-cos`](skills/tencentcloud-cos/SKILL.md) | Object storage | list buckets / objects, upload, download, pre-signed URL, batch delete with prefix, du, cp |
| [`tencentcloud-cls`](skills/tencentcloud-cls/SKILL.md) | Log search | CQL filtering, SQL analytics (`SELECT ... GROUP BY`), trace-id lookup across topics, pagination via `Context`, tail-style polling |
| [`tencentcloud-cls-alarm`](skills/tencentcloud-cls-alarm/SKILL.md) | Alarms | CRUD on alarm policies / notice groups / shields, `Enable` vs `Status` callout, alarm firing history (`GetAlarmLog`), clone-from-existing |
| [`tencentcloud-tke`](skills/tencentcloud-tke/SKILL.md) | Kubernetes | cluster / node / node-pool inspection via SDK; pod / event / scale / restart via `kubectl` against an SDK-fetched kubeconfig |
| [`tencentcloud-dns`](skills/tencentcloud-dns/SKILL.md) | DNSPod | A / AAAA / CNAME / MX / TXT / NS / SRV / CAA records; CNAME-apex restriction; v3 API only (no `DP_Id`/`DP_Key`) |
| [`tencentcloud-edgeone`](skills/tencentcloud-edgeone/SKILL.md) | CDN + edge | purge by URL / prefix / host / all, prefetch, task-status polling, EdgeOne DNS records |
| [`_shared/tencentcloud.md`](skills/_shared/tencentcloud.md) | Auth doc | SecretId / SecretKey / region setup, sub-account hardening, region cheatsheet, `.env` vs sandboxed env-var injection, sanity-check snippet |

## Style

Anthropic-style — markdown docs with Python code examples the agent reads and adapts to construct calls at runtime. **No bundled scripts.** Rationale:

- Keeps each skill ~200 LoC of markdown rather than ~500 LoC of Python.
- No re-shipping of SDK boilerplate (the official `tencentcloud-sdk-python` is the dependency).
- Agent can adapt examples to the user's specific phrasing instead of being constrained to a CLI's flag surface.
- Mirrors how upstream `anthropics/skills/skills/{pdf,xlsx,pptx,docx}` are written.

## Credentials convention

Every skill assumes the official Tencent Cloud SDK env-var names (so `EnvironmentVariableCredential().get_credential()` Just Works):

| Var | Source |
|---|---|
| `TENCENTCLOUD_SECRET_ID` | injected by AuthBackend agent runtime from the user's encrypted `Connection` (PR 6 of the series), or set manually via `.env` for local dev |
| `TENCENTCLOUD_SECRET_KEY` | same |
| `TENCENTCLOUD_REGION` | optional default; per-call overrides allowed |

Sub-account hardening guidance is in [`_shared/tencentcloud.md`](skills/_shared/tencentcloud.md) — we explicitly recommend creating a CAM sub-user with only the needed policies (e.g. `QcloudCOSReadOnlyAccess`).

## Verification

```python
$ python /tmp/check_skills.py
skills/tencentcloud-cls-alarm/SKILL.md: name='tencentcloud-cls-alarm' ok_name=True ok_desc=True conns=['tencentcloud']
skills/tencentcloud-cls/SKILL.md:       name='tencentcloud-cls'       ok_name=True ok_desc=True conns=['tencentcloud']
skills/tencentcloud-cos/SKILL.md:       name='tencentcloud-cos'       ok_name=True ok_desc=True conns=['tencentcloud']
skills/tencentcloud-dns/SKILL.md:       name='tencentcloud-dns'       ok_name=True ok_desc=True conns=['tencentcloud']
skills/tencentcloud-edgeone/SKILL.md:   name='tencentcloud-edgeone'   ok_name=True ok_desc=True conns=['tencentcloud']
skills/tencentcloud-tke/SKILL.md:       name='tencentcloud-tke'       ok_name=True ok_desc=True conns=['tencentcloud']
```

All 6 pass AuthBackend's `parse_skill_content` validation (`SLUG_RE`, non-empty `description`, `connections` known via the lenient catalog-import path that downgrades unknown providers to a logged warning).

## Rollout

This PR can ship independently of AuthBackend changes:

- **Until [PR 5](#) (Skills-repo catalog source registration)** lands and deploys, these skills aren't visible at https://auth.acedata.cloud/user/skills — they're just sitting in the repo.
- Once PR 5 + a `sync_skill_catalog` Job run kick over, the 6 skills appear in the Browse Skills dialog with publisher = **AceDataCloud**.

## Followups

- **AuthBackend PR 5** — register `AceDataCloud/Skills` as a `DEFAULT_SOURCES` entry in [`app/services/skill_catalog.py`](https://github.com/AceDataCloud/AuthBackend/blob/main/app/services/skill_catalog.py).
- **AuthBackend PR 6** — agent-runtime credential injection: `GET /connections/by-skill/<id>/credentials` returns the decrypted SecretId/SecretKey JIT for the sandbox to set as env vars.
- **PR 7** — `Docs/zh-CN/development_connector_byoc.md` documenting the connector + skills user flow end to end.
