### PR TITLE
fix(google-gmail): null-guard jq messages list recipes

### DIFF
--- a/skills/google-gmail/SKILL.md
+++ b/skills/google-gmail/SKILL.md
@@ -132,8 +132,16 @@ curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
   --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
   --data-urlencode 'q=is:unread in:inbox newer_than:7d' \
   --data-urlencode 'maxResults=20' \
-  | jq '.messages[]'
+  | jq '.messages // [] | .[]'
 ```
+
+**Always default `.messages` to `[]`** — Gmail's `messages.list` omits the
+field entirely when there are zero matches (the response is just
+`{"resultSizeEstimate": 0}`), so a bare `.messages[]` will crash jq
+with `Cannot iterate over null (null)` and exit 5. Same applies to
+`.threads`, `.labels`, `.drafts` on their list endpoints. If the result
+is empty, tell the user plainly (e.g. "No unread mail in the last 7
+days") instead of retrying.
 
 The `messages.list` endpoint returns only `{id, threadId}` — you have
 to fan out to `messages.get` for headers / body. Cheap pattern: list
@@ -147,8 +155,10 @@ IDS=$(curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
   --get "https://gmail.googleapis.com/gmail/v1/users/me/messages" \
   --data-urlencode 'q=is:unread in:inbox' \
   --data-urlencode 'maxResults=10' \
-  | jq -r '.messages[].id')
+  | jq -r '.messages // [] | .[].id')
 
+# If $IDS is empty the for-loop below runs zero times — tell the user
+# "no unread mail" rather than echoing an empty result.
 for ID in $IDS; do
   curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
     --get "https://gmail.googleapis.com/gmail/v1/users/me/messages/$ID" \
@@ -195,7 +205,7 @@ curl -sS -H "Authorization: Bearer $GOOGLE_GMAIL_TOKEN" \
   --data-urlencode 'metadataHeaders=From' \
   --data-urlencode 'metadataHeaders=Subject' \
   --data-urlencode 'metadataHeaders=Date' \
-  | jq '{id, historyId, messages: [.messages[] | {id, snippet, from: (.payload.headers | from_entries.From), date: (.payload.headers | from_entries.Date)}]}'
+  | jq '{id, historyId, messages: [(.messages // [])[] | {id, snippet, from: (.payload.headers | from_entries.From), date: (.payload.headers | from_entries.Date)}]}'
 ```
 
 ### Search by Gmail query


### PR DESCRIPTION
## Why

Live multi-scenario probe (gmail.sse.txt, 2026-05-24) showed:

```
#01 load_skill('acedatacloud/google-gmail')  ✓
#02 → playbook: "Drive Gmail via curl + jq. … Allowed tools: Bash."
#05 Bash: curl ... /users/me/messages?q=is:unread… | jq -r '.messages[].id'
#06 → jq: error (at <stdin>:3): Cannot iterate over null (null)
       [exit code]: 5
```

The model did exactly what the SKILL playbook told it to do. The bug
is in the playbook: Gmail's `users.messages.list` **omits** the
`messages` field entirely when there are zero matches (response is
just `{"resultSizeEstimate": 0}`), so `jq '.messages[]'` /
`'.messages[].id'` / `'[.messages[] | ...]'` all crash with
`Cannot iterate over null (null)` and exit 5.

The pagination recipe at line 281 already used the safe `.messages[]?`
form, and the Search-by-query / Filter-by-label recipes use
`.messages // []` — the three list/triage recipes above were just
missed when those defensive patterns were rolled out.

## What

In `skills/google-gmail/SKILL.md`, rewrite the three unguarded jq
expressions to use `.messages // [] | .[]` (matches the Search/Filter
recipes' style), and add a short note telling the model what to **tell
the user** when results are empty (so it doesn't just retry forever).

| recipe | before | after |
|---|---|---|
| List recent unread inbox | `jq '.messages[]'` | `jq '.messages // [] \| .[]'` |
| List + enrich with headers | `jq -r '.messages[].id'` | `jq -r '.messages // [] \| .[].id'` |
| Read a whole thread | `messages: [.messages[] \| {...}]` | `messages: [(.messages // [])[] \| {...}]` |

The three files in the repo (`skills/`, `.agents/skills/`, `.github/skills/`)
share the same inode (hardlinked), so the single source-of-truth edit
propagates automatically.

## Verified

```
$ echo '{"resultSizeEstimate": 0}' | jq '.messages // [] | .[]'
$ echo $?
0

$ echo '{"messages":[{"id":"abc"},{"id":"def"}]}' | jq -r '.messages // [] | .[].id'
abc
def
$ echo $?
0
```

## Follow-up (out of scope for this PR)

The same null-iteration bug pattern exists in five other connector
playbooks — same one-line fix, but filed separately so this PR stays
scoped to the trace that surfaced the issue:

- `skills/google-tasks/SKILL.md` — `jq '.items[]'` (4 occurrences)
- `skills/google-calendar/SKILL.md` — `jq '.items[]'` (5 occurrences)
- `skills/microsoft-onedrive/SKILL.md` — `jq '.value[]'` (4 occurrences)
- `skills/notion/SKILL.md` — `jq '.results[]'` (2 occurrences)
- `skills/wechat-official-account/SKILL.md` — `jq '.item[]'` / `.list[]'` (3 occurrences)
