### PR TITLE
feat(connectors): 11 connector skills + read+write recipes for the four google-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Compatible with **30+ AI coding agents** via the [agentskills.io](https://agentskills.io/) open standard: Claude Code, GitHub Copilot, Gemini CLI, OpenAI Codex, Cursor, Roo Code, Goose, and more.
 
-## Available Skills (19)
+## Available Skills (30)
 
 ### AI Music & Audio
 
@@ -51,6 +51,24 @@ Compatible with **30+ AI coding agents** via the [agentskills.io](https://agents
 | [face-transform](skills/face-transform/) | Face analysis, beautification, age/gender transform, swap, cartoon |
 | [short-url](skills/short-url/) | Create and manage short URLs |
 | [acedatacloud-api](skills/acedatacloud-api/) | API usage guide — authentication, SDKs, error handling |
+
+### Connectors
+
+These skills drive third-party connectors users wire up at [auth.acedata.cloud/user/connections](https://auth.acedata.cloud/user/connections). Each declares the OAuth / BYOC connection it needs in `connections:` frontmatter; the [aichat2](https://chat.acedata.cloud) runtime injects the matching access token into the sandbox before the skill's `Bash` calls run.
+
+| Skill | Description | Connection |
+|-------|-------------|------------|
+| [github](skills/github/) | GitHub issues, pull requests, repos, code search, and Actions via `gh` CLI | `github` |
+| [gitlab](skills/gitlab/) | GitLab issues, MRs, projects, pipelines via the `glab` CLI | `gitlab` |
+| [google-drive](skills/google-drive/) | List, search, and read Google Drive files via the Drive v3 REST API | `google/drive` |
+| [google-gmail](skills/google-gmail/) | Read, search, and triage Gmail messages via the Gmail v1 REST API | `google/gmail` |
+| [google-calendar](skills/google-calendar/) | Read calendar events, agenda, and free-busy windows via Calendar v3 | `google/calendar` |
+| [google-tasks](skills/google-tasks/) | List and inspect Google Tasks via the Tasks v1 REST API | `google/tasks` |
+| [microsoft-onedrive](skills/microsoft-onedrive/) | List and read OneDrive files via the Microsoft Graph API | `microsoft/onedrive` |
+| [microsoft-outlook](skills/microsoft-outlook/) | Read Outlook mail, calendar events, and contacts via Microsoft Graph | `microsoft/outlook` |
+| [notion](skills/notion/) | Read and search Notion pages, databases, and blocks | `notion` |
+| [slack](skills/slack/) | Read Slack channels, messages, and user info via Web API | `slack` |
+| [wechat-official-account](skills/wechat-official-account/) | Manage WeChat MP — drafts, publishing, materials, user tags | `wechat` (BYOC) |
 
 ## Prerequisites
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: github
+description: GitHub issues, pull requests, repos, code search, and Actions via the gh CLI. Use when the user mentions GitHub, an issue/PR number, a repo, a commit, or code review.
+when_to_use: |
+  Trigger when the user wants to read or write something on GitHub —
+  list / view / create / comment on issues or PRs, search code, view
+  a repo, view CI runs, etc.
+connections: [github]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Use the `gh` CLI for everything. The user's OAuth access token is exported
+as `$GH_TOKEN`; `gh` reads it automatically — `gh auth status` will say
+"not logged in" because gh keeps no config file in the sandbox, but every
+authenticated subcommand works regardless.
+
+`gh --help` and `gh <subcommand> --help` are always current. When unsure,
+read the help first instead of guessing flags.
+
+## Two ways to call gh — prefer subcommands
+
+### Style A: First-class subcommands — START HERE
+
+`gh issue`, `gh pr`, `gh repo`, `gh search`, `gh release`, `gh workflow`,
+`gh run`, `gh status`, `gh project`, `gh label`, `gh secret`,
+`gh variable`, `gh gist`. Use these whenever they cover the task; they
+output formatted text by default and structured JSON via
+`--json <fields> [--jq <expr>]`.
+
+### Style B: Raw REST / GraphQL via `gh api`
+
+`gh api <endpoint>` for REST, `gh api graphql -f query='…'` for GraphQL.
+Useful when no first-class subcommand exists. Notable flags:
+
+- `-X POST|PATCH|PUT|DELETE` — override method (default `GET`, becomes
+  `POST` automatically when `-f`/`-F` is set).
+- `-f key=value` — string field; `-F key=value` — JSON-typed field
+  (`true`/`123`/`@file.json`); both URL-encode for `GET` and JSON-encode
+  for body methods.
+- `-q '<jq>'` — same as `--jq`. With a primitive top-level value (string
+  / number) it prints the raw value (no quotes).
+- `-H 'Accept: application/vnd.github.raw'` — fetch a file's raw bytes
+  instead of the JSON wrapper.
+- `--paginate` — auto-walk `Link: rel="next"`.
+
+## Recipes
+
+### Triage what's on my plate (issues + PRs + reviews + mentions)
+
+```sh
+gh status
+```
+
+### List recent issues in a repo
+
+```sh
+gh issue list --repo OWNER/REPO --limit 20
+gh issue list --repo OWNER/REPO --state all --limit 20 \
+  --json number,title,state,author,updatedAt,labels --jq '.[]'
+```
+
+### View an issue with comments
+
+```sh
+gh issue view 123 --repo OWNER/REPO --comments
+gh issue view 123 --repo OWNER/REPO --json title,body,comments \
+  --jq '{title, body, comments: [.comments[] | {author: .author.login, body, createdAt}]}'
+```
+
+### Create / comment / close an issue
+
+```sh
+gh issue create --repo OWNER/REPO --title "Bug: foo" --body "Repro steps…" --label bug
+gh issue comment 123 --repo OWNER/REPO --body "LGTM"
+gh issue close 123 --repo OWNER/REPO --comment "Fixed in #456"
+```
+
+### List PRs assigned to / authored by me
+
+```sh
+gh search prs --assignee=@me --state=open --json number,title,repository,updatedAt
+gh search prs --author=@me --state=open
+```
+
+### View a PR with diff and CI checks
+
+```sh
+gh pr view 456 --repo OWNER/REPO
+gh pr diff 456 --repo OWNER/REPO
+gh pr checks 456 --repo OWNER/REPO
+```
+
+### Comment / review / merge a PR
+
+```sh
+gh pr comment 456 --repo OWNER/REPO --body "Please rebase on main."
+gh pr review 456 --repo OWNER/REPO --approve --body "LGTM"
+gh pr review 456 --repo OWNER/REPO --request-changes --body "See nits"
+gh pr merge 456 --repo OWNER/REPO --squash --delete-branch
+```
+
+### Search code across GitHub
+
+```sh
+gh search code 'someFunction language:typescript' --limit 20 \
+  --json repository,path,url --jq '.[] | "\(.repository.nameWithOwner) \(.path)"'
+```
+
+### Read a file from a repo (raw bytes, no base64 dance)
+
+```sh
+gh api "repos/OWNER/REPO/contents/path/to/file.ts" \
+  -H 'Accept: application/vnd.github.raw'
+```
+
+### List recent commits on the default branch
+
+```sh
+gh api "repos/OWNER/REPO/commits?per_page=20" \
+  --jq '.[] | "\(.sha[0:7]) \(.commit.author.date) \(.commit.message | split("\n")[0])"'
+```
+
+### Trigger / inspect Actions workflows
+
+```sh
+gh workflow list --repo OWNER/REPO
+gh workflow run ci.yaml --repo OWNER/REPO --ref main -f key=value
+gh run list --repo OWNER/REPO --workflow ci.yaml --limit 5
+gh run view <RUN_ID> --repo OWNER/REPO --log-failed
+```
+
+### View a repo's metadata
+
+```sh
+gh repo view OWNER/REPO
+gh repo view OWNER/REPO --json description,url,stargazerCount,defaultBranchRef
+```
+
+### GraphQL for things REST can't do (e.g. project board items)
+
+```sh
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $num: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $num) {
+        title
+        timelineItems(first: 50) {
+          nodes { __typename ... on CrossReferencedEvent { source { ... on PullRequest { number title state } } } }
+        }
+      }
+    }
+  }' -f owner=OWNER -f repo=REPO -F num=123
+```
+
+## Notes
+
+- For private repos the user MUST have granted `repo` scope when they
+  authorized the connection at `auth.acedata.cloud/user/connections`.
+  A 404 on a repo you know exists usually means missing scope, not a
+  wrong URL.
+- When `--json` rejects a field name, gh prints the full list of valid
+  fields — re-read the error and pick from there.
+- `gh issue list --search` and `gh search issues` use the GitHub search
+  syntax (`is:open`, `assignee:@me`, `repo:owner/name`, etc.). Use
+  `gh search issues` / `gh search prs` for cross-repo queries; use
+  `gh issue list` for one repo.
+- `gh api --paginate` only works on endpoints that emit a `Link` header;
+  for cursor-paginated endpoints you have to follow `pagination.next`
+  yourself.

--- a/skills/gitlab/SKILL.md
+++ b/skills/gitlab/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: gitlab
+description: GitLab issues, merge requests, repositories, CI pipelines, and code search via the glab CLI. Use when the user mentions GitLab, an MR/issue number, a project on gitlab.com, or a self-hosted GitLab instance.
+when_to_use: |
+  Trigger when the user wants to read or write something on GitLab —
+  list / view / create / comment on issues or MRs, browse a project,
+  view CI pipelines, etc.
+connections: [gitlab]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Use the `glab` CLI for everything. The user's OAuth access token is
+exported as `$GITLAB_TOKEN`; `glab` reads it automatically (the token
+is also accepted via `GITLAB_ACCESS_TOKEN` and `OAUTH_TOKEN` for tooling
+compatibility). Default host is `gitlab.com` — for self-hosted set
+`GITLAB_HOST` or pass `--hostname <host>` per command.
+
+`glab --help` and `glab <subcommand> --help` are always current.
+
+## Two ways to call glab — prefer subcommands
+
+### Style A: First-class subcommands — START HERE
+
+`glab issue`, `glab mr`, `glab repo`, `glab ci`, `glab job`, `glab pipeline`,
+`glab release`, `glab snippet`, `glab variable`, `glab label`,
+`glab milestone`, `glab schedule`. These print formatted text by default
+and JSON via `--output json`.
+
+### Style B: Raw REST / GraphQL via `glab api`
+
+`glab api <path>` for REST, `glab api graphql -f query='…'` for GraphQL.
+Notable flags:
+
+- `-X POST|PATCH|PUT|DELETE` — override method (default `GET`, becomes
+  `POST` when `--field` / `--raw-field` is set).
+- `-f key=value` — magic-typed (literals `true` / `false` / `null` /
+  integers become JSON types, leading `@filename` reads from a file).
+- `-F key=value` — same as `-f` but always treats the value as a string.
+- `--paginate` — auto-walk `Link: rel="next"`.
+- `--hostname <host>` — target a different GitLab host than default.
+- Path placeholders: when run inside a git checkout, `:fullpath` /
+  `:branch` / `:user` are auto-populated from the repo. From a generic
+  shell, encode the path manually (see recipes).
+
+## Recipes
+
+### List open issues on a project
+
+```sh
+glab issue list --repo OWNER/PROJECT --opened --output json
+glab issue list --repo OWNER/PROJECT --assignee=@me --output json
+```
+
+### View an issue with comments
+
+```sh
+glab issue view 42 --repo OWNER/PROJECT --comments
+glab issue view 42 --repo OWNER/PROJECT --output json
+```
+
+### Create / comment / close an issue
+
+```sh
+glab issue create --repo OWNER/PROJECT --title "Bug: foo" --description "Repro steps…" --label bug
+glab issue note 42 --repo OWNER/PROJECT --message "Acknowledged."
+glab issue close 42 --repo OWNER/PROJECT
+```
+
+### List MRs assigned to / authored by me
+
+```sh
+glab mr list --repo OWNER/PROJECT --assignee=@me --opened --output json
+glab mr list --repo OWNER/PROJECT --author=@me --opened
+```
+
+### View an MR with diff and CI pipeline
+
+```sh
+glab mr view 99 --repo OWNER/PROJECT
+glab mr diff 99 --repo OWNER/PROJECT
+glab ci view --repo OWNER/PROJECT --branch <BRANCH>
+```
+
+### Approve / merge / leave a note on an MR
+
+```sh
+glab mr approve 99 --repo OWNER/PROJECT
+glab mr note 99 --repo OWNER/PROJECT --message "Looks good — ready when CI is green."
+glab mr merge 99 --repo OWNER/PROJECT --squash --remove-source-branch
+```
+
+### Read a file from the default branch (raw bytes)
+
+```sh
+# URL-encode the project path AND the file path because both contain '/'.
+PROJECT=$(printf '%s' 'OWNER/PROJECT' | jq -sRr @uri)
+FILE=$(printf '%s' 'src/main.go' | jq -sRr @uri)
+glab api "projects/${PROJECT}/repository/files/${FILE}/raw?ref=main"
+```
+
+### List the latest pipelines on a branch
+
+```sh
+glab ci list --repo OWNER/PROJECT --status running,success,failed
+glab ci view --repo OWNER/PROJECT --branch main
+glab ci trace --repo OWNER/PROJECT <JOB_ID>     # stream a job log
+```
+
+### Search across a group's issues
+
+```sh
+glab api "groups/GROUP_PATH_OR_ID/issues?state=opened&search=keyword" \
+  --paginate \
+  | jq '.[] | {iid, title, project: .references.full, web_url}'
+```
+
+### GraphQL example: project metadata + open MR count
+
+```sh
+glab api graphql -f query='
+  query($path: ID!) {
+    project(fullPath: $path) {
+      name webUrl
+      mergeRequests(state: opened) { count }
+    }
+  }' -f path=OWNER/PROJECT
+```
+
+## Notes
+
+- `--repo OWNER/PROJECT` accepts `OWNER/PROJECT`, `GROUP/SUBGROUP/PROJECT`,
+  full HTTPS URL, or git URL. The project path goes verbatim (no URL
+  encoding) for `--repo`, but does need `jq @uri` encoding when used
+  inside a `glab api` path.
+- For self-hosted GitLab the user must have authorized the connection
+  with the right `host`. A 404 on a project you know exists usually
+  means the connection is pointing at gitlab.com when the project lives
+  elsewhere — surface that hint to the user.
+- Many `glab` commands have an `--output` flag that takes `text` (default)
+  or `json`. `glab issue list` and `glab mr list` additionally have
+  `--output-format` (`details` / `ids` / `urls`) which is a separate,
+  list-only formatter. Pass the long flag `--output json` to avoid the
+  short-flag confusion (`-O` vs `-F`).

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -1,37 +1,47 @@
 ---
 name: google-calendar
-description: Read Google Calendar events / agenda / free-busy / invitations via the Calendar v3 REST API. Use when the user mentions Google Calendar events, today's agenda, this week's meetings, finding conflicts, listing invitations, or checking free time on a specific calendar.
+description: Read and manage Google Calendar events / agenda / free-busy / invitations via the Calendar v3 REST API. Use when the user mentions Google Calendar events, today's agenda, this week's meetings, finding conflicts, listing invitations, checking free time, or scheduling / rescheduling / cancelling a meeting.
 when_to_use: |
-  Trigger when the user wants to read events from their Google
-  Calendar — list / search / inspect events, build today's or this
-  week's agenda, check free / busy windows, or pull invite details
-  for a specific meeting. The installed connector grants read-only
-  scope (`calendar.readonly`); creating / updating / cancelling
-  events is out of scope.
+  Trigger when the user wants to read or manage events on their
+  Google Calendar — list / search / inspect events, build today's
+  or this week's agenda, check free / busy windows, pull invite
+  details, or have the AI create / update / cancel events on their
+  behalf and email invites to attendees. The installed connector
+  always grants `calendar.readonly`; the user opts in to the
+  broader `calendar` scope (full read + write) at install — confirm
+  before destructive writes.
 connections: [google/calendar]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 Drive Google Calendar via `curl + jq`. The user's OAuth bearer token
 is in `$GOOGLE_CALENDAR_TOKEN`; every call needs it as
-`Authorization: Bearer $GOOGLE_CALENDAR_TOKEN`. The token already
-carries the `calendar.readonly` scope the user agreed to at install
-plus the identity scopes (`openid email profile`).
+`Authorization: Bearer $GOOGLE_CALENDAR_TOKEN`. At minimum the token
+carries `calendar.readonly` plus the identity scopes
+(`openid email profile`); if the user opted in to write at install
+time it also carries the broader `calendar` scope (read + write).
 
 The Calendar API returns standard JSON; failures surface as
 `{"error": {"code": 401|403|..., "message": "..."}}` — show that
 error verbatim. `401` means the token expired (re-install). `403
-insufficientPermissions` means the user is asking for a write this
-connector cannot satisfy — say so.
+insufficientPermissions` on a write means the user only granted
+`calendar.readonly` — ask them to re-install the connector with the
+read+write box checked.
 
 **Always start with `users/me/calendarList`** to learn which calendars
 the account can see (the user's primary plus any subscribed / shared
 ones), AND with `users/me/settings/timezone` so you render times in
 the user's local zone instead of UTC.
+
+**Before any destructive write** (creating, moving, or cancelling an
+event that has attendees) show the exact event details and ask the
+user to confirm. When attendees are involved, also confirm whether
+they want Google to email the attendees — that's controlled by the
+`sendUpdates` query parameter.
 
 ## Recipes
 
@@ -182,14 +192,150 @@ while : ; do
 done
 ```
 
+## Write recipes
+
+These all need the broader `calendar` scope. If the user only granted
+`calendar.readonly` you'll get `403 insufficientPermissions` —
+surface that and ask them to re-install with the read+write box
+checked. **Always echo the event summary, time and attendee list
+back to the user before creating or cancelling anything.**
+
+### Create a single event (with optional attendees + Google Meet link)
+
+```sh
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+
+cat > /tmp/_cal_event.json <<JSON
+{
+  "summary": "Sync — Q2 OKR review",
+  "location": "Online",
+  "description": "Drafted by AceDataCloud.",
+  "start": {"dateTime": "2026-05-12T10:00:00", "timeZone": "$TZ"},
+  "end":   {"dateTime": "2026-05-12T10:30:00", "timeZone": "$TZ"},
+  "attendees": [
+    {"email": "alice@example.com"},
+    {"email": "bob@example.com"}
+  ],
+  "reminders": {"useDefault": true},
+  "conferenceData": {
+    "createRequest": {
+      "requestId": "meet-$(date +%s)",
+      "conferenceSolutionKey": {"type": "hangoutsMeet"}
+    }
+  }
+}
+JSON
+
+# sendUpdates: 'all' = email all attendees; 'externalOnly' = only non-org; 'none' = silent
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/_cal_event.json \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all" \
+  | jq '{id, htmlLink, hangoutLink, summary, start, end, attendees}'
+```
+
+Drop the `conferenceData` block if the user didn't ask for a Meet
+link — it'll fall back to a plain event.
+
+### Create a recurring event
+
+```sh
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+cat > /tmp/_cal_recur.json <<JSON
+{
+  "summary": "Weekly 1:1",
+  "start": {"dateTime": "2026-05-12T15:00:00", "timeZone": "$TZ"},
+  "end":   {"dateTime": "2026-05-12T15:30:00", "timeZone": "$TZ"},
+  "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TU;COUNT=12"]
+}
+JSON
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/_cal_recur.json \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+  | jq '{id, recurrence, summary}'
+```
+
+RRULE follows RFC 5545. Common patterns: `FREQ=DAILY`, `FREQ=WEEKLY;BYDAY=MO,WE,FR`,
+`FREQ=MONTHLY;BYMONTHDAY=15`. Add `UNTIL=20261231T235959Z` or `COUNT=12`
+for a hard stop.
+
+### Update an existing event (PATCH — partial update)
+
+```sh
+EVENT_ID='abc123def4567890ghijklmnop'
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"location":"Conference Room 4","description":"Now in-person."}' \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID?sendUpdates=all" \
+  | jq '{id, summary, location, description}'
+```
+
+`PATCH` only changes the fields you send; `PUT` replaces the entire
+event payload. Prefer `PATCH`.
+
+### Reschedule an event
+
+```sh
+EVENT_ID='abc123def4567890ghijklmnop'
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+cat > /tmp/_cal_resched.json <<JSON
+{
+  "start": {"dateTime": "2026-05-12T14:00:00", "timeZone": "$TZ"},
+  "end":   {"dateTime": "2026-05-12T14:30:00", "timeZone": "$TZ"}
+}
+JSON
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/_cal_resched.json \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID?sendUpdates=all" \
+  | jq '{id, summary, start, end}'
+```
+
+### Add or change attendees
+
+Google requires you to send the **complete** attendee list when
+patching attendees — fetch the current list, mutate, send back:
+
+```sh
+EVENT_ID='abc123def4567890ghijklmnop'
+CURRENT=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID?fields=attendees" \
+  | jq '.attendees // []')
+NEW=$(echo "$CURRENT" | jq '. + [{"email":"carol@example.com"}]')
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"attendees\": $NEW}" \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID?sendUpdates=all" \
+  | jq '{id, attendees}'
+```
+
+### Cancel / delete an event
+
+```sh
+EVENT_ID='abc123def4567890ghijklmnop'
+curl -sS -X DELETE -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID?sendUpdates=all" \
+  -o /dev/null -w 'HTTP %{http_code}\n'
+```
+
+`204` = success. To cancel one occurrence of a recurring event, fetch
+the instance with `events.instances` first, then `DELETE` the
+specific instance id (it has a longer `EVENT_ID_YYYYMMDDTHHMMSSZ`
+shape).
+
 ## Common error codes
 
 | HTTP | meaning | what to tell the user |
 |---|---|---|
 | `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Calendar connector on the Connections page." |
-| `403 insufficientPermissions` | scope missing | "This connector is read-only — creating or modifying events isn't possible." |
+| `403 insufficientPermissions` | write scope missing | "This action needs the Calendar read+write scope, but only `calendar.readonly` was granted. Re-install the connector with the read+write box checked." |
 | `403 forbidden` | calendar id not visible to this account | check `calendarList` first; if it's a shared calendar, the owner needs to share it. |
 | `404 notFound` | wrong event / calendar id | double-check the id and try `calendarList` to confirm the calendar exists. |
+| `409 conflict` | recurring event id collision | append a UUID to your `requestId` and retry. |
 | `429 quotaExceeded` | quota / throttling | back off ~5s, then retry once. |
 
 Never log or echo `$GOOGLE_CALENDAR_TOKEN` — treat it as a secret.

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: google-calendar
+description: Read Google Calendar events / agenda / free-busy / invitations via the Calendar v3 REST API. Use when the user mentions Google Calendar events, today's agenda, this week's meetings, finding conflicts, listing invitations, or checking free time on a specific calendar.
+when_to_use: |
+  Trigger when the user wants to read events from their Google
+  Calendar — list / search / inspect events, build today's or this
+  week's agenda, check free / busy windows, or pull invite details
+  for a specific meeting. The installed connector grants read-only
+  scope (`calendar.readonly`); creating / updating / cancelling
+  events is out of scope.
+connections: [google/calendar]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Google Calendar via `curl + jq`. The user's OAuth bearer token
+is in `$GOOGLE_CALENDAR_TOKEN`; every call needs it as
+`Authorization: Bearer $GOOGLE_CALENDAR_TOKEN`. The token already
+carries the `calendar.readonly` scope the user agreed to at install
+plus the identity scopes (`openid email profile`).
+
+The Calendar API returns standard JSON; failures surface as
+`{"error": {"code": 401|403|..., "message": "..."}}` — show that
+error verbatim. `401` means the token expired (re-install). `403
+insufficientPermissions` means the user is asking for a write this
+connector cannot satisfy — say so.
+
+**Always start with `users/me/calendarList`** to learn which calendars
+the account can see (the user's primary plus any subscribed / shared
+ones), AND with `users/me/settings/timezone` so you render times in
+the user's local zone instead of UTC.
+
+## Recipes
+
+### Verify auth + discover calendars (always run first)
+
+```sh
+# Account confirmation + calendars the user can read
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/calendarList" \
+  | jq '.items[] | {id, summary, primary, accessRole, timeZone}'
+
+# User's preferred display zone (use this when formatting times)
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" \
+  | jq -r .value
+```
+
+The `id` of each calendar (`primary`, or an email-shaped id like
+`team-monday@group.calendar.google.com`) is what subsequent
+`calendars/{id}/events` calls take.
+
+### Today's agenda on the primary calendar
+
+```sh
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+TODAY=$(TZ=$TZ date +%Y-%m-%d)
+START="${TODAY}T00:00:00Z"
+END="${TODAY}T23:59:59Z"
+
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  --get "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+  --data-urlencode "timeMin=$START" \
+  --data-urlencode "timeMax=$END" \
+  --data-urlencode 'singleEvents=true' \
+  --data-urlencode 'orderBy=startTime' \
+  --data-urlencode "timeZone=$TZ" \
+  | jq '.items[] | {summary, start: (.start.dateTime // .start.date), end: (.end.dateTime // .end.date), location, attendees: [.attendees[]?.email], hangout: .hangoutLink, status, htmlLink}'
+```
+
+`singleEvents=true` flattens recurring meetings into individual
+instances — almost always what you want for an agenda. Without it,
+you'd get the recurrence rule once and have to expand it client-side.
+
+### This week's meetings (Mon–Sun)
+
+```sh
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+# Bash date math: Monday-of-this-week
+MON=$(TZ=$TZ date -d "$(TZ=$TZ date +%Y-%m-%d) -$(($(TZ=$TZ date +%u) - 1)) days" +%Y-%m-%d 2>/dev/null \
+  || TZ=$TZ date -v-mondayw +%Y-%m-%d)  # macOS fallback
+SUN=$(TZ=$TZ date -d "$MON +6 days" +%Y-%m-%d 2>/dev/null \
+  || TZ=$TZ date -v+6d -j -f %Y-%m-%d "$MON" +%Y-%m-%d)
+
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  --get "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+  --data-urlencode "timeMin=${MON}T00:00:00Z" \
+  --data-urlencode "timeMax=${SUN}T23:59:59Z" \
+  --data-urlencode 'singleEvents=true' \
+  --data-urlencode 'orderBy=startTime' \
+  | jq -r '.items[] | "\(.start.dateTime // .start.date)\t\(.summary)\t\((.attendees // []) | length) attendees"'
+```
+
+### Search events by query
+
+```sh
+Q='quarterly review'
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  --get "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+  --data-urlencode "q=$Q" \
+  --data-urlencode 'singleEvents=true' \
+  --data-urlencode 'maxResults=20' \
+  | jq '.items[] | {start: .start.dateTime, summary, htmlLink}'
+```
+
+`q` matches against summary, description, location, attendee emails,
+and creator/organizer.
+
+### Get one event's full details (incl. attendees, location, link)
+
+```sh
+EVENT_ID='abc123def4567890ghijklmnop'
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/$EVENT_ID" \
+  | jq '{summary, start, end, location, description, attendees, organizer, hangoutLink, conferenceData}'
+```
+
+### Free / busy across multiple calendars (next 7 days)
+
+```sh
+TZ=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  "https://www.googleapis.com/calendar/v3/users/me/settings/timezone" | jq -r .value)
+NOW=$(TZ=$TZ date -u +%Y-%m-%dT%H:%M:%SZ)
+NEXT_WEEK=$(TZ=$TZ date -u -d "+7 days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || TZ=$TZ date -u -v+7d +%Y-%m-%dT%H:%M:%SZ)
+
+cat > /tmp/freebusy.json <<JSON
+{
+  "timeMin": "$NOW",
+  "timeMax": "$NEXT_WEEK",
+  "timeZone": "$TZ",
+  "items": [
+    {"id": "primary"},
+    {"id": "team-monday@group.calendar.google.com"}
+  ]
+}
+JSON
+
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/freebusy.json \
+  "https://www.googleapis.com/calendar/v3/freeBusy" \
+  | jq '.calendars'
+```
+
+Each calendar's response is `{"busy": [{"start": "...", "end": "..."}]}`
+— gaps between are free.
+
+### List events on a non-primary calendar
+
+```sh
+CAL_ID='team-monday@group.calendar.google.com'
+# URL-encode the @ in the path
+CAL_ENCODED=$(printf %s "$CAL_ID" | jq -sRr @uri)
+curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+  --get "https://www.googleapis.com/calendar/v3/calendars/$CAL_ENCODED/events" \
+  --data-urlencode 'singleEvents=true' \
+  --data-urlencode 'orderBy=startTime' \
+  --data-urlencode 'maxResults=20' \
+  | jq '.items[] | {start: .start.dateTime, summary}'
+```
+
+### Pagination
+
+```sh
+PAGE_TOKEN=''
+while : ; do
+  RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" \
+    --get "https://www.googleapis.com/calendar/v3/calendars/primary/events" \
+    --data-urlencode 'singleEvents=true' \
+    --data-urlencode 'orderBy=startTime' \
+    --data-urlencode 'maxResults=250' \
+    ${PAGE_TOKEN:+--data-urlencode "pageToken=$PAGE_TOKEN"})
+  echo "$RESP" | jq -c '.items[]?'
+  PAGE_TOKEN=$(echo "$RESP" | jq -r '.nextPageToken // empty')
+  [ -z "$PAGE_TOKEN" ] && break
+done
+```
+
+## Common error codes
+
+| HTTP | meaning | what to tell the user |
+|---|---|---|
+| `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Calendar connector on the Connections page." |
+| `403 insufficientPermissions` | scope missing | "This connector is read-only — creating or modifying events isn't possible." |
+| `403 forbidden` | calendar id not visible to this account | check `calendarList` first; if it's a shared calendar, the owner needs to share it. |
+| `404 notFound` | wrong event / calendar id | double-check the id and try `calendarList` to confirm the calendar exists. |
+| `429 quotaExceeded` | quota / throttling | back off ~5s, then retry once. |
+
+Never log or echo `$GOOGLE_CALENDAR_TOKEN` — treat it as a secret.

--- a/skills/google-drive/SKILL.md
+++ b/skills/google-drive/SKILL.md
@@ -1,32 +1,40 @@
 ---
 name: google-drive
-description: Read and search Google Drive files / folders / shared content via the Drive v3 REST API. Use when the user mentions Drive files, "my drive", shared documents, Google Docs / Sheets / Slides, exporting / downloading a Drive file, or searching by name / owner / folder.
+description: Read, search, upload, rename, move and delete Google Drive files / folders / shared content via the Drive v3 REST API. Use when the user mentions Drive files, "my drive", shared documents, Google Docs / Sheets / Slides, exporting / downloading a Drive file, searching by name / owner / folder, uploading a new file, renaming or moving files, or organising folders.
 when_to_use: |
-  Trigger when the user wants to list, search, read or download files
-  in their Google Drive — including Google-native docs (Docs / Sheets /
-  Slides) which need a special "export" call to get plain content. The
-  installed connector grants read-only scope (`drive.readonly`); writes
-  are out of scope.
+  Trigger when the user wants to list, search, read, download or
+  modify files in their Google Drive — including Google-native docs
+  (Docs / Sheets / Slides) which need a special "export" call to get
+  plain content, as well as uploads, renames, folder moves, and
+  trashing files. The installed connector always grants `drive.readonly`;
+  the user opts in to the broader `drive` scope (full read + write)
+  at install time — confirm before performing destructive writes.
 connections: [google/drive]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 Drive Google Drive via `curl + jq`. The user's OAuth bearer token is
 in `$GOOGLE_DRIVE_TOKEN`; every call needs it as
-`Authorization: Bearer $GOOGLE_DRIVE_TOKEN`. The token already carries
-the `drive.readonly` scope the user agreed to at install plus the
-identity scopes (`openid email profile`).
+`Authorization: Bearer $GOOGLE_DRIVE_TOKEN`. At minimum the token
+carries `drive.readonly` plus the identity scopes
+(`openid email profile`); if the user opted in to write at install
+time it also carries the broader `drive` scope (full read + write).
 
 The Drive API returns standard JSON; failures surface as
 `{"error": {"code": 401|403|..., "message": "..."}}` — show that
 error verbatim to the user. `401` means the token expired and the
 user must re-install the connector. `403 insufficientPermissions`
-means the connector grants only `drive.readonly` and the user is
-asking for a write — say so explicitly.
+on a write means the user did not grant the `drive` scope at install
+— ask them to re-install with the read+write box checked.
+
+**Before any destructive write** (renaming, moving, trashing, or
+bulk-mutating files) show the exact target list and ask the user to
+confirm. Never trash by guessing an id — always echo back the file
+name + path you're about to touch.
 
 **Always start with `/about?fields=user`** to confirm the connection
 works AND learn which Google account you're operating against.
@@ -188,14 +196,153 @@ while : ; do
 done
 ```
 
+## Write recipes
+
+These all need the broader `drive` scope. If the user only granted
+`drive.readonly` you'll get `403 insufficientPermissions` — surface
+that and suggest re-installing with the read+write box checked.
+**Always echo the target name + path back to the user before
+trashing or bulk-moving anything.**
+
+### Rename a file
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+NEW_NAME='2026 Q2 OKR (final).gdoc'
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"name\":$(jq -nr --arg n "$NEW_NAME" '$n')}" \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?fields=id,name"
+```
+
+### Move a file to a different folder
+
+Drive's folder model is parent-id based. Move = remove old parent,
+add new parent:
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+NEW_PARENT='1XYZnewFolderId'
+
+# Read existing parents (so we can pass them in removeParents)
+OLD_PARENTS=$(curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?fields=parents" \
+  | jq -r '.parents | join(",")')
+
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --data '' \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?addParents=$NEW_PARENT&removeParents=$OLD_PARENTS&fields=id,name,parents"
+```
+
+### Create a new folder
+
+```sh
+PARENT_ID='1XYZparentFolderId'  # or 'root' for My Drive root
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"name\":\"Reports / 2026Q2\",\"mimeType\":\"application/vnd.google-apps.folder\",\"parents\":[\"$PARENT_ID\"]}" \
+  "https://www.googleapis.com/drive/v3/files?fields=id,name,webViewLink" \
+  | jq
+```
+
+### Upload a file (multipart so metadata + bytes go in one request)
+
+```sh
+LOCAL=/tmp/report.pdf
+NAME='Q2 report.pdf'
+PARENT_ID='1XYZparentFolderId'
+MIME='application/pdf'
+
+BOUNDARY='aceDataBoundary'
+META=$(jq -nc --arg n "$NAME" --arg p "$PARENT_ID" '{name:$n, parents:[$p]}')
+{
+  printf -- '--%s\r\n' "$BOUNDARY"
+  printf 'Content-Type: application/json; charset=UTF-8\r\n\r\n'
+  printf '%s\r\n' "$META"
+  printf -- '--%s\r\n' "$BOUNDARY"
+  printf 'Content-Type: %s\r\n\r\n' "$MIME"
+  cat "$LOCAL"
+  printf '\r\n--%s--\r\n' "$BOUNDARY"
+} > /tmp/_drive_upload.bin
+
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H "Content-Type: multipart/related; boundary=$BOUNDARY" \
+  --data-binary @/tmp/_drive_upload.bin \
+  "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,webViewLink" \
+  | jq
+```
+
+For a **media-only** upload (no metadata) use `uploadType=media`; for
+files >5 MB use `uploadType=resumable` (covered in [Drive's docs]
+(https://developers.google.com/drive/api/guides/manage-uploads#resumable)).
+
+### Replace the contents of an existing file
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+LOCAL=/tmp/report-v2.pdf
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H 'Content-Type: application/pdf' \
+  --data-binary @"$LOCAL" \
+  "https://www.googleapis.com/upload/drive/v3/files/$FILE_ID?uploadType=media&fields=id,name,modifiedTime"
+```
+
+Metadata stays the same (id / parents / name) — only the bytes are
+replaced and Drive bumps `modifiedTime`.
+
+### Trash a file (or restore one)
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"trashed":true}' \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?fields=id,name,trashed"
+
+# Restore:
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"trashed":false}' \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?fields=id,name,trashed"
+```
+
+Prefer `trashed:true` over `DELETE` — `DELETE` is permanent and the
+user can't undo it. Only use `DELETE` when they explicitly say
+"permanently delete".
+
+### Bulk "move every PDF in the root to /Documents/PDF" (confirmation pattern)
+
+```sh
+# 1. List candidates and show the user before doing anything
+DST_FOLDER_ID='1XYZdocsPdfFolder'
+ROOT_ID='root'
+
+CANDS=$(curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --get "https://www.googleapis.com/drive/v3/files" \
+  --data-urlencode "q='$ROOT_ID' in parents and mimeType='application/pdf' and trashed=false" \
+  --data-urlencode 'fields=files(id,name,webViewLink)' \
+  | jq '.files')
+echo "$CANDS" | jq -r '.[] | "- \(.name)"'
+
+# 2. (after user confirms) actually move
+echo "$CANDS" | jq -r '.[] | .id' | while read FID; do
+  curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+    --data '' \
+    "https://www.googleapis.com/drive/v3/files/$FID?addParents=$DST_FOLDER_ID&removeParents=$ROOT_ID&fields=id,name,parents" \
+    | jq -c '{id, name, parents}'
+done
+```
+
 ## Common error codes
 
 | HTTP | meaning | what to tell the user |
 |---|---|---|
 | `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Drive connector on the Connections page." |
-| `403 insufficientPermissions` | scope missing | "Your installed connector only grants read access — this action needs a write scope we don't have." |
+| `403 insufficientPermissions` | write scope missing | "This action needs the Drive read+write scope, but only `drive.readonly` was granted at install. Re-install the connector and check the read+write box." |
 | `403 userRateLimitExceeded` | quota | retry once after 5–10s; if it persists, tell the user. |
 | `404 notFound` | wrong file id OR file isn't visible to this account | double-check the id; if shared, use `sharedWithMe` query above. |
 | `400 invalidQuery` | malformed `q` | print the `q` you sent + the error message back to the user. |
+
+Never log or echo `$GOOGLE_DRIVE_TOKEN` — treat it as a secret.
 
 Never log or echo `$GOOGLE_DRIVE_TOKEN` — treat it as a secret.

--- a/skills/google-drive/SKILL.md
+++ b/skills/google-drive/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: google-drive
+description: Read and search Google Drive files / folders / shared content via the Drive v3 REST API. Use when the user mentions Drive files, "my drive", shared documents, Google Docs / Sheets / Slides, exporting / downloading a Drive file, or searching by name / owner / folder.
+when_to_use: |
+  Trigger when the user wants to list, search, read or download files
+  in their Google Drive — including Google-native docs (Docs / Sheets /
+  Slides) which need a special "export" call to get plain content. The
+  installed connector grants read-only scope (`drive.readonly`); writes
+  are out of scope.
+connections: [google/drive]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Google Drive via `curl + jq`. The user's OAuth bearer token is
+in `$GOOGLE_DRIVE_TOKEN`; every call needs it as
+`Authorization: Bearer $GOOGLE_DRIVE_TOKEN`. The token already carries
+the `drive.readonly` scope the user agreed to at install plus the
+identity scopes (`openid email profile`).
+
+The Drive API returns standard JSON; failures surface as
+`{"error": {"code": 401|403|..., "message": "..."}}` — show that
+error verbatim to the user. `401` means the token expired and the
+user must re-install the connector. `403 insufficientPermissions`
+means the connector grants only `drive.readonly` and the user is
+asking for a write — say so explicitly.
+
+**Always start with `/about?fields=user`** to confirm the connection
+works AND learn which Google account you're operating against.
+
+## Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/about?fields=user(displayName,emailAddress,photoLink),storageQuota(usage,limit)" \
+  | jq '{user, quota: .storageQuota}'
+```
+
+### List recent files (last modified first)
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files?orderBy=modifiedTime%20desc&pageSize=20&fields=files(id,name,mimeType,modifiedTime,owners(emailAddress),webViewLink,parents)" \
+  | jq '.files[] | {id, name, mimeType, modified: .modifiedTime, owner: .owners[0].emailAddress, webViewLink}'
+```
+
+`pageSize` max is 1000; default is 100. Use `pageToken` from the
+response (`nextPageToken`) for follow-up pages.
+
+### Search by name / fulltext
+
+```sh
+# Exact-name fragments — note "name contains" supports tokens, not regex
+Q='name contains "季度复盘" and trashed = false'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --get "https://www.googleapis.com/drive/v3/files" \
+  --data-urlencode "q=$Q" \
+  --data-urlencode 'fields=files(id,name,mimeType,modifiedTime,webViewLink,owners(emailAddress))' \
+  --data-urlencode 'pageSize=20' \
+  | jq '.files[] | {id, name, modified: .modifiedTime, owner: .owners[0].emailAddress}'
+
+# Full-text search (body + title)
+Q='fullText contains "OKR 2026Q2" and trashed = false'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --get "https://www.googleapis.com/drive/v3/files" \
+  --data-urlencode "q=$Q" \
+  --data-urlencode 'fields=files(id,name,modifiedTime,webViewLink)' \
+  | jq '.files[]'
+```
+
+The `q` param uses [Drive's mini query language](https://developers.google.com/drive/api/guides/search-files):
+`name`, `fullText`, `mimeType`, `parents`, `'<email>' in owners`,
+`'<email>' in writers`, `modifiedTime > '2026-01-01T00:00:00'`,
+`sharedWithMe`, `trashed`, joined by `and` / `or` / `not`.
+
+### List files shared with me
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --get "https://www.googleapis.com/drive/v3/files" \
+  --data-urlencode 'q=sharedWithMe and trashed = false' \
+  --data-urlencode 'orderBy=sharedWithMeTime desc' \
+  --data-urlencode 'fields=files(id,name,mimeType,sharedWithMeTime,owners(displayName,emailAddress))' \
+  --data-urlencode 'pageSize=30' \
+  | jq '.files[] | {name, sharedAt: .sharedWithMeTime, sharedBy: .owners[0]}'
+```
+
+### List children of a folder
+
+```sh
+FOLDER_ID='1A2B3CdEfGhIjKlMn'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  --get "https://www.googleapis.com/drive/v3/files" \
+  --data-urlencode "q='$FOLDER_ID' in parents and trashed = false" \
+  --data-urlencode 'fields=files(id,name,mimeType,size,modifiedTime),nextPageToken' \
+  | jq '.files'
+```
+
+### Get metadata for a single file
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?fields=id,name,mimeType,size,modifiedTime,parents,owners,webViewLink,description"
+```
+
+### Download a binary file (PDF / image / zip / …)
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+OUT=/tmp/download.bin
+curl -sS -L -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID?alt=media" \
+  -o "$OUT"
+file "$OUT" && wc -c "$OUT"
+```
+
+### Read a Google Doc as plain markdown / text
+
+Google-native files (Docs, Sheets, Slides) **don't have raw bytes** —
+you have to ask Drive to *export* them to a concrete MIME type:
+
+```sh
+DOC_ID='1A2B3CdEfGhIjKlMn'
+
+# Markdown (best for chat-friendly summaries)
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$DOC_ID/export?mimeType=text/markdown" \
+  > /tmp/doc.md
+head -40 /tmp/doc.md
+
+# Plain text fallback for older docs
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$DOC_ID/export?mimeType=text/plain" \
+  > /tmp/doc.txt
+```
+
+Common export MIME types:
+
+| native MIME | export to |
+|---|---|
+| `application/vnd.google-apps.document` | `text/markdown`, `text/plain`, `text/html`, `application/pdf`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
+| `application/vnd.google-apps.spreadsheet` | `text/csv`, `application/pdf`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
+| `application/vnd.google-apps.presentation` | `application/pdf`, `text/plain`, `application/vnd.openxmlformats-officedocument.presentationml.presentation` |
+
+### Read a Google Sheet as CSV
+
+```sh
+SHEET_ID='1A2B3CdEfGhIjKlMn'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$SHEET_ID/export?mimeType=text/csv" \
+  > /tmp/sheet.csv
+head /tmp/sheet.csv
+```
+
+The Drive `export` endpoint returns the **first sheet only**. For
+multi-tab access the user needs to install a separate Google Sheets
+connector (currently out of catalog) — explain that and stop.
+
+### Get permissions / sharing on a file
+
+```sh
+FILE_ID='1A2B3CdEfGhIjKlMn'
+curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+  "https://www.googleapis.com/drive/v3/files/$FILE_ID/permissions?fields=permissions(id,type,role,emailAddress,domain,deleted)" \
+  | jq '.permissions[] | {who: (.emailAddress // .domain // .type), role}'
+```
+
+### Pagination boilerplate
+
+```sh
+PAGE_TOKEN=''
+while : ; do
+  RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" \
+    --get "https://www.googleapis.com/drive/v3/files" \
+    --data-urlencode 'q=trashed = false' \
+    --data-urlencode 'fields=files(id,name),nextPageToken' \
+    --data-urlencode 'pageSize=200' \
+    ${PAGE_TOKEN:+--data-urlencode "pageToken=$PAGE_TOKEN"})
+  echo "$RESP" | jq -c '.files[]'
+  PAGE_TOKEN=$(echo "$RESP" | jq -r '.nextPageToken // empty')
+  [ -z "$PAGE_TOKEN" ] && break
+done
+```
+
+## Common error codes
+
+| HTTP | meaning | what to tell the user |
+|---|---|---|
+| `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Drive connector on the Connections page." |
+| `403 insufficientPermissions` | scope missing | "Your installed connector only grants read access — this action needs a write scope we don't have." |
+| `403 userRateLimitExceeded` | quota | retry once after 5–10s; if it persists, tell the user. |
+| `404 notFound` | wrong file id OR file isn't visible to this account | double-check the id; if shared, use `sharedWithMe` query above. |
+| `400 invalidQuery` | malformed `q` | print the `q` you sent + the error message back to the user. |
+
+Never log or echo `$GOOGLE_DRIVE_TOKEN` — treat it as a secret.

--- a/skills/google-gmail/SKILL.md
+++ b/skills/google-gmail/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: google-gmail
+description: Read, search and triage Gmail mail / threads / labels / attachments via the Gmail v1 REST API. Use when the user mentions Gmail, "my inbox", unread mail, recent emails from someone, summarising a thread, downloading an attachment, or finding mail by label / query.
+when_to_use: |
+  Trigger when the user wants to read, list, search, summarise or
+  inspect Gmail mail — including triaging the inbox, surfacing unread,
+  pulling a single thread for review, or downloading an attachment.
+  The installed connector grants read-only scope (`gmail.readonly`);
+  sending / replying / archiving / labelling are out of scope.
+connections: [google/gmail]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Gmail via `curl + jq`. The user's OAuth bearer token is in
+`$GOOGLE_GMAIL_TOKEN`; every call needs it as
+`Authorization: Bearer $GOOGLE_GMAIL_TOKEN`. The token already
+carries the `gmail.readonly` scope the user agreed to at install plus
+the identity scopes (`openid email profile`).
+
+The Gmail API returns standard JSON; failures surface as
+`{"error": {"code": 401|403|..., "message": "..."}}` — show that
+error verbatim. `401` means the token expired (re-install). `403`
+or `400 insufficientPermissions` means the user is asking for a write
+this connector cannot satisfy — say so.
+
+**Always start with `users/me/profile`** to confirm the connection works
+AND learn which Gmail account you're operating against. Mailbox payloads
+can be huge — fetch metadata first, only `format=full` when the user
+actually wants the body of a specific message.
+
+## Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/profile" \
+  | jq '{email: .emailAddress, totalMessages, totalThreads, historyId}'
+```
+
+### List recent unread inbox
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+  --data-urlencode 'q=is:unread in:inbox newer_than:7d' \
+  --data-urlencode 'maxResults=20' \
+  | jq '.messages[]'
+```
+
+The `messages.list` endpoint returns only `{id, threadId}` — you have
+to fan out to `messages.get` for headers / body. Cheap pattern: list
+ids → get with `format=metadata&metadataHeaders=From,Subject,Date` for
+each. Use `format=full` only if the user wants the body.
+
+### List + enrich with headers (one-shot inbox triage)
+
+```sh
+IDS=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+  --data-urlencode 'q=is:unread in:inbox' \
+  --data-urlencode 'maxResults=10' \
+  | jq -r '.messages[].id')
+
+for ID in $IDS; do
+  curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+    --get "https://gmail.googleapis.com/gmail/v1/users/me/messages/$ID" \
+    --data-urlencode 'format=metadata' \
+    --data-urlencode 'metadataHeaders=From' \
+    --data-urlencode 'metadataHeaders=Subject' \
+    --data-urlencode 'metadataHeaders=Date' \
+    | jq '{id: .id, snippet: .snippet, headers: (.payload.headers | map({(.name): .value}) | add), labels: .labelIds}'
+done | jq -s '.'
+```
+
+### Read a single message body (plain text and html)
+
+```sh
+ID='18f1a2b3c4d5e6f0'
+RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages/$ID" \
+  --data-urlencode 'format=full')
+
+echo "$RESP" | jq '{id, snippet, headers: (.payload.headers | map({(.name): .value}) | add)}'
+
+# Body is base64url-encoded inside payload.parts[].body.data — Gmail
+# splits multipart messages, so collect every text/plain or text/html
+# leaf and base64url-decode them.
+echo "$RESP" | jq -r '
+  def walk(p):
+    if (p.parts // null) then (p.parts | map(walk(.)) | add) else [p] end;
+  walk(.payload)
+  | map(select(.mimeType=="text/plain" and (.body.data // "") != ""))
+  | .[].body.data' \
+  | tr '_-' '/+' | base64 -d 2>/dev/null
+```
+
+If the plain-text leaf is empty, fall back to the `text/html` leaf
+(same walk, swap the mimeType filter) and tell the user it's HTML.
+
+### Read a whole thread
+
+```sh
+THREAD_ID='18f1a2b3c4d5e6f0'
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/threads/$THREAD_ID" \
+  --data-urlencode 'format=metadata' \
+  --data-urlencode 'metadataHeaders=From' \
+  --data-urlencode 'metadataHeaders=Subject' \
+  --data-urlencode 'metadataHeaders=Date' \
+  | jq '{id, historyId, messages: [.messages[] | {id, snippet, from: (.payload.headers | from_entries.From), date: (.payload.headers | from_entries.Date)}]}'
+```
+
+### Search by Gmail query
+
+```sh
+# Same query DSL the Gmail UI uses: from:, to:, subject:, has:attachment,
+# is:unread, label:Work, after:2026/04/01, before:2026/05/01, …
+Q='from:boss@example.com subject:OKR newer_than:30d'
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+  --data-urlencode "q=$Q" \
+  --data-urlencode 'maxResults=20' \
+  | jq '.messages // []'
+```
+
+`q` syntax reference: <https://support.google.com/mail/answer/7190> —
+the model-friendly bits are `from:`, `to:`, `cc:`, `subject:`, `label:`,
+`is:unread`, `is:read`, `is:starred`, `has:attachment`, `filename:pdf`,
+`newer_than:7d`, `older_than:30d`, `after:YYYY/MM/DD`, `before:`, `in:inbox`,
+`in:trash`. Combine with `OR` / `()` / `-`.
+
+### List labels (system + user-defined)
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/labels" \
+  | jq '.labels[] | {id, name, type, color: .color.backgroundColor}'
+```
+
+The system labels are `INBOX`, `SENT`, `DRAFT`, `IMPORTANT`, `UNREAD`,
+`STARRED`, `SPAM`, `TRASH`, plus `CATEGORY_*` (Personal / Social /
+Promotions / Updates / Forums).
+
+### Filter by label
+
+```sh
+LABEL_ID='Label_4'  # from labels.list above
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+  --data-urlencode "labelIds=$LABEL_ID" \
+  --data-urlencode 'maxResults=20' \
+  | jq '.messages // []'
+```
+
+Multiple `labelIds` query params behave like AND.
+
+### Download an attachment
+
+```sh
+MSG_ID='18f1a2b3c4d5e6f0'
+
+# 1. find the attachment leaf
+RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID" \
+  --data-urlencode 'format=full')
+
+echo "$RESP" | jq '
+  def walk(p):
+    if (p.parts // null) then (p.parts | map(walk(.)) | add) else [p] end;
+  walk(.payload)
+  | map(select(.body.attachmentId? != null))
+  | .[] | {filename, mimeType, attachmentId: .body.attachmentId, size: .body.size}'
+
+# 2. fetch the attachment by id
+ATT_ID='ANGjdJ-abc123'
+OUT=/tmp/attachment.bin
+curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/attachments/$ATT_ID" \
+  | jq -r .data | tr '_-' '/+' | base64 -d > "$OUT"
+file "$OUT"
+```
+
+### Pagination
+
+```sh
+PAGE_TOKEN=''
+while : ; do
+  RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+    --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+    --data-urlencode 'q=in:inbox' \
+    --data-urlencode 'maxResults=100' \
+    ${PAGE_TOKEN:+--data-urlencode "pageToken=$PAGE_TOKEN"})
+  echo "$RESP" | jq -c '.messages[]?'
+  PAGE_TOKEN=$(echo "$RESP" | jq -r '.nextPageToken // empty')
+  [ -z "$PAGE_TOKEN" ] && break
+done
+```
+
+## Common error codes
+
+| HTTP | meaning | what to tell the user |
+|---|---|---|
+| `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Gmail connector on the Connections page." |
+| `403 insufficientPermissions` | scope missing | "This connector grants only read access — modifying mail isn't possible." |
+| `403 userRateLimitExceeded` / `429` | quota / throttling | back off ~5s, then retry once. |
+| `404 notFound` | wrong message / thread / attachment id | double-check the id, or fall back to `messages.list` with the right query. |
+| `400 invalidQuery` | malformed `q` | print the `q` you sent + the error back to the user. |
+
+Never log or echo `$GOOGLE_GMAIL_TOKEN` — treat it as a secret.

--- a/skills/google-gmail/SKILL.md
+++ b/skills/google-gmail/SKILL.md
@@ -1,31 +1,44 @@
 ---
 name: google-gmail
-description: Read, search and triage Gmail mail / threads / labels / attachments via the Gmail v1 REST API. Use when the user mentions Gmail, "my inbox", unread mail, recent emails from someone, summarising a thread, downloading an attachment, or finding mail by label / query.
+description: Read, search, triage, label, archive and send Gmail mail / threads / labels / attachments via the Gmail v1 REST API. Use when the user mentions Gmail, "my inbox", unread mail, recent emails from someone, summarising a thread, downloading an attachment, finding mail by label / query, archiving or labelling a thread, or drafting and sending a reply / new message.
 when_to_use: |
-  Trigger when the user wants to read, list, search, summarise or
-  inspect Gmail mail — including triaging the inbox, surfacing unread,
-  pulling a single thread for review, or downloading an attachment.
-  The installed connector grants read-only scope (`gmail.readonly`);
-  sending / replying / archiving / labelling are out of scope.
+  Trigger when the user wants to read, list, search, summarise,
+  inspect, modify or send Gmail mail — including triaging the inbox,
+  surfacing unread, pulling a single thread, downloading an
+  attachment, archiving / labelling / trashing messages, or having
+  the AI draft and send a reply or new message on their behalf.
+  The installed connector always grants `gmail.readonly`; the user
+  also opts in to `gmail.modify` (label / archive / trash) and
+  `gmail.send` (compose + send) at install time — confirm the action
+  is in scope before issuing it.
 connections: [google/gmail]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 Drive Gmail via `curl + jq`. The user's OAuth bearer token is in
 `$GOOGLE_GMAIL_TOKEN`; every call needs it as
-`Authorization: Bearer $GOOGLE_GMAIL_TOKEN`. The token already
-carries the `gmail.readonly` scope the user agreed to at install plus
-the identity scopes (`openid email profile`).
+`Authorization: Bearer $GOOGLE_GMAIL_TOKEN`. At minimum the token
+carries `gmail.readonly` plus the identity scopes
+(`openid email profile`); if the user opted in to write at install
+time it also carries `gmail.modify` (label / archive / trash) and/or
+`gmail.send` (compose + send). Always assume the narrowest scope
+until a write actually fails — don't ask Google for new scopes from
+here.
 
 The Gmail API returns standard JSON; failures surface as
 `{"error": {"code": 401|403|..., "message": "..."}}` — show that
-error verbatim. `401` means the token expired (re-install). `403`
-or `400 insufficientPermissions` means the user is asking for a write
-this connector cannot satisfy — say so.
+error verbatim. `401` means the token expired (re-install). `403
+insufficientPermissions` means the user didn't grant the write scope
+this call needs — explain which scope is missing and suggest
+re-installing the connector with the matching write box checked.
+
+**Before any destructive write** (trashing a thread, sending an email)
+show the user the exact target / draft and ask them to confirm. Don't
+fan out across many messages without an explicit go-ahead.
 
 **Always start with `users/me/profile`** to confirm the connection works
 AND learn which Gmail account you're operating against. Mailbox payloads
@@ -201,12 +214,169 @@ while : ; do
 done
 ```
 
+## Write recipes
+
+These all need `gmail.modify` (label / archive / trash) or
+`gmail.send` (compose + send). If the user only granted
+`gmail.readonly` at install you'll get `403 insufficientPermissions`
+— surface that and ask them to re-install with the write boxes
+checked.
+
+### Mark a message read / unread, star it, archive it (gmail.modify)
+
+```sh
+MSG_ID='18f1a2b3c4d5e6f0'
+
+# Mark as read = remove the UNREAD label
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"removeLabelIds":["UNREAD"]}' \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/modify"
+
+# Star it = add the STARRED label
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"addLabelIds":["STARRED"]}' \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/modify"
+
+# Archive = remove from INBOX (keeps in All Mail)
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"removeLabelIds":["INBOX"]}' \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/modify"
+```
+
+The `modify` endpoint takes `addLabelIds` and `removeLabelIds`
+together — useful for atomic "archive + label" moves. Use the same
+shape on `/threads/$THREAD_ID/modify` to apply across a whole thread.
+
+### Apply a custom label
+
+```sh
+# 1. find or remember the label id from labels.list
+LABEL_ID='Label_4'
+MSG_ID='18f1a2b3c4d5e6f0'
+
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"addLabelIds\":[\"$LABEL_ID\"]}" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/modify"
+```
+
+Creating a brand-new label needs the same scope:
+
+```sh
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"name":"Follow up","messageListVisibility":"show","labelListVisibility":"labelShow"}' \
+  "https://gmail.googleapis.com/gmail/v1/users/me/labels" \
+  | jq '{id, name}'
+```
+
+### Trash a message or thread
+
+```sh
+MSG_ID='18f1a2b3c4d5e6f0'
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/$MSG_ID/trash"
+
+# Whole thread:
+THREAD_ID='18f1a2b3c4d5e6f0'
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/threads/$THREAD_ID/trash"
+```
+
+Use `/untrash` (same shape) to restore. **Never** use
+`messages.delete` — it permanently deletes and needs a higher scope
+that we don't request.
+
+### Send a brand-new email (gmail.send)
+
+Gmail wants the message as a base64url-encoded RFC 2822 string.
+
+```sh
+# Compose the message
+TO='alice@example.com'
+SUBJECT='Quick hello'
+BODY='Hi Alice,
+
+Just a quick test note from the AceDataCloud Gmail connector.
+
+Best,
+Qingcai'
+
+# Multi-line subject lines need MIME encoded-word for non-ASCII; ASCII is fine raw.
+RAW=$(printf 'To: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\nMIME-Version: 1.0\r\n\r\n%s' \
+  "$TO" "$SUBJECT" "$BODY" \
+  | base64 | tr -d '\n' | tr '+/' '-_' | tr -d '=')
+
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"raw\":\"$RAW\"}" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/send" \
+  | jq '{id, threadId, labelIds}'
+```
+
+For non-ASCII subjects (Chinese / emoji), use MIME encoded-word:
+
+```sh
+SUBJECT_RAW='你好，季度复盘草稿'
+SUBJECT_ENCODED="=?UTF-8?B?$(printf %s "$SUBJECT_RAW" | base64)?="
+```
+
+### Reply in-thread (keeps the thread together)
+
+Reply by setting the `In-Reply-To` and `References` headers to the
+Message-Id of the message you're replying to, **and** pass the
+Gmail thread id in the API body:
+
+```sh
+ORIG_MSG_ID='18f1a2b3c4d5e6f0'
+ORIG=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  --get "https://gmail.googleapis.com/gmail/v1/users/me/messages/$ORIG_MSG_ID" \
+  --data-urlencode 'format=metadata' \
+  --data-urlencode 'metadataHeaders=Message-ID' \
+  --data-urlencode 'metadataHeaders=Subject' \
+  --data-urlencode 'metadataHeaders=From')
+MID=$(echo "$ORIG" | jq -r '.payload.headers | from_entries | .["Message-ID"] // .["Message-Id"]')
+FROM=$(echo "$ORIG" | jq -r '.payload.headers | from_entries | .From')
+SUBJ=$(echo "$ORIG" | jq -r '.payload.headers | from_entries | .Subject')
+TID=$(echo "$ORIG" | jq -r .threadId)
+
+RAW=$(printf 'To: %s\r\nSubject: Re: %s\r\nIn-Reply-To: %s\r\nReferences: %s\r\nContent-Type: text/plain; charset=UTF-8\r\nMIME-Version: 1.0\r\n\r\n%s' \
+  "$FROM" "$SUBJ" "$MID" "$MID" \
+  'Replying inline — will follow up later today.' \
+  | base64 | tr -d '\n' | tr '+/' '-_' | tr -d '=')
+
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"raw\":\"$RAW\",\"threadId\":\"$TID\"}" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/send" \
+  | jq '{id, threadId}'
+```
+
+Without the `threadId` in the body Gmail starts a brand-new thread
+even with the right `In-Reply-To` headers.
+
+### Save a draft instead of sending
+
+Same `raw` payload, different endpoint — still costs `gmail.send`
+(`drafts` shares the send scope under the hood for write):
+
+```sh
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"message\":{\"raw\":\"$RAW\"}}" \
+  "https://gmail.googleapis.com/gmail/v1/users/me/drafts" \
+  | jq '{id, message: {id: .message.id, threadId: .message.threadId}}'
+```
+
 ## Common error codes
 
 | HTTP | meaning | what to tell the user |
 |---|---|---|
 | `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Gmail connector on the Connections page." |
