### PR TITLE
ci: auto-trigger AuthBackend skill catalog sync on merge to main

### DIFF
--- a/.github/workflows/sync-catalog.yml
+++ b/.github/workflows/sync-catalog.yml
@@ -1,0 +1,54 @@
+name: Sync Skill Catalog
+
+# After a merge to main, immediately trigger the AuthBackend
+# `skill-catalog-sync` CronJob so the freshly merged skills appear at
+# https://auth.acedata.cloud/user/skills without waiting up to 6h for
+# the next scheduled run.
+#
+# This mirrors the post-deploy `kubectl create job --from=cronjob/...`
+# step in AuthBackend/deploy/run.sh, but is triggered by Skills repo
+# changes rather than AuthBackend image rebuilds.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".claude-plugin/marketplace.json"
+  workflow_dispatch:
+
+concurrency:
+  group: sync-catalog
+  cancel-in-progress: false
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v5
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Trigger skill-catalog-sync Job
+        run: |
+          set -euo pipefail
+          JOB_NAME="skill-catalog-sync-skills-${GITHUB_RUN_ID}"
+          echo "Creating Job $JOB_NAME from cronjob/auth-backend-skill-catalog-sync"
+          kubectl -n acedatacloud create job \
+            "$JOB_NAME" \
+            --from=cronjob/auth-backend-skill-catalog-sync
+
+          echo "Waiting for Job to complete (up to 8 minutes)…"
+          kubectl -n acedatacloud wait \
+            --for=condition=complete \
+            --timeout=8m \
+            "job/$JOB_NAME" || {
+              echo "::warning::Job did not complete within 8 minutes; logs follow"
+              kubectl -n acedatacloud logs "job/$JOB_NAME" --tail=200 || true
+              exit 1
+            }
+
+          echo "✓ Job completed. Last log lines:"
+          kubectl -n acedatacloud logs "job/$JOB_NAME" --tail=50 || true


### PR DESCRIPTION
## Why

Today, when a skill is merged into [`AceDataCloud/Skills`](https://github.com/AceDataCloud/Skills), it doesn't appear at https://auth.acedata.cloud/user/skills until the AuthBackend CronJob runs again — schedule is `15 */6 * * *`, so worst case ~6h latency.

We already have a way to trigger the same sync immediately: [`AuthBackend/deploy/run.sh`](https://github.com/AceDataCloud/AuthBackend/blob/main/deploy/run.sh#L21-L29) does this on every AuthBackend deploy:

```sh
kubectl -n acedatacloud create job \
  "skill-catalog-sync-deploy-${BUILD_NUMBER}" \
  --from=cronjob/auth-backend-skill-catalog-sync
```

…but that path only fires when AuthBackend itself ships. A pure Skills-side merge has no AuthBackend rebuild, so the catalog stays stale.

## What

Add [`.github/workflows/sync-catalog.yml`](.github/workflows/sync-catalog.yml). On `push` to `main` touching `skills/**` or `.claude-plugin/marketplace.json`, it:

1. Loads the org-level `KUBE_CONFIG` secret (same one every other AceDataCloud repo uses for kubectl).
2. Creates a one-shot Job from `cronjob/auth-backend-skill-catalog-sync` named `skill-catalog-sync-skills-<run_id>` (suffix prevents collisions with the AuthBackend deploy path's `-deploy-<build>` jobs).
3. Waits up to 8 minutes for `condition=complete` and tails the last 50 log lines on success, or the last 200 on timeout (then fails the workflow so the merger sees a red ❌).

`concurrency: sync-catalog` with `cancel-in-progress: false` queues parallel merges instead of cancelling them — each merge's content should land in the catalog.

`workflow_dispatch` is also enabled so we can manually re-trigger from the Actions tab.

### Path filter rationale

| Path | Trigger? | Why |
|---|---|---|
| `skills/**` | ✅ | The actual catalog content `sync_skill_catalog` reads |
| `.claude-plugin/marketplace.json` | ✅ | Manifest changes affect what's installable |
| `.github/**`, `README.md`, `template/`, `bin/`, `.npmignore`, etc. | ❌ | No catalog impact |

### Why a Job (not a direct `python manage.py …`)

Reusing the CronJob template means the Job inherits all the env / secret / image-tag / RBAC config from [`AuthBackend/deploy/production/skill-catalog-sync-cronjob.yaml`](https://github.com/AceDataCloud/AuthBackend/blob/main/deploy/production/skill-catalog-sync-cronjob.yaml) — so the trigger never drifts from the scheduled run's behaviour, and any future change to that CronJob (image, env, args) automatically applies here too.

## Verification

- `actionlint`-equivalent shape (matches the format in every other repo's `deploy.yaml`).
- After merge, the next `skills/**` push should produce a green Actions run, and a fresh `skill-catalog-sync-skills-*` Job in `kubectl -n acedatacloud get jobs` followed by the new skill being visible in https://auth.acedata.cloud/user/skills's Browse Skills dialog without further action.

## Out of scope

The connector-catalog sync at `cronjob/auth-backend-connector-catalog-sync` is a sibling pattern but driven by the AuthBackend `app/seeds/connectors*.yaml` files, not by this repo. No trigger needed here.
