### PR TITLE
chore: drop DeepSeek from skills marketing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Skills are located in the `skills/` directory (also mirrored to `.agents/skills/
 - **wan-video** — Generate videos with Alibaba Wan
 
 ### AI Chat & Tools
-- **ai-chat** — Unified LLM gateway — GPT, Claude, Gemini, DeepSeek, Grok (50+ models)
+- **ai-chat** — Unified LLM gateway — GPT, Claude, Gemini, Kimi, Grok (50+ models)
 - **google-search** — Search the web, images, news, maps, places, and videos via Google
 - **face-transform** — Face analysis, beautification, age/gender transform, swap, cartoon
 - **short-url** — Create and manage short URLs

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Compatible with **30+ AI coding agents** via the [agentskills.io](https://agents
 
 | Skill | Description |
 |-------|-------------|
-| [ai-chat](skills/ai-chat/) | Unified LLM gateway — GPT, Claude, Gemini, DeepSeek, Grok (50+ models) |
+| [ai-chat](skills/ai-chat/) | Unified LLM gateway — GPT, Claude, Gemini, Kimi, Grok (50+ models) |
 | [google-search](skills/google-search/) | Search the web, images, news, maps, places, and videos via Google |
 | [face-transform](skills/face-transform/) | Face analysis, beautification, age/gender transform, swap, cartoon |
 | [short-url](skills/short-url/) | Create and manage short URLs |

--- a/skills/acedatacloud-api/SKILL.md
+++ b/skills/acedatacloud-api/SKILL.md
@@ -111,7 +111,7 @@ Error response format:
 
 | Category | Services | Base Path |
 |----------|----------|-----------|
-| **AI Chat** | GPT, Claude, Gemini, DeepSeek, Grok | `/v1/chat/completions` |
+| **AI Chat** | GPT, Claude, Gemini, Kimi, Grok | `/v1/chat/completions` |
 | **Image Gen** | Midjourney, Flux, Seedream, NanoBanana | `/midjourney/*`, `/flux/*`, etc. |
 | **Video Gen** | Luma, Sora, Veo, Kling, Hailuo, Seedance, Wan | `/luma/*`, `/sora/*`, etc. |
 | **Music Gen** | Suno, Producer, Fish Audio | `/suno/*`, `/producer/*`, `/fish/*` |

--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-chat
-description: Access 50+ LLM models through a unified OpenAI-compatible API via AceDataCloud. Use when you need chat completions from GPT, Claude, Gemini, DeepSeek, Grok, or other models through a single endpoint. Supports streaming, function calling, and vision.
+description: Access 50+ LLM models through a unified OpenAI-compatible API via AceDataCloud. Use when you need chat completions from GPT, Claude, Gemini, Kimi, Grok, or other models through a single endpoint. Supports streaming, function calling, and vision.
 license: Apache-2.0
 metadata:
   author: acedatacloud
@@ -77,15 +77,6 @@ print(response.choices[0].message.content)
 |-------|----------|
 | `gemini-1.5-pro` | Long context, complex tasks |
 | `gemini-1.5-flash` | Fast, efficient |
-
-### DeepSeek
-
-| Model | Best For |
-|-------|----------|
-| `deepseek-r1` | Deep reasoning |
-| `deepseek-r1-0528` | Latest reasoning |
-| `deepseek-v3` | General-purpose |
-| `deepseek-v3-250324` | Latest general |
 
 ### xAI Grok
 


### PR DESCRIPTION
Remove DeepSeek mentions from skills marketing copy (docs/markdown only).