-| `403 insufficientPermissions` | scope missing | "This connector grants only read access — modifying mail isn't possible." |
+| `403 insufficientPermissions` | scope missing | identify which scope (`gmail.modify` for label/archive/trash, `gmail.send` for sending) and suggest re-installing the connector with that box checked. |
 | `403 userRateLimitExceeded` / `429` | quota / throttling | back off ~5s, then retry once. |
 | `404 notFound` | wrong message / thread / attachment id | double-check the id, or fall back to `messages.list` with the right query. |
 | `400 invalidQuery` | malformed `q` | print the `q` you sent + the error back to the user. |

--- a/skills/google-tasks/SKILL.md
+++ b/skills/google-tasks/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: google-tasks
+description: Read Google Tasks task lists and individual tasks via the Tasks v1 REST API. Use when the user mentions Google Tasks, todo / pending / overdue tasks, weekly task recap, or grouping todos by list.
+when_to_use: |
+  Trigger when the user wants to inspect their Google Tasks — list
+  task lists, surface pending items, group by due date, or pull
+  details for one task. The installed connector grants read-only
+  scope (`tasks.readonly`); creating / updating / deleting tasks is
+  out of scope.
+connections: [google/tasks]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Google Tasks via `curl + jq`. The user's OAuth bearer token is
+in `$GOOGLE_TASKS_TOKEN`; every call needs it as
+`Authorization: Bearer $GOOGLE_TASKS_TOKEN`. The token already
+carries the `tasks.readonly` scope the user agreed to at install plus
+the identity scopes (`openid email profile`).
+
+The Tasks API returns standard JSON; failures surface as
+`{"error": {"code": 401|403|..., "message": "..."}}` — show that
+error verbatim. `401` means the token expired (re-install). `403
+insufficientPermissions` means the user is asking for a write this
+connector cannot satisfy — say so.
+
+**Always start with `users/@me/lists`** to discover which task lists
+the account has — the user's default plus any extras they created on
+calendar.google.com or in the Tasks app.
+
+## Recipes
+
+### Verify auth + list all task lists (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq '.items[] | {id, title, updated}'
+```
+
+The default list is usually titled "我的任务" / "My Tasks" but the
+**id** (a long opaque string like `MTAxMjM0NTY3OA`) is what every
+subsequent `lists/{id}/tasks` call needs.
+
+### List all unfinished tasks across every list
+
+```sh
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq -r '.items[] | "\(.id)\t\(.title)"' | while IFS=$'\t' read LIST_ID LIST_TITLE; do
+    curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+      --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+      --data-urlencode 'showCompleted=false' \
+      --data-urlencode 'maxResults=100' \
+      | jq --arg list "$LIST_TITLE" '.items[]? | {list: $list, title, due, status, notes}'
+  done | jq -s '. | sort_by(.due // "9999")'
+```
+
+`showCompleted=false` filters out done items at the API level. The
+default `showCompleted=true&showHidden=false` returns done tasks too.
+
+### Pending tasks in one specific list, sorted by due date
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+  --data-urlencode 'showCompleted=false' \
+  --data-urlencode 'maxResults=100' \
+  | jq '.items // [] | sort_by(.due // "9999") | .[] | {title, due, notes, status, position}'
+```
+
+`position` is the user's drag-to-reorder rank inside the list — useful
+when the user says "what's at the top of my tasks". Tasks without a
+`due` field are open-ended.
+
+### Tasks due today
+
+```sh
+TODAY=$(date -u +%Y-%m-%d)
+TOMORROW=$(date -u -d "+1 day" +%Y-%m-%d 2>/dev/null \
+  || date -u -v+1d +%Y-%m-%d)
+TODAY_START="${TODAY}T00:00:00.000Z"
+TOMORROW_START="${TOMORROW}T00:00:00.000Z"
+
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq -r '.items[] | "\(.id)\t\(.title)"' | while IFS=$'\t' read LIST_ID LIST_TITLE; do
+    curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+      --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+      --data-urlencode "dueMin=$TODAY_START" \
+      --data-urlencode "dueMax=$TOMORROW_START" \
+      --data-urlencode 'showCompleted=false' \
+      | jq --arg list "$LIST_TITLE" '.items[]? | {list: $list, title, due, notes}'
+  done | jq -s
+```
+
+`dueMin` / `dueMax` are RFC 3339 timestamps. The Tasks API stores
+`due` at midnight UTC, so the local-day window is approximate around
+the date boundary — that's fine for "due today" semantics, mention
+the caveat only if the user pushes back.
+
+### Overdue tasks (everything still pending with a due date in the past)
+
+```sh
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq -r '.items[] | "\(.id)\t\(.title)"' | while IFS=$'\t' read LIST_ID LIST_TITLE; do
+    curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+      --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+      --data-urlencode "dueMax=$NOW" \
+      --data-urlencode 'showCompleted=false' \
+      | jq --arg list "$LIST_TITLE" '.items[]? | {list: $list, title, due, daysOverdue: (((now * 1000) - (.due | sub("Z"; "+00:00") | fromdateiso8601 * 1000)) / 86400000 | floor)}'
+  done | jq -s
+```
+
+### Recently completed tasks (this week, for a recap)
+
+```sh
+ONE_WEEK_AGO=$(date -u -d "-7 days" +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null \
+  || date -u -v-7d +%Y-%m-%dT%H:%M:%S.000Z)
+
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq -r '.items[] | "\(.id)\t\(.title)"' | while IFS=$'\t' read LIST_ID LIST_TITLE; do
+    curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+      --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+      --data-urlencode 'showCompleted=true' \
+      --data-urlencode 'showHidden=true' \
+      --data-urlencode "completedMin=$ONE_WEEK_AGO" \
+      | jq --arg list "$LIST_TITLE" '.items[]? | select(.status=="completed") | {list: $list, title, completed}'
+  done | jq -s '. | sort_by(.completed)'
+```
+
+`completedMin` / `completedMax` mirror `dueMin`/`Max` and only apply
+to tasks already moved to the "completed" state. You **must** pass
+`showCompleted=true` AND `showHidden=true` to see them — Google hides
+completed tasks from the default list.
+
+### Get one task's details
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+TASK_ID='dGFza0lkRXhhbXBsZQ'
+curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks/$TASK_ID" \
+  | jq '{title, due, status, notes, completed, position, links: .links}'
+```
+
+`links` exposes the user's manual hyperlinks (e.g. an attached email
+or Drive doc) — render them as a list to the user when present.
+
+### Pagination
+
+`maxResults` caps at 100 per page. Use `nextPageToken`:
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+PAGE_TOKEN=''
+while : ; do
+  RESP=$(curl -sS -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+    --get "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+    --data-urlencode 'maxResults=100' \
+    --data-urlencode 'showCompleted=false' \
+    ${PAGE_TOKEN:+--data-urlencode "pageToken=$PAGE_TOKEN"})
+  echo "$RESP" | jq -c '.items[]?'
+  PAGE_TOKEN=$(echo "$RESP" | jq -r '.nextPageToken // empty')
+  [ -z "$PAGE_TOKEN" ] && break
+done
+```
+
+## Common error codes
+
+| HTTP | meaning | what to tell the user |
+|---|---|---|
+| `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Tasks connector on the Connections page." |
+| `403 insufficientPermissions` | scope missing | "This connector is read-only — adding or completing tasks isn't possible." |
+| `404 notFound` | wrong list / task id | re-list with `users/@me/lists` to find the right id. |
+| `429 quotaExceeded` | quota / throttling | back off ~5s, then retry once. |
+
+Never log or echo `$GOOGLE_TASKS_TOKEN` — treat it as a secret.

--- a/skills/google-tasks/SKILL.md
+++ b/skills/google-tasks/SKILL.md
@@ -1,35 +1,42 @@
 ---
 name: google-tasks
-description: Read Google Tasks task lists and individual tasks via the Tasks v1 REST API. Use when the user mentions Google Tasks, todo / pending / overdue tasks, weekly task recap, or grouping todos by list.
+description: Read and manage Google Tasks task lists and individual tasks via the Tasks v1 REST API. Use when the user mentions Google Tasks, todo / pending / overdue tasks, weekly task recap, grouping todos by list, adding or completing a task, or moving / deleting tasks.
 when_to_use: |
-  Trigger when the user wants to inspect their Google Tasks — list
-  task lists, surface pending items, group by due date, or pull
-  details for one task. The installed connector grants read-only
-  scope (`tasks.readonly`); creating / updating / deleting tasks is
-  out of scope.
+  Trigger when the user wants to inspect or manage their Google
+  Tasks — list task lists, surface pending items, group by due date,
+  pull details for one task, add new todos, mark items complete,
+  re-order or delete tasks. The installed connector always grants
+  `tasks.readonly`; the user opts in to the broader `tasks` scope
+  (full read + write) at install — confirm before destructive writes.
 connections: [google/tasks]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 Drive Google Tasks via `curl + jq`. The user's OAuth bearer token is
 in `$GOOGLE_TASKS_TOKEN`; every call needs it as
-`Authorization: Bearer $GOOGLE_TASKS_TOKEN`. The token already
-carries the `tasks.readonly` scope the user agreed to at install plus
-the identity scopes (`openid email profile`).
+`Authorization: Bearer $GOOGLE_TASKS_TOKEN`. At minimum the token
+carries `tasks.readonly` plus the identity scopes
+(`openid email profile`); if the user opted in to write at install
+time it also carries the broader `tasks` scope (read + write).
 
 The Tasks API returns standard JSON; failures surface as
 `{"error": {"code": 401|403|..., "message": "..."}}` — show that
 error verbatim. `401` means the token expired (re-install). `403
