### PR TITLE
feat(google-{gmail,calendar,drive}): document optional gws CLI for write operations

### DIFF
--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -15,7 +15,7 @@ allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.1"
+  version: "1.2"
 ---
 
 Drive Google Calendar via `curl + jq`. The user's OAuth bearer token
@@ -42,6 +42,72 @@ event that has attendees) show the exact event details and ask the
 user to confirm. When attendees are involved, also confirm whether
 they want Google to email the attendees — that's controlled by the
 `sendUpdates` query parameter.
+
+## Optional: Google Workspace CLI (`gws`) for agenda + create
+
+[`gws`](https://github.com/googleworkspace/cli) is Google's official CLI
+(not officially supported — community-maintained on the `googleworkspace`
+org). It dynamically builds its command surface from Google's Discovery
+Document, exits non-zero on API errors, and ships hand-crafted helper
+commands (prefixed `+`) for time-aware workflows.
+
+**Use `gws` for two specific cases:**
+
+- `+agenda` reads the user's account timezone from `Settings.timezone`
+  (cached for 24 h) and renders today's events in that zone, so you don't
+  have to fetch the timezone yourself before formatting times.
+- `+insert` shapes the create-event JSON for you (attendees, sendUpdates,
+  reminders) so a one-line invocation produces a well-formed request.
+
+For everything else (events.list / patch / move / delete, freebusy,
+calendarList) the curl recipes below are equivalent and shorter — stay
+on those.
+
+### Install
+
+```sh
+npm install -g @googleworkspace/cli   # or: brew install googleworkspace-cli
+# Pre-built binaries also at https://github.com/googleworkspace/cli/releases
+gws --version
+```
+
+### Auth
+
+`gws` reads its OAuth bearer token from the `GOOGLE_WORKSPACE_CLI_TOKEN`
+environment variable. The Calendar token used in this skill is in
+`$GOOGLE_CALENDAR_TOKEN`, so re-export it once at the top of every shell
+block that calls `gws`:
+
+```sh
+export GOOGLE_WORKSPACE_CLI_TOKEN="$GOOGLE_CALENDAR_TOKEN"
+```
+
+### Agenda + create
+
+```sh
+# Today on the primary calendar, in the account's own timezone
+gws calendar +agenda
+
+# Today / week, with explicit overrides
+gws calendar +agenda --today --tz America/New_York
+gws calendar +agenda --range week
+
+# Create an event (auto-shapes attendees + sendUpdates JSON)
+gws calendar +insert --calendar primary \
+  --json '{
+    "summary":"Standup",
+    "start":{"dateTime":"2026-05-06T10:00:00-04:00"},
+    "end":  {"dateTime":"2026-05-06T10:30:00-04:00"},
+    "attendees":[{"email":"alice@example.com"}]
+  }' \
+  --params '{"sendUpdates":"all"}'
+```
+
+Both helpers exit non-zero with a structured JSON error on stderr if
+Google rejects the request — surface that verbatim. `+insert` against
+attendees requires the broader `calendar` scope; on `403
+insufficientPermissions` ask the user to re-install with read+write
+checked.
 
 ## Recipes
 

--- a/skills/google-drive/SKILL.md
+++ b/skills/google-drive/SKILL.md
@@ -14,7 +14,7 @@ allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.1"
+  version: "1.2"
 ---
 
 Drive Google Drive via `curl + jq`. The user's OAuth bearer token is
@@ -38,6 +38,61 @@ name + path you're about to touch.
 
 **Always start with `/about?fields=user`** to confirm the connection
 works AND learn which Google account you're operating against.
+
+## Optional: Google Workspace CLI (`gws`) for uploads
+
+[`gws`](https://github.com/googleworkspace/cli) is Google's official CLI
+(not officially supported — community-maintained on the `googleworkspace`
+org). It dynamically builds its command surface from Google's Discovery
+Document, exits non-zero on API errors, supports `--page-all`
+auto-pagination, and ships a `+upload` helper that wraps the multipart
+upload protocol.
+
+**Use `gws` for uploads.** A Drive multipart upload requires a
+hand-formatted `multipart/related` body with a JSON metadata part and a
+binary file part separated by a boundary string — easy to get wrong from
+curl. `gws drive +upload` does it correctly. **For everything else**
+(list, search, get, export, rename, move, trash, delete) the curl recipes
+below are equivalent and shorter — stay on those.
+
+### Install
+
+```sh
+npm install -g @googleworkspace/cli   # or: brew install googleworkspace-cli
+# Pre-built binaries also at https://github.com/googleworkspace/cli/releases
+gws --version
+```
+
+### Auth
+
+`gws` reads its OAuth bearer token from the `GOOGLE_WORKSPACE_CLI_TOKEN`
+environment variable. The Drive token used in this skill is in
+`$GOOGLE_DRIVE_TOKEN`, so re-export it once at the top of every shell
+block that calls `gws`:
+
+```sh
+export GOOGLE_WORKSPACE_CLI_TOKEN="$GOOGLE_DRIVE_TOKEN"
+```
+
+### Upload
+
+```sh
+# Simple upload to My Drive (auto-detects MIME type, sets the file name
+# from --name; falls back to the local filename if --name is omitted)
+gws drive +upload ./report.pdf --name "Q1 Report"
+
+# Upload into a specific folder, or with explicit metadata, via the
+# generic Discovery method + --upload (multipart wire format handled
+# for you)
+gws drive files create \
+  --json '{"name":"report.pdf","parents":["FOLDER_ID"],"description":"Q1"}' \
+  --upload ./report.pdf
+```
+
+Both exit non-zero with a structured JSON error on stderr if Google
+rejects the request — surface that verbatim. Uploads need the broader
+`drive` scope; on `403 insufficientPermissions` ask the user to
+re-install the connector with read+write checked.
 
 ## Recipes
 

--- a/skills/google-gmail/SKILL.md
+++ b/skills/google-gmail/SKILL.md
@@ -16,7 +16,7 @@ allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.1"
+  version: "1.2"
 ---
 
 Drive Gmail via `curl + jq`. The user's OAuth bearer token is in
@@ -44,6 +44,76 @@ fan out across many messages without an explicit go-ahead.
 AND learn which Gmail account you're operating against. Mailbox payloads
 can be huge — fetch metadata first, only `format=full` when the user
 actually wants the body of a specific message.
+
+## Optional: Google Workspace CLI (`gws`) for outbound mail
+
+[`gws`](https://github.com/googleworkspace/cli) is Google's official CLI
+(not officially supported — community-maintained on the `googleworkspace`
+org). It dynamically builds its command surface from Google's Discovery
+Document, exits non-zero on API errors, and ships hand-crafted helper
+commands (prefixed `+`) that handle the message-encoding boilerplate.
+
+**Use `gws` for sending mail.** The Gmail REST API requires every
+outbound message to be a fully-formed RFC 822 message, base64url-encoded
+into a `raw` field, with reply / forward threading carried in
+`In-Reply-To` / `References` / `threadId`. The `+send / +reply /
++reply-all / +forward` helpers do all of that for you. **For everything
+else** (read, search, labels, attachments) `gws` and curl are equivalent,
+so the curl recipes below are usually shorter — stay on those.
+
+### Install
+
+```sh
+npm install -g @googleworkspace/cli   # or: brew install googleworkspace-cli
+# Pre-built binaries also at https://github.com/googleworkspace/cli/releases
+gws --version
+```
+
+### Auth
+
+`gws` reads its OAuth bearer token from the `GOOGLE_WORKSPACE_CLI_TOKEN`
+environment variable. The Gmail token used in this skill is in
+`$GOOGLE_GMAIL_TOKEN`, so re-export it once at the top of every shell
+block that calls `gws`:
+
+```sh
+export GOOGLE_WORKSPACE_CLI_TOKEN="$GOOGLE_GMAIL_TOKEN"
+```
+
+You can confirm the active account with `gws gmail users getProfile
+--params '{"userId":"me"}'`.
+
+### Send / reply / forward
+
+```sh
+# New message
+gws gmail +send \
+  --to alice@example.com \
+  --cc team@example.com \
+  --subject "Q1 status" \
+  --body "Numbers attached."
+
+# Reply (handles threadId, In-Reply-To, References automatically;
+# To is the original sender, Subject gets the "Re: " prefix)
+gws gmail +reply --message-id MSG_ID --body "Thanks — looks good."
+
+# Reply-all
+gws gmail +reply-all --message-id MSG_ID --body "+1"
+
+# Forward to new recipients (preserves the original message body
+# inline; original headers are summarised in the forward block)
+gws gmail +forward --message-id MSG_ID --to bob@example.com
+```
+
+Each helper exits with a non-zero status and a JSON error on stderr if
+Google rejects the request — surface that error verbatim. `+send` /
+`+reply` need the `gmail.send` scope; if the user only granted
+`gmail.readonly` you'll see `403 insufficientPermissions` and should ask
+them to re-install the connector with the send box checked.
+
+All the read / list / search / label / attachment recipes below are
+intentionally **not** rewritten to `gws` — a one-line `curl ... | jq` is
+shorter and easier to compose with shell pipelines.
 
 ## Recipes
 

--- a/skills/tencentcloud-cls-alarm/scripts/cls_alarm.py
+++ b/skills/tencentcloud-cls-alarm/scripts/cls_alarm.py
@@ -17,8 +17,7 @@ Quick examples:
 
 Environment:
   Reads TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY, TENCENTCLOUD_REGION
-  from the sandbox environment (auto-injected by aichat2 from the user's
-  AceDataCloud BYOC connection; or set manually in `.env`).
+  from the environment.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

Two small alignments with how the aichat2 sandbox image actually ships today (after the recent preinstall PRs):

1. **`gws` is preinstalled** in the sandbox ([sandbox Dockerfile L82](https://github.com/AceDataCloud/PlatformService/blob/main/sandbox/worker/Dockerfile)) but the Google skills still tell the model to use raw `curl` for everything — including the operations where `gws` is genuinely better.

2. **`tencentcloud-sdk-python` and `cos-python-sdk-v5` are now preinstalled** ([PR #850](https://github.com/AceDataCloud/PlatformService/pull/850)) but every `tencentcloud-*` skill still prints `"Run: pip3 install ..."` on `ImportError`. That hint was always misleading — the sandbox runs as a non-root user with no writable site-packages, so the model can't actually fix it that way.

## What changes

### Google skills — narrow `gws` opt-in (gmail / calendar / drive)

Adds a small `## Quick wins via the preinstalled gws CLI` block right before the existing `## Recipes` section in 3 SKILL.md files. **Scope is intentionally narrow** — only the operations where `gws` is a real ergonomic win for the model:

| Skill | What `gws` is recommended for | What stays on curl |
|---|---|---|
| `google-gmail` | `+send` / `+reply` / `+reply-all` / `+forward` (handles RFC 822 + base64url + threadId/References — the things curl gets wrong most often) | reads, search, triage, labels, attachments |
| `google-calendar` | `+agenda` (auto account-tz) and `+insert` (auto-handles attendee + sendUpdates JSON shape) | events.list / patch / delete, freebusy, calendarList |
| `google-drive` | `+upload` (eliminates multipart boundary hand-coding) | files.list / get / export / update / delete |

`google-tasks` is intentionally **not** changed: no helper commands, all generic Discovery methods — `gws` would be a 1:1 rewrite of the curl recipes for no benefit and net prompt-token cost.

Each block is ~10–15 lines, carefully scoped so the SKILL.md prompt-token budget stays small.

### Tencent skills — drop stale `pip install` hints

`tencentcloud-{cls, cls-alarm, dns, edgeone, tke, cos}` + `_shared/tencentcloud.md`:

- SKILL.md `## Dependencies` sections: replace `\`\`\`bash pip install ... \`\`\`` with a one-paragraph note that says "preinstalled in the sandbox image; if import fails it's a build regression, surface and stop".
- Helper-script `ImportError` branches: same treatment in the runtime error message — instead of telling the model to run a pip command that won't work, tell it the image is broken.

## Risk

Documentation-only for the SKILL.md changes. Helper-script error message text changes are runtime-visible only on the (unreachable in production) `ImportError` path. No behaviour change for any happy path.