-insufficientPermissions` means the user is asking for a write this
-connector cannot satisfy — say so.
+insufficientPermissions` on a write means the user only granted
+`tasks.readonly` — ask them to re-install with the read+write box
+checked.
 
 **Always start with `users/@me/lists`** to discover which task lists
 the account has — the user's default plus any extras they created on
 calendar.google.com or in the Tasks app.
+
+**Before bulk creates / completions / deletes** echo the exact
+titles back to the user and ask them to confirm. Don't trash a
+task by guessing an id.
 
 ## Recipes
 
@@ -173,12 +180,115 @@ while : ; do
 done
 ```
 
+## Write recipes
+
+These all need the broader `tasks` scope. If the user only granted
+`tasks.readonly` you'll get `403 insufficientPermissions` — surface
+that and ask them to re-install with the read+write box checked.
+
+### Add a new task
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"title":"Draft Q2 plan","notes":"Outline + risks + asks.","due":"2026-05-15T00:00:00.000Z"}' \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+  | jq '{id, title, due, status}'
+```
+
+Google stores `due` as midnight UTC of the chosen day — the time of
+day is ignored in the UI. To insert at the very top of the list,
+add `?previous=` (no value) to the URL.
+
+### Bulk add three tasks under user confirmation
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+DUE='2026-05-12T00:00:00.000Z'
+for T in 'Reply to Alice' 'Review PR #404' 'Send meeting recap'; do
+  curl -sS -X POST -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+    -H 'Content-Type: application/json' \
+    --data "{\"title\":$(jq -nr --arg t "$T" '$t'),\"due\":\"$DUE\"}" \
+    "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks" \
+    | jq -c '{id, title, due}'
+done
+```
+
+Always list the titles you're about to create and ask for the user's
+go-ahead before running this loop — there is no atomic batch endpoint.
+
+### Mark a task complete
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+TASK_ID='dGFza0lkRXhhbXBsZQ'
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data "{\"status\":\"completed\",\"completed\":\"$NOW\"}" \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks/$TASK_ID" \
+  | jq '{id, title, status, completed}'
+```
+
+Reverse with `{"status":"needsAction","completed":null}`.
+
+### Edit a task's title / notes / due date
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+TASK_ID='dGFza0lkRXhhbXBsZQ'
+curl -sS -X PATCH -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"title":"Draft Q2 plan (rev2)","notes":"Cover risks + asks + budget.","due":"2026-05-20T00:00:00.000Z"}' \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks/$TASK_ID" \
+  | jq '{id, title, due, notes}'
+```
+
+### Delete a task
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+TASK_ID='dGFza0lkRXhhbXBsZQ'
+curl -sS -X DELETE -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks/$TASK_ID" \
+  -o /dev/null -w 'HTTP %{http_code}\n'
+```
+
+`204` = success. There is no soft-delete — once gone the task is
+gone. Echo the title back before deleting.
+
+### Re-order: move a task to a position
+
+```sh
+LIST_ID='MTAxMjM0NTY3OA'
+TASK_ID='dGFza0lkRXhhbXBsZQ'
+PREV='dGFza0lkUHJldg'  # task id this one should appear AFTER; omit to move to top
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  --data '' \
+  "https://tasks.googleapis.com/tasks/v1/lists/$LIST_ID/tasks/$TASK_ID/move?previous=$PREV" \
+  | jq '{id, title, parent, position}'
+```
+
+Use `?parent=...` instead of `?previous=...` to nest a task under
+another task as a sub-task.
+
+### Create a brand-new task list
+
+```sh
+curl -sS -X POST -H "Authorization: Bearer $GOOGLE_TASKS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{"title":"Q2 follow-ups"}' \
+  "https://tasks.googleapis.com/tasks/v1/users/@me/lists" \
+  | jq '{id, title}'
+```
+
 ## Common error codes
 
 | HTTP | meaning | what to tell the user |
 |---|---|---|
 | `401 UNAUTHENTICATED` | token expired / revoked | "Reconnect the Google Tasks connector on the Connections page." |
-| `403 insufficientPermissions` | scope missing | "This connector is read-only — adding or completing tasks isn't possible." |
+| `403 insufficientPermissions` | write scope missing | "This action needs the Tasks read+write scope, but only `tasks.readonly` was granted. Re-install the connector with the read+write box checked." |
 | `404 notFound` | wrong list / task id | re-list with `users/@me/lists` to find the right id. |
 | `429 quotaExceeded` | quota / throttling | back off ~5s, then retry once. |
 

--- a/skills/microsoft-onedrive/SKILL.md
+++ b/skills/microsoft-onedrive/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: microsoft-onedrive
+description: Read and manage OneDrive / SharePoint files via Microsoft Graph. Use when the user mentions OneDrive files / folders, SharePoint documents, file uploads / downloads, sharing links, or "my drive".
+when_to_use: |
+  Trigger when the user wants to read, list, search, upload, download,
+  rename, move, share or delete files in OneDrive (personal or
+  Microsoft 365 work / school) or SharePoint document libraries.
+connections: [microsoft/onedrive]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Microsoft Graph for OneDrive / SharePoint via `curl + jq`. The
+user's OAuth bearer token is in `$MICROSOFT_ONEDRIVE_TOKEN`; every call
+needs it as `Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN`. The token
+already carries the OneDrive scopes the user agreed to at install time
+(`Files.Read`, `Files.Read.All`, optionally `Files.ReadWrite.All`,
+`Sites.Read.All`).
+
+The Graph API returns standard JSON; failures surface as JSON
+`{"error": {"code": "...", "message": "..."}}` — show that error
+verbatim to the user.
+
+**Always start with `/me`** to confirm the connection works AND learn
+which account / drive you're operating against.
+
+## Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  https://graph.microsoft.com/v1.0/me \
+  | jq '{displayName, mail, userPrincipalName}'
+```
+
+If you get `401 InvalidAuthenticationToken`, the token expired —
+report it; the user has to reinstall the connector.
+
+### List files in root
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/root/children?\$top=20&\$select=id,name,size,lastModifiedDateTime,folder,file" \
+  | jq '.value[] | {id, name, size, kind: (if .folder then "folder" else .file.mimeType end), modified: .lastModifiedDateTime}'
+```
+
+Folders have `"folder":{"childCount":N}`, files have `"file":{"mimeType":"..."}`.
+
+### List files in a sub-folder by path
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/root:/Documents:/children?\$top=20&\$select=id,name,size,lastModifiedDateTime"
+```
+
+Path uses `:` as the path/segment separator — `:/Documents/Q1:/children`.
+
+### Search files (recursive)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  --data-urlencode "q=quarterly report" --get \
+  "https://graph.microsoft.com/v1.0/me/drive/root/search(q='quarterly report')?\$top=25&\$select=id,name,size,webUrl,lastModifiedDateTime"
+```
+
+> `search(q='')` with empty query returns 400. To find files by type
+> without a keyword, search by extension: `search(q='.pdf')`.
+
+### Recently modified files (cross-folder)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/recent?\$top=25" \
+  | jq '.value[] | {name, modified: .lastModifiedDateTime, parent: .parentReference.path}'
+```
+
+### Files shared with me
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/sharedWithMe?\$top=25" \
+  | jq '.value[] | {name, size: .size, owner: .remoteItem.shared.owner.user.displayName}'
+```
+
+### Download a file by item id
+
+```sh
+# /content returns 302 to a pre-signed URL — let curl follow it.
+curl -sSL -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}/content" \
+  -o "$SKILL_DIR/tmp/$(basename "$NAME")"
+```
+
+### Download a file by path
+
+```sh
+# URL-encode each path segment with jq -Rr @uri (or use printf encoding).
+ENCODED=$(printf '%s' "Documents/report.docx" | jq -sRr @uri)
+curl -sSL -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/root:/${ENCODED}:/content" \
+  -o report.docx
+```
+
+### Upload a small file (< 4 MB)
+
+```sh
+curl -sS -X PUT \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @/tmp/report.pdf \
+  "https://graph.microsoft.com/v1.0/me/drive/root:/Documents/report.pdf:/content"
+```
+
+For files **> 4 MB** use an upload session (chunked):
+
+```sh
+# 1) create session
+SESSION=$(curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"item":{"@microsoft.graph.conflictBehavior":"rename"}}' \
+  "https://graph.microsoft.com/v1.0/me/drive/root:/Documents/big.zip:/createUploadSession")
+UPLOAD_URL=$(echo "$SESSION" | jq -r .uploadUrl)
+# 2) PUT in 10 MiB chunks with Content-Range: bytes <start>-<end>/<total>
+# (See Microsoft Graph docs for the chunking loop; jq + dd makes this trivial.)
+```
+
+### Create a folder
+
+```sh
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Reports","folder":{},"@microsoft.graph.conflictBehavior":"rename"}' \
+  https://graph.microsoft.com/v1.0/me/drive/root/children
+```
+
+`@microsoft.graph.conflictBehavior`: `rename` (auto-suffix), `replace`
+(overwrite), `fail` (error if exists). Default is `fail`.
+
+### Rename / move (PATCH)
+
+**⚠️ Always show the source and destination before executing.**
+
+```sh
+# Rename only
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"renamed.docx"}' \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}"
+
+# Move to a different folder
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg pid "$NEW_PARENT_ID" '{parentReference:{id:$pid}}')" \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}"
+```
+
+### Delete
+
+**⚠️ Always fetch the item name first and confirm with the user.**
+
+```sh
+# 1) Show what will be deleted
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}?\$select=name,size,lastModifiedDateTime" \
+  | jq '"Delete \(.name) (\(.size) bytes, modified \(.lastModifiedDateTime))?"'
+
+# 2) After user confirms (returns 204 No Content)
+curl -sS -X DELETE -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}" \
+  -w "HTTP %{http_code}\n"
+```
+
+### Create a sharing link
+
+**⚠️ Confirm with the user before sharing — this exposes data externally.**
+
+```sh
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"view","scope":"organization"}' \
+  "https://graph.microsoft.com/v1.0/me/drive/items/${ITEM_ID}/createLink" \
+  | jq '.link.webUrl'
+```
+
+`type`: `view` | `edit` | `embed`. `scope`: `anonymous` | `organization` | `users`.
+
+### List SharePoint sites
+
+Requires `Sites.Read.All`.
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/sites?search=*&\$top=10" \
+  | jq '.value[] | {id, name: .displayName, webUrl}'
+```
+
+Files inside a site:
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_ONEDRIVE_TOKEN" \
+  "https://graph.microsoft.com/v1.0/sites/${SITE_ID}/drive/root/children?\$top=20"
+```
+
+## OData quick reference
+
+| Param | Example |
+|---|---|
+| `$select` | `id,name,size,lastModifiedDateTime` |
+| `$filter` | `name eq 'report.docx'`, `size gt 1000000` |
+| `$orderby` | `lastModifiedDateTime desc` |
+| `$top` | `10` browsing, `25` search |
+| `$expand` | `children`, `permissions` |
+
+Use `--data-urlencode "$key=$value" --get` with curl to avoid shell-quoting `$` and spaces.
+
+## Rules
+
+- **Always pass `$select`** — defaults return 30+ fields per item.
+- **`$top=10`** for browse, `25` for search. Don't paginate past 50 unless asked.
+- **URL-encode IDs** if using them in a path — IDs can contain `+`, `/`, `=`. Use `jq -sRr @uri`.
+- **Empty `search(q='')` returns 400** — search by extension if you don't have a keyword.
+
+## CRITICAL: User consent for destructive actions
+
+**Never** delete, overwrite or share without explicit confirmation. Pattern: **prepare → present → execute**.
+
+| Action | What to show user |
+|---|---|
+| Delete | "Delete '{name}' ({size} bytes, modified {date})?" |
+| Overwrite (`@microsoft.graph.conflictBehavior=replace`) | "Overwrite '{name}'? Existing: {size}, modified {date}" |
+| Share (`createLink`) | "Create {type} link for '{name}' with {scope} access?" |
+| Move | "Move '{name}' from {old folder} to {new folder}?" |
+| Bulk | Count + sample: "Delete 12 files in /Reports/?" |
+
+## Errors
+
+- `401 InvalidAuthenticationToken` → token expired; user must reinstall the connector.
+- `403 accessDenied` → scope missing (e.g. trying to write with read-only token); ask user to reinstall and tick the write scope.
+- `429 TooManyRequests` → respect the `Retry-After` header (in seconds).
+- `404 itemNotFound` → wrong id or path; double-check casing.
+
+## Reference
+
+For deep dives consult Microsoft's docs:
+- Drive items: <https://learn.microsoft.com/en-us/graph/api/resources/driveitem>
+- Upload large files: <https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession>
+- Sharing: <https://learn.microsoft.com/en-us/graph/api/driveitem-createlink>

--- a/skills/microsoft-outlook/SKILL.md
+++ b/skills/microsoft-outlook/SKILL.md
@@ -1,0 +1,488 @@
+---
+name: microsoft-outlook
+description: Read, search, draft, send and manage Outlook / Microsoft 365 email AND calendar events via Microsoft Graph. Use when the user mentions Outlook (mail or calendar), Microsoft 365 inbox, sending mail, replying / forwarding, today's agenda, scheduling a meeting, finding free time, or modifying / cancelling an event.
+when_to_use: |
+  Trigger when the user wants to read or write Outlook **mail or
+  calendar** — list / search / read / triage / archive messages,
+  draft and send new mail, reply or forward, manage folders, download
+  attachments, see today / this week's events, find conflicts, find a
+  free slot, create / update / cancel a meeting, accept / decline an
+  invite, check shared mailboxes or shared calendars.
+connections: [microsoft/outlook]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Drive Microsoft Graph for Outlook / Microsoft 365 — both **mail** and
+**calendar** — via `curl + jq`. The user's OAuth bearer token is in
+`$MICROSOFT_OUTLOOK_TOKEN`; every call needs it as
+`Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN`. The token already
+carries the scopes the user agreed to at install: any of `Mail.Read`,
+`Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.Read`,
+`MailboxSettings.ReadWrite`, `Calendars.Read`, `Calendars.ReadWrite`,
+plus `*.Shared` variants. Mail and calendar are unified into one
+connector (and one OAuth grant) because Microsoft Graph treats them as
+sibling features of the same mailbox — there is no value in splitting
+them at the skill layer.
+
+The Graph API returns JSON; failures surface as
+`{"error": {"code": "...", "message": "..."}}` — show that error
+verbatim to the user.
+
+**Always start with `/me`** to confirm the connection works AND learn
+which mailbox you're operating against. For calendar work, also fetch
+`mailboxSettings.timeZone` so dates render right.
+
+---
+
+# Mail — Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  https://graph.microsoft.com/v1.0/me \
+  | jq '{displayName, mail, userPrincipalName}'
+```
+
+### List recent messages
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages?\$top=10&\$select=id,subject,from,receivedDateTime,isRead,hasAttachments&\$orderby=receivedDateTime desc" \
+  | jq '.value[] | {subject, from: .from.emailAddress.address, received: .receivedDateTime, unread: (.isRead | not)}'
+```
+
+Filters: append to URL with `&` (URL-encode the spaces).
+
+| Want | Append |
+|---|---|
+| Unread only | `&$filter=isRead eq false` |
+| With attachments | `&$filter=hasAttachments eq true` |
+| From a specific sender | `&$filter=from/emailAddress/address eq 'user@example.com'` |
+| Date range | `&$filter=receivedDateTime ge 2026-04-01T00:00:00Z and receivedDateTime lt 2026-05-01T00:00:00Z` |
+| Combine | Use `and` / `or` between filter clauses |
+
+### Search messages (full-text on subject + body)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  --data-urlencode '$search="quarterly report"' \
+  --data-urlencode '$top=10' \
+  --data-urlencode '$select=id,subject,from,receivedDateTime' \
+  --get https://graph.microsoft.com/v1.0/me/messages
+```
+
+> `$search` cannot be combined with `$filter` or `$orderby` in the same
+> query — pick one. `$search` returns relevance-ranked results.
+
+### Read a message body
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}?\$select=subject,body,from,toRecipients,receivedDateTime" \
+  | jq '{subject, from: .from.emailAddress.address, received: .receivedDateTime, body: .body.content}'
+```
+
+`body.contentType` is usually `"HTML"`. Use `jq -r .body.content` if
+you want the raw HTML.
+
+### Send an email
+
+> **⚠️ ALWAYS use draft → confirm → send. NEVER call `/me/sendMail`
+> directly — it sends immediately with no undo.**
+
+```sh
+# Step 1: create draft
+DRAFT=$(curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc \
+        --arg subj "Project update" \
+        --arg body "<p>Wanted to share the latest numbers.</p>" \
+        --arg to "alice@example.com" \
+        '{subject:$subj, body:{contentType:"HTML", content:$body}, toRecipients:[{emailAddress:{address:$to}}]}')" \
+  https://graph.microsoft.com/v1.0/me/messages)
+DRAFT_ID=$(echo "$DRAFT" | jq -r .id)
+
+# Step 2: present the draft to the user — subject, recipients, body preview
+echo "$DRAFT" | jq '{subject, to: .toRecipients[0].emailAddress.address, body: .body.content}'
+
+# Step 3: ONLY after user confirms — send (returns 202 No Content)
+curl -sS -X POST -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${DRAFT_ID}/send" \
+  -w "HTTP %{http_code}\n"
+```
+
+CC / BCC: include `ccRecipients` / `bccRecipients` arrays in the same
+shape as `toRecipients`.
+
+### Reply / reply-all / forward
+
+> **⚠️ Show the user your draft text + recipients before sending.**
+
+```sh
+# Quick reply (sends immediately on /reply — for explicit user-confirmed flow)
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"comment":"Thanks for the update!"}' \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}/reply"
+
+# Or: createReply → review → /send (preferred for non-trivial replies)
+DRAFT=$(curl -sS -X POST -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}/createReply")
+DRAFT_ID=$(echo "$DRAFT" | jq -r .id)
+# PATCH body if needed, then /send
+
+# Forward
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg to "bob@example.com" \
+        '{comment:"FYI", toRecipients:[{emailAddress:{address:$to}}]}')" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}/forward"
+```
+
+### Mark read / unread
+
+```sh
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"isRead": true}' \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}"
+```
+
+### List folders + read a specific folder
+
+```sh
+# Well-known folder names: Inbox, Drafts, SentItems, DeletedItems, Archive, JunkEmail
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/mailFolders('SentItems')/messages?\$top=5&\$select=subject,toRecipients,sentDateTime" \
+  | jq '.value[] | {subject, sent: .sentDateTime}'
+```
+
+### List + download attachments
+
+```sh
+# Metadata
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}/attachments?\$select=id,name,size,contentType" \
+  | jq '.value[] | {id, name, size}'
+
+# Download a single attachment
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}/attachments/${ATT_ID}/\$value" \
+  -o "$SKILL_DIR/tmp/attachment.bin"
+```
+
+### Mailbox settings (timezone, signature, automatic replies)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/mailboxSettings"
+```
+
+Set an out-of-office reply:
+
+> **⚠️ Confirm with user before changing — auto-reply will fire on every incoming mail.**
+
+```sh
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"automaticRepliesSetting":{
+        "status":"scheduled",
+        "scheduledStartDateTime":{"dateTime":"2026-05-10T09:00:00","timeZone":"China Standard Time"},
+        "scheduledEndDateTime":{"dateTime":"2026-05-15T18:00:00","timeZone":"China Standard Time"},
+        "internalReplyMessage":"<p>I'm out this week, back Monday.</p>"}}' \
+  "https://graph.microsoft.com/v1.0/me/mailboxSettings"
+```
+
+Requires `MailboxSettings.ReadWrite` scope.
+
+### Delete a message
+
+> **⚠️ Always fetch the subject first and confirm with the user.**
+
+```sh
+# 1) show what's about to be deleted
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}?\$select=subject,from,receivedDateTime" \
+  | jq '"Delete \"\(.subject)\" from \(.from.emailAddress.address) (\(.receivedDateTime))?"'
+
+# 2) after user confirms (moves to Deleted Items, returns 204)
+curl -sS -X DELETE -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/messages/${MSG_ID}" \
+  -w "HTTP %{http_code}\n"
+```
+
+---
+
+# Calendar — Recipes
+
+### Get user timezone (run once at start of any calendar work)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/me/mailboxSettings" \
+  | jq '.timeZone'
+# → e.g. "China Standard Time"
+```
+
+Pass that timezone in the `Prefer: outlook.timezone` header on every
+calendar call so `start.dateTime` / `end.dateTime` come back rendered
+in the user's local time:
+
+```sh
+TZ_HEADER='Prefer: outlook.timezone="China Standard Time"'
+```
+
+### Today's agenda (calendarView)
+
+`calendarView` expands recurring series into individual occurrences
+within the window — exactly what you want for an agenda. Plain
+`/events` returns only the recurrence master.
+
+```sh
+START=$(date -u +'%Y-%m-%dT00:00:00Z')
+END=$(date -u -v+1d +'%Y-%m-%dT00:00:00Z')   # macOS; use -d on Linux
+curl -sS \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Prefer: outlook.timezone=\"China Standard Time\"" \
+  --data-urlencode "startDateTime=$START" \
+  --data-urlencode "endDateTime=$END" \
+  --data-urlencode '$select=id,subject,start,end,location,attendees,onlineMeeting,isCancelled' \
+  --data-urlencode '$orderby=start/dateTime' \
+  --get https://graph.microsoft.com/v1.0/me/calendarView \
+  | jq '.value[] | {subject, start: .start.dateTime, end: .end.dateTime, location: .location.displayName, attendees: [.attendees[].emailAddress.address]}'
+```
+
+### This week's events (Mon–Sun)
+
+```sh
+START=$(date -u -v-Mon +'%Y-%m-%dT00:00:00Z' 2>/dev/null || date -u -d 'last monday' +'%Y-%m-%dT00:00:00Z')
+END=$(date -u -v+7d -v-Mon +'%Y-%m-%dT00:00:00Z' 2>/dev/null || date -u -d 'next monday' +'%Y-%m-%dT00:00:00Z')
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Prefer: outlook.timezone=\"China Standard Time\"" \
+  --data-urlencode "startDateTime=$START" \
+  --data-urlencode "endDateTime=$END" \
+  --data-urlencode '$select=subject,start,end' \
+  --data-urlencode '$orderby=start/dateTime' \
+  --get https://graph.microsoft.com/v1.0/me/calendarView
+```
+
+### Find free / busy slots (`getSchedule`)
+
+Best way to find a slot that works for multiple people. Returns
+30-minute buckets of free / busy / tentative across the requested
+window.
+
+```sh
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc '{
+        schedules: ["me", "alice@example.com", "bob@example.com"],
+        startTime: {dateTime: "2026-05-05T09:00:00", timeZone: "China Standard Time"},
+        endTime:   {dateTime: "2026-05-05T18:00:00", timeZone: "China Standard Time"},
+        availabilityViewInterval: 30
+      }')" \
+  https://graph.microsoft.com/v1.0/me/calendar/getSchedule \
+  | jq '.value[] | {who: .scheduleId, view: .availabilityView}'
+# availabilityView is a string of digits: 0=free 1=tentative 2=busy 3=oof 4=workingElsewhere
+```
+
+### Read a single event (incl. attendees + body)
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Prefer: outlook.timezone=\"China Standard Time\"" \
+  "https://graph.microsoft.com/v1.0/me/events/${EVENT_ID}?\$select=subject,start,end,location,attendees,body,organizer,onlineMeeting" \
+  | jq '{subject, start: .start.dateTime, attendees: [.attendees[] | {addr: .emailAddress.address, response: .status.response}], body: .body.content}'
+```
+
+### Create an event
+
+> **⚠️ ALWAYS show subject / time / attendees to the user before
+> creating — invitations fire automatically the moment the event is
+> POSTed.**
+
+```sh
+PAYLOAD=$(jq -nc \
+  --arg subj "Project sync" \
+  --arg body "<p>Quarterly review.</p>" \
+  --arg start "2026-05-06T10:00:00" \
+  --arg end   "2026-05-06T10:30:00" \
+  --arg tz    "China Standard Time" \
+  --arg loc   "Meeting room 3F" \
+  --arg a1    "alice@example.com" \
+  '{
+    subject: $subj,
+    body:    {contentType:"HTML", content:$body},
+    start:   {dateTime:$start, timeZone:$tz},
+    end:     {dateTime:$end,   timeZone:$tz},
+    location:{displayName:$loc},
+    attendees:[{emailAddress:{address:$a1}, type:"required"}],
+    isOnlineMeeting: true,
+    onlineMeetingProvider: "teamsForBusiness"
+  }')
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" \
+  https://graph.microsoft.com/v1.0/me/events \
+  | jq '{id, subject, start: .start.dateTime, joinUrl: .onlineMeeting.joinUrl}'
+```
+
+`isOnlineMeeting: true` + `onlineMeetingProvider: "teamsForBusiness"`
+auto-generates a Teams meeting link. Drop both for an in-person event.
+
+### Update / reschedule (PATCH)
+
+> **⚠️ Updating sends an "Updated" notice to all attendees. Confirm first.**
+
+```sh
+curl -sS -X PATCH \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc \
+        --arg start "2026-05-06T14:00:00" \
+        --arg end   "2026-05-06T14:30:00" \
+        --arg tz    "China Standard Time" \
+        '{start:{dateTime:$start, timeZone:$tz}, end:{dateTime:$end, timeZone:$tz}}')" \
+  "https://graph.microsoft.com/v1.0/me/events/${EVENT_ID}"
+```
+
+### Cancel a meeting (sends cancellation notice)
+
+> **⚠️ Confirm with the user — every attendee is notified.**
+
+```sh
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"comment":"Need to reschedule, sorry."}' \
+  "https://graph.microsoft.com/v1.0/me/events/${EVENT_ID}/cancel" \
+  -w "HTTP %{http_code}\n"
+```
+
+### Accept / decline / tentative an incoming invite
+
+```sh
+curl -sS -X POST \
+  -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"comment":"See you there", "sendResponse":true}' \
+  "https://graph.microsoft.com/v1.0/me/events/${EVENT_ID}/accept"
+
+# Or /decline, /tentativelyAccept
+```
+
+### Read a shared calendar
+
+Requires `Calendars.Read.Shared`.
+
+```sh
+curl -sS -H "Authorization: Bearer $MICROSOFT_OUTLOOK_TOKEN" \
+  "https://graph.microsoft.com/v1.0/users/${USER_UPN}/calendarView?startDateTime=${START}&endDateTime=${END}&\$select=subject,start,end" \
+  -G
+```
+
+### Working with timezones
+
+| Field | Meaning |
+|---|---|
+| `start.dateTime` / `end.dateTime` | The local wall-clock time. |
+| `start.timeZone` / `end.timeZone` | IANA-ish name (`"Pacific Standard Time"`, `"China Standard Time"`, `"UTC"`). |
+| `Prefer: outlook.timezone="..."` request header | Re-renders all returned `dateTime` values into this zone. |
+
+Always set `Prefer: outlook.timezone` on read calls so the JSON arrives
+in the user's expected timezone instead of UTC.
+
+### Recurrence
+
+Use `calendarView` (it expands occurrences for you) — not `?$expand=`.
+To create a recurring event, include `recurrence`:
+
+```json
+{
+  "recurrence": {
+    "pattern":  {"type":"weekly", "interval":1, "daysOfWeek":["monday","wednesday"]},
+    "range":    {"type":"endDate", "startDate":"2026-05-06", "endDate":"2026-08-06"}
+  }
+}
+```
+
+To modify a single occurrence of a series, PATCH that occurrence's id
+(returned by `calendarView`), NOT the series master.
+
+---
+
+# OData quick reference (mail + calendar)
+
+| Param | Mail example | Calendar example |
+|---|---|---|
+| `$select` | `id,subject,from,receivedDateTime,isRead` | `subject,start,end,location,attendees` |
+| `$filter` | `isRead eq false` | `start/dateTime ge '2026-05-01T00:00:00'` |
+| `$orderby` | `receivedDateTime desc` | `start/dateTime` |
+| `$top` | `10` browse, `25` search | `10` browse |
+| `$search` | `"keyword"` (mail only — cannot combine with $filter / $orderby) | n/a |
+| `$expand` | `attachments` | `attendees`, `attachments` |
+
+Use `--data-urlencode "$key=$value" --get` with curl to avoid
+shell-quoting `$` and spaces.
+
+# Rules
+
+- **Always pass `$select`** — defaults return 30+ fields per item.
+- **`$top=10`** for browse, `25` for search. Don't paginate past 50 unless asked.
+- **HTML bodies only** for mail. `contentType: "Text"` collapses whitespace.
+- **Use `calendarView`** for any agenda / "what's on my calendar"
+  question. `/events` returns recurrence masters only.
+- **Set `Prefer: outlook.timezone`** on calendar read calls; otherwise
+  `dateTime` comes back in UTC.
+- **URL-encode message / event / attachment IDs** if using them in a
+  path — IDs can contain `+`, `/`, `=`. Use `jq -sRr @uri`.
+- **Date math**: `date -u -v+1d` works on macOS, `date -u -d 'tomorrow'` on Linux.
+
+# CRITICAL: User consent for destructive / notifying actions
+
+**Sent emails cannot be unsent. Calendar writes fan out emails to
+attendees. Deleted messages may be permanently lost.**
+Pattern: **prepare → present → execute**.
+
+| Action | Prepare step | Show user |
+|---|---|---|
+| Send mail | `POST /me/messages` (draft) | subject, recipients, body preview |
+| Reply / forward | createReply / createForward | quote snippet + your reply text |
+| Delete mail | fetch `subject` first | "Delete '{subject}' from {sender}?" |
+| Out-of-office | show current setting first | new schedule + message preview |
+| Create event | build payload | subject, time, attendees, online-meeting on/off |
+| Update event | diff with current | what's changing, attendee count being notified |
+| Cancel event | fetch event first | subject, time, attendee count |
+| Accept / decline invite | fetch event first | event subject + organizer |
+| Bulk | list affected | count + sample |
+
+**Never call `/me/sendMail`** — it sends immediately with no undo. Always draft → confirm → `/send`.
+
+# Errors
+
+- `401 InvalidAuthenticationToken` → token expired; user must reinstall the connector.
+- `403 ErrorAccessDenied` → write scope missing (e.g. trying `Mail.Send` without it granted, or `Calendars.ReadWrite` for create / cancel); ask user to reinstall and tick the write scope.
+- `429 TooManyRequests` → respect `Retry-After` header.
+- `404 ErrorItemNotFound` → wrong message / event id (or it was already deleted / cancelled).
+
+# Reference
+
+- Mail API: <https://learn.microsoft.com/en-us/graph/api/resources/mail-api-overview>
+- Message resource: <https://learn.microsoft.com/en-us/graph/api/resources/message>
+- Calendar resource: <https://learn.microsoft.com/en-us/graph/api/resources/calendar>
+- Event resource: <https://learn.microsoft.com/en-us/graph/api/resources/event>
+- calendarView: <https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview>
+- getSchedule: <https://learn.microsoft.com/en-us/graph/api/calendar-getschedule>
+- MailboxSettings: <https://learn.microsoft.com/en-us/graph/api/resources/mailboxsettings>

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: notion
+description: Search, read, append to, and create Notion pages and databases via the Notion REST API. Use when the user mentions Notion, a page in their workspace, or wants to log something to a database.
+when_to_use: |
+  Trigger when the user wants to read or write something in Notion —
+  search a workspace, read a page, append blocks, query a database,
+  create a page from a template, etc.
+connections: [notion]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+We drive the [Notion API](https://developers.notion.com/reference) with
+`curl + jq`. The user's OAuth bearer token is in `$NOTION_TOKEN`; every
+call needs it plus the `Notion-Version` header.
+
+Notion-Version is currently `2022-06-28` (the most recent stable). Bump
+this header when Notion ships a new version.
+
+The user's connection only sees the pages and databases they explicitly
+shared with the integration when they authorized. If a search or page
+read returns nothing, the most likely cause is "the page was never
+shared with the integration" — surface that hint to the user.
+
+## Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS https://api.notion.com/v1/users/me \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  | jq '{id, name, type, bot: (.bot != null)}'
+```
+
+### Search the workspace
+
+```sh
+curl -sS https://api.notion.com/v1/search \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Q1 budget", "page_size": 10}' \
+  | jq '.results[] | {id, type: .object, url, title: (.properties.title // .properties.Name)?.title?[0]?.plain_text // .child_page?.title}'
+```
+
+### Read a page (metadata only)
+
+```sh
+curl -sS "https://api.notion.com/v1/pages/PAGE_ID" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28"
+```
+
+### Read a page's full content
+
+```sh
+curl -sS "https://api.notion.com/v1/blocks/PAGE_ID/children?page_size=100" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  | jq '.results[] | {type, content: (.[.type] // {})}'
+```
+
+### Append a paragraph to a page
+
+```sh
+curl -sS -X PATCH "https://api.notion.com/v1/blocks/PAGE_ID/children" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc --arg text "Appended via the assistant." '
+    {children: [{
+      object: "block",
+      type: "paragraph",
+      paragraph: {rich_text: [{type:"text", text:{content:$text}}]}
+    }]}')"
+```
+
+### Query a database
+
+```sh
+curl -sS -X POST "https://api.notion.com/v1/databases/DATABASE_ID/query" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "filter": {"property": "Status", "select": {"equals": "Open"}},
+    "sorts":  [{"property": "Updated", "direction": "descending"}],
+    "page_size": 25
+  }'
+```
+
+### Create a page in a database
+
+```sh
+curl -sS -X POST "https://api.notion.com/v1/pages" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -nc \
+        --arg db "DATABASE_ID" \
+        --arg title "New entry" \
+        '{
+          parent: {database_id: $db},
+          properties: {
+            Name:   {title: [{text: {content: $title}}]},
+            Status: {select: {name: "Open"}}
+          }
+        }')"
+```
+
+## Notes
+
+- Notion's pagination is cursor-based: append `start_cursor=$cursor` to
+  paginate, using the `next_cursor` from each response. Stop when
+  `has_more` is `false`.
+- Most write failures (400/404) come from a property type mismatch —
+  e.g. sending `{"select": "Open"}` instead of `{"select": {"name": "Open"}}`.
+  Read the database schema once via `GET /v1/databases/<id>` if unsure.

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: slack
+description: Send messages, search history, and manage channels via Slack's Web API. Use when the user mentions Slack, a channel, a DM, or wants to post to a specific user/group.
+when_to_use: |
+  Trigger when the user wants to read or write something in Slack —
+  send a message to a channel/DM, search history, list channels,
+  upload a file, etc.
+connections: [slack]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+There is no first-party Slack CLI fit for daily use, so we drive the
+[Slack Web API](https://api.slack.com/methods) with `curl + jq`. The
+user's OAuth bearer token is in `$SLACK_TOKEN`; every call needs it as
+`Authorization: Bearer $SLACK_TOKEN`.
+
+The Slack API ALWAYS returns 200 — check the JSON `ok` field for success.
+A failed call has `{"ok": false, "error": "<reason>"}`. Surface the
+`error` value verbatim to the user when it occurs.
+
+**Always start with `auth.test`** to confirm the connection works AND
+to learn what bot user / team you're posting as. Many subsequent calls
+need the bot's user id (`auth.test` returns `user_id`).
+
+## Recipes
+
+### Verify auth (always run first)
+
+```sh
+curl -sS -H "Authorization: Bearer $SLACK_TOKEN" \
+  https://slack.com/api/auth.test
+# {"ok": true, "team": "...", "team_id": "...", "user": "<bot>", "user_id": "U..."}
+```
+
+### Resolve a channel name to its ID (you'll need this a lot)
+
+```sh
+curl -sS -H "Authorization: Bearer $SLACK_TOKEN" \
+  "https://slack.com/api/conversations.list?limit=1000&types=public_channel,private_channel" \
+  | jq -r --arg name "general" '.channels[] | select(.name == $name) | .id'
+```
+
+### Post a message
+
+```sh
+curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$(jq -nc \
+        --arg ch "C0123456789" \
+        --arg text "Deploy complete." \
+        '{channel:$ch, text:$text}')"
+```
+
+### Reply in a thread
+
+```sh
+curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$(jq -nc \
+        --arg ch "C0123456789" \
+        --arg ts "1777656720.123456" \
+        --arg text "Thanks!" \
+        '{channel:$ch, thread_ts:$ts, text:$text}')"
+```
+
+### Search messages
+
+```sh
+curl -sS -G \
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  "https://slack.com/api/search.messages" \
+  --data-urlencode "query=in:#engineering deploy" \
+  --data-urlencode "count=20"
+```
+
+### Send a DM to a user (by email)
+
+```sh
+USER_ID=$(curl -sS -G -H "Authorization: Bearer $SLACK_TOKEN" \
+  "https://slack.com/api/users.lookupByEmail" \
+  --data-urlencode "email=alice@example.com" \
+  | jq -r '.user.id')
+
+# DM channels are auto-created the first time you postMessage to a user id.
+curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$(jq -nc --arg ch "$USER_ID" --arg text "Hi from the bot." '{channel:$ch, text:$text}')"
+```
+
+### Upload a file to a channel
+
+Two-step: create an upload URL, then complete.
+
+```sh
+UPLOAD=$(curl -sS -G -H "Authorization: Bearer $SLACK_TOKEN" \
+  "https://slack.com/api/files.getUploadURLExternal" \
+  --data-urlencode "filename=report.pdf" \
+  --data-urlencode "length=$(wc -c < report.pdf)")
+URL=$(echo "$UPLOAD" | jq -r '.upload_url')
+ID=$(echo "$UPLOAD" | jq -r '.file_id')
+
+curl -sS -T report.pdf "$URL"
+
+curl -sS -X POST https://slack.com/api/files.completeUploadExternal \
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d "$(jq -nc --arg fid "$ID" --arg ch "C0123456789" \
+        '{files:[{id:$fid, title:"report.pdf"}], channel_id:$ch}')"
+```
+
+## Notes
+
+- **`chat.postMessage` to a public channel requires the bot to be a
+  member of that channel.** If you get `not_in_channel`, call
+  `conversations.join` first (which also takes the channel id), then
+  retry. Private channels and DMs need a manual invite — ask the user.
+- Always check `.ok` on the JSON response. `not_authed` / `invalid_auth`
+  → ask the user to re-authorize at `auth.acedata.cloud/user/connections`.
+- Channel ids start with `C` (channels), `D` (DMs), `G` (private). Don't
+  invent ids — always look them up via `conversations.list` or
+  `users.lookupByEmail`.
+- Slack rate-limits aggressively; `Retry-After` is in the response
+  headers if you get a 429. Sleep and retry rather than parallelizing.

--- a/skills/wechat-official-account/SKILL.md
+++ b/skills/wechat-official-account/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: wechat-official-account
+description: Generate articles, manage drafts, publish to «发表记录», send customer-service messages, manage menus and pull stats on a WeChat Official Account (微信公众号 / 服务号 / 订阅号) via the WeChat MP server-side API. Use when the user mentions 公众号, 服务号, 订阅号, mp.weixin.qq.com, AppID/AppSecret of a WeChat Official Account, or asks to draft / publish / send a customer message via WeChat.
+when_to_use: |
+  Trigger when the user wants to do anything with their WeChat
+  Official Account: turn a chat conversation into a draft article,
+  list / publish / delete drafts, send a 48-hour-window customer
+  service message to a follower (by openid), upload images that will
+  appear inside an article body, manage the bottom menu, look up
+  follower stats, etc.
+connections: [wechat]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+We drive the [WeChat MP server-side API](https://developers.weixin.qq.com/doc/service/guide/) with `curl + jq`. Unlike OAuth-bearer connectors, WeChat MP uses a two-step flow:
+
+1. Exchange `AppID + AppSecret` for an `access_token` (TTL 7200s, **global limit ≈ 2000 calls/day per app**).
+2. Pass that `access_token` as a **query string parameter** on every other call.
+
+The user's credentials are in `$WECHAT_APP_ID` and `$WECHAT_APP_SECRET`. **Never log or echo `$WECHAT_APP_SECRET`** — treat it like a password.
+
+The WeChat MP API returns standard JSON. **Errors are returned with HTTP 200**; the body looks like `{"errcode": 40013, "errmsg": "invalid appid"}`. `errcode == 0` means success — show the original `errmsg` to the user verbatim on any non-zero code.
+
+## Important constraints — surface these to the user before they're surprised
+
+- **IP whitelist**: every API call's source IP must be in this app's IP whitelist (公众平台 → 设置与开发 → 基本配置 → IP 白名单). If you see `errcode 40164` ("invalid ip"), the worker's egress IP isn't whitelisted; tell the user to add the IP shown in `errmsg` and retry.
+- **Verified account required for publishing**: as of 2025-07, only **verified (已认证) corporate-subject** accounts can call `freepublish/*` and `mass/*`. Personal-subject accounts and unverified corporate accounts get a permission error. Drafts (`draft/*`) and customer messages (`message/custom/*`) usually work without verification.
+- **Group-send quota is harsh**: 服务号 = 4 sends/month, 订阅号 = 1 send/day. Treat `freepublish/submit` and `mass/sendall` like a **destructive operation** — *always* confirm with the user before calling them, even if instructions say "publish it". Default to creating a draft and pasting the draft URL.
+- **Customer-service window is 48 hours**: `message/custom/send` only works for a follower whose `openid` interacted with the account in the last 48 hours. Outside that window you get `errcode 45015`.
+
+## Recipes
+
+### Step 0 — get an access_token (do this first, cache the result)
+
+```sh
+# Cache to /tmp so subsequent calls in the same session reuse it.
+TOKEN_CACHE="/tmp/wx-mp-token-${WECHAT_APP_ID}.json"
+
+# Reuse cached token if it's still valid (we conservatively refresh
+# 5 minutes early to avoid edge-of-window failures).
+NOW=$(date +%s)
+if [ -f "$TOKEN_CACHE" ] && [ "$(jq -r '.exp_at // 0' "$TOKEN_CACHE")" -gt "$((NOW + 300))" ]; then
+  WECHAT_ACCESS_TOKEN=$(jq -r '.access_token' "$TOKEN_CACHE")
+else
+  RESP=$(curl -sS "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${WECHAT_APP_ID}&secret=${WECHAT_APP_SECRET}")
+  WECHAT_ACCESS_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
+  if [ -z "$WECHAT_ACCESS_TOKEN" ]; then
+    echo "Failed to fetch access_token: $RESP" >&2
+    exit 1
+  fi
+  EXPIRES=$(echo "$RESP" | jq -r '.expires_in // 7200')
+  jq -nc --arg t "$WECHAT_ACCESS_TOKEN" --argjson e "$((NOW + EXPIRES))" \
+    '{access_token:$t, exp_at:$e}' > "$TOKEN_CACHE"
+fi
+echo "OK token=${WECHAT_ACCESS_TOKEN:0:8}…"
+```
+
+If the response is `{"errcode": 40164, ...}` (invalid IP) or `{"errcode": 40013, ...}` (invalid appid) — surface that error to the user; it means the connector setup itself is wrong, not the request.
+
+### Verify the connection (always run this once before complex operations)
+
+```sh
+# Pull basic public-account self-info; cheapest call that proves the token works.
+curl -sS "https://api.weixin.qq.com/cgi-bin/account/getaccountbasicinfo?access_token=${WECHAT_ACCESS_TOKEN}" | jq
+```
+
+### Upload an image to use *inside* an article body (returns a public URL)
+
+This is for `<img src="...">` tags inside the article HTML. The returned `url` is hosted by Tencent and works in published articles.
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/media/uploadimg?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -F "media=@/path/to/your-image.jpg"
+# → {"url": "http://mmbiz.qpic.cn/..."}
+```
+
+Limits: ≤ 1 MB, JPG/PNG only, no count limit on this endpoint.
+
+### Upload a thumbnail (needed as the article cover)
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/material/add_material?access_token=${WECHAT_ACCESS_TOKEN}&type=thumb" \
+  -F "media=@/path/to/cover.jpg" | jq '{media_id, url}'
+# → {"media_id": "MEDIA_ID", "url": "http://mmbiz.qpic.cn/..."}
+```
+
+The `media_id` you get back is what you pass as `thumb_media_id` when creating a draft.
+Recommended cover dimensions: 900×500 px, JPG, < 64 KB ideally.
+
+### Create a draft (the safe default — *do not* directly publish)
+
+```sh
+TITLE="Q1 product update"
+AUTHOR="Acme Inc."
+THUMB_MEDIA_ID="MEDIA_ID_FROM_PREVIOUS_STEP"
+CONTENT_HTML='<p>欢迎关注我们的最新动态。</p><p><img src="http://mmbiz.qpic.cn/..."></p><p>更多内容请见底部「阅读原文」。</p>'
+DIGEST="Q1 has been a wild ride — here's what shipped."
+SOURCE_URL="https://example.com/q1-recap"   # optional; populates 「阅读原文」, leave empty to omit
+
+PAYLOAD=$(jq -nc \
+  --arg title       "$TITLE" \
+  --arg author      "$AUTHOR" \
+  --arg thumb       "$THUMB_MEDIA_ID" \
+  --arg content     "$CONTENT_HTML" \
+  --arg digest      "$DIGEST" \
+  --arg source_url  "$SOURCE_URL" \
+  '{articles: [{
+    article_type: "news",
+    title: $title,
+    author: $author,
+    thumb_media_id: $thumb,
+    content: $content,
+    digest: $digest,
+    content_source_url: $source_url,
+    need_open_comment: 0,
+    only_fans_can_comment: 0
+  }]}')
+
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/draft/add?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$PAYLOAD" | jq
+# → {"media_id": "DRAFT_MEDIA_ID"}
+```
+
+Tell the user: *"Draft created. Open https://mp.weixin.qq.com → 草稿箱 to review and tap «发表» from there."* — that's the safest path because the user controls the publish click in WeChat's own UI.
+
+### List drafts (newest first)
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/draft/batchget?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw '{"offset": 0, "count": 20, "no_content": 1}' \
+  | jq '.item[] | {media_id, update_time, title: .content.news_item[0].title}'
+```
+
+### Get the full content of one draft
+
+```sh
+DRAFT_MEDIA_ID="..."
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/draft/get?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg m "$DRAFT_MEDIA_ID" '{media_id: $m}')" | jq
+```
+
+### Update an existing draft
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/draft/update?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg m "$DRAFT_MEDIA_ID" --arg t "Updated title" --arg c "<p>new body</p>" --arg th "$THUMB_MEDIA_ID" '
+    {media_id: $m, index: 0, articles: {
+      title: $t, content: $c, thumb_media_id: $th
+    }}')" | jq
+```
+
+### Publish a draft to «发表记录» — DESTRUCTIVE, confirm before calling
+
+```sh
+# Eats one of the monthly publish slots. Always echo back to the user
+# what's about to go live and require an explicit "yes" confirmation
+# in conversation BEFORE invoking this.
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/freepublish/submit?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg m "$DRAFT_MEDIA_ID" '{media_id: $m}')" | jq
+# → {"errcode": 0, "msg_data_id": ..., "publish_id": "..."}
+```
+
+Then poll publish status (publishing is async, takes ~5-30 seconds):
+
+```sh
+PUBLISH_ID="..."
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/freepublish/get?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg p "$PUBLISH_ID" '{publish_id: $p}')" | jq '{publish_status, fail_idx, article_id, article_url: .article_detail.item[0].article_url}'
+# publish_status: 0 = success, 1 = publishing, 2 = original-check-failed,
+#                 3 = failed, 4 = published-but-removed, 5 = unverified-removed
+```
+
+When `publish_status == 0`, return `article_detail.item[0].article_url` to the user — that's the canonical https://mp.weixin.qq.com/s/... URL.
+
+### List already-published articles
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/freepublish/batchget?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw '{"offset": 0, "count": 20, "no_content": 1}' \
+  | jq '.item[] | {article_id, update_time, title: .content.news_item[0].title, url: .content.news_item[0].url}'
+```
+
+### Send a customer-service message (one specific follower, 48h window)
+
+```sh
+OPENID="oXXXXXXXXXXXXXXXXX"   # the recipient follower's openid
+TEXT="Hi! Your subscription has been renewed. Thanks for sticking with us."
+
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg u "$OPENID" --arg t "$TEXT" '
+    {touser: $u, msgtype: "text", text: {content: $t}}')" | jq
+```
+
+`errcode 45015` = recipient hasn't messaged the account in the last 48h — explain that to the user; there's nothing the API can do about it.
+
+To send an article card via customer message, change to `msgtype: "mpnews"` with `mpnews: {media_id: "..."}` (use `material/add_news` to first create a permanent news media_id).
+
+### Pull follower-growth + read stats
+
+```sh
+BEGIN="2026-04-25"
+END="2026-05-01"   # max 7-day window for getusersummary
+
+# New / unsubscribed / cumulative followers per day
+curl -sS -X POST \
+  "https://api.weixin.qq.com/datacube/getusersummary?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg b "$BEGIN" --arg e "$END" '{begin_date: $b, end_date: $e}')" \
+  | jq '.list[] | {date: .ref_date, new: .new_user, lost: .cancel_user, source: .user_source}'
+
+# Article reads per day (max 3-day window for getuserread)
+curl -sS -X POST \
+  "https://api.weixin.qq.com/datacube/getuserread?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$(jq -nc --arg b "$BEGIN" --arg e "$BEGIN" '{begin_date: $b, end_date: $e}')" | jq
+```
+
+`datacube/*` requires an authenticated (已认证) account with the data-cube permission.
+
+### Manage the bottom menu
+
+```sh
+# Read current menu
+curl -sS "https://api.weixin.qq.com/cgi-bin/menu/get?access_token=${WECHAT_ACCESS_TOKEN}" | jq
+
+# Replace the menu (max 3 top-level buttons; each top-level button can have ≤ 5 sub-buttons)
+MENU=$(jq -nc '{
+  button: [
+    {type: "click", name: "今日推荐", key: "DAILY_REC"},
+    {name: "更多",
+     sub_button: [
+       {type: "view", name: "官网",   url: "https://example.com"},
+       {type: "view", name: "联系我们", url: "https://example.com/contact"}
+     ]}
+  ]
+}')
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/menu/create?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw "$MENU" | jq
+# → {"errcode": 0, "errmsg": "ok"}
+```
+
+### Get the follower list (paginated by next_openid)
+
+```sh
+NEXT=""
+curl -sS "https://api.weixin.qq.com/cgi-bin/user/get?access_token=${WECHAT_ACCESS_TOKEN}&next_openid=${NEXT}" \
+  | jq '{total, count, openids: .data.openid, next: .next_openid}'
+# Loop: pass the returned `next_openid` as NEXT until count < 10000.
+```
+
+For each openid, batch-fetch profile (≤ 100 per call):
+
+```sh
+curl -sS -X POST \
+  "https://api.weixin.qq.com/cgi-bin/user/info/batchget?access_token=${WECHAT_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data-raw '{"user_list": [{"openid": "OPENID1", "lang": "zh_CN"}]}' \
+  | jq '.user_info_list[] | {openid, nickname, subscribe_time, tagid_list}'
+```
+
+## HTML rules for article `content`
+
+The `content` field in `draft/add` accepts a *subset* of HTML, not full web HTML:
+
+- Allowed: `<p>`, `<span>`, `<strong>`, `<em>`, `<a href>`, `<img src>`, `<br>`, `<h1>`–`<h3>`, `<ul>/<ol>/<li>`, `<blockquote>`, `<section>`.
+- **Inline styles only** (`<p style="...">`) — no `<style>` blocks, no `<link>` to external CSS.
+- All `<img>` `src` URLs **must** be either previously-uploaded `mmbiz.qpic.cn` URLs (from `media/uploadimg`) or already-published `mmbiz` URLs. WeChat strips images hosted on third-party domains.
+- Total content size limit: ~ 20 K characters (HTML included).
+
+## Common errcode cheat-sheet
+
+| errcode | meaning | what to tell the user |
+|---|---|---|
+| 0 | success | — |
+| 40001 | invalid access_token | Token expired mid-call; flush `$TOKEN_CACHE` and retry |
+| 40013 | invalid appid | The AppID in the connector is wrong — re-add the connection |
+| 40164 | source IP not in whitelist | Add the IP shown in `errmsg` to 公众平台 → 设置与开发 → 基本配置 → IP白名单 |
+| 41001 | missing access_token | Bug — you forgot to pass `?access_token=...` |
+| 45009 | API daily quota exceeded | Try again tomorrow; the per-app daily quota was hit |
+| 45015 | response message out of 48h | Customer-service window has closed for this openid; can't recover via API |
+| 48001 | api unauthorized | Account doesn't have permission for this endpoint (e.g. publish without 认证); see the doc URL in errmsg |
+| 61450 | system error | Tencent-side flake; retry once after a 1-second backoff |
+
+## Why we use bare `curl + jq` (not an SDK)
+
+Skill bodies must be self-contained shell. Calling `pip install wechatpy` is not allowed in the sandbox, and the API surface here is small (15-ish endpoints) and stable since 2018. The python SDKs ([wechatpy](https://github.com/wechatpy/wechatpy), werobot) are useful references for parameter shapes, but every recipe above is a direct call to the documented endpoint — the SDKs are just thin wrappers around the same JSON.


### PR DESCRIPTION
## Summary

Two-commit branch:

1. **`feat(connectors): add 11 connector skills`** (existing, from earlier work) — the original SKILL.md files for github, gitlab, google-{drive,gmail,calendar,tasks}, microsoft-{onedrive,outlook}, notion, slack, wechat-mp.

2. **`feat(skills): add write recipes to google-drive/gmail/calendar/tasks`** (this round) — extends the four Google skills so they document the optional read+write scopes the connector now requests, instead of only the readonly flows.

## What changed in round 2

For each Google skill:

- Frontmatter `description` and `when_to_use` rewritten to mention writes + clarify that the broader scope is opt-in at install time (`*.readonly` is always granted; the user checks the read+write box in the connector's permission picker).
- Intro paragraph: "the token *at minimum* carries `*.readonly`; if the user opted in to write, it also carries the broader write scope."
- Error-code tables updated so 403 `insufficientPermissions` points the user at re-installing with the right write box checked, instead of "this connector is read-only".
- New **Write recipes** section after the existing read recipes:

| skill | new recipes |
|---|---|
| google-drive | rename, move, create folder, multipart upload, media-replace, trash/restore, bulk-move-with-confirm |
| google-gmail | mark read / star / archive / label, custom labels, trash thread, send (RFC 2822 + base64url), in-thread reply with `In-Reply-To`/`References`/`threadId`, save draft |
| google-calendar | create single + recurring events with optional Meet link, PATCH update, reschedule, attendee mutation, cancel/delete with `sendUpdates` |
| google-tasks | add, bulk-add-with-confirm, complete/uncomplete, edit, delete, move/reposition, create new list |

## Mirrors

`.agents/skills` and `.github/skills` are git symlinks to `../skills`, so the edits propagate automatically — no manual copy step.

## Verification

- `npm run validate` (the repo's `validate.yml` workflow) passes the structural checks: SKILL.md exists, frontmatter has `name` ≤ 64 chars, `description` ≤ 1024 chars, `name` matches directory.
- Line count check: each skill is now ~250–375 lines (over the recommended 500-line *warning* threshold? No — well under).

## Coordination

Companion PRs:

- AuthBackend [#116](https://github.com/AceDataCloud/AuthBackend/pull/116) — adds the matching `gmail.modify` / `gmail.send` / `drive` / `calendar` / `tasks` scopes to the connector seeds so the user can grant them at install.
- PlatformService [#837](https://github.com/AceDataCloud/PlatformService/pull/837) — mirrors these recipes into `aichat2/worker/src/skills/builtin/google-*` (the runtime copy that the AI chat actually executes).
