### PR TITLE
feat: publisher connector skills (devto, blogger, reddit, linkedin)

### DIFF
--- a/PUBLISHER_CONNECTORS.md
+++ b/PUBLISHER_CONNECTORS.md
@@ -1,0 +1,69 @@
+# Publisher Connectors — Go-Live Steps (what YOU need to do)
+
+These connectors + skills are code-complete. To make them **work on production**,
+a human has to register OAuth apps / enable APIs and set secrets, then run the
+sync commands. Per-platform steps below. Order: do the setup, set the env, then
+`python manage.py sync_connectors` (AuthBackend) — the skills sync automatically
+via the Skills catalog.
+
+Common OAuth callback (Reddit & LinkedIn) — register **the same redirect base
+the existing Google/GitHub connectors use**, with the provider path appended:
+
+```
+https://auth.acedata.cloud/api/v1/connections/callback/reddit
+https://auth.acedata.cloud/api/v1/connections/callback/linkedin
+```
+(If your Google/GitHub apps use a different callback base, mirror it — the path
+segment is the provider id `reddit` / `linkedin`.)
+
+---
+
+## 1. Dev.to — nothing for you to do ✅
+BYOC. Each end-user generates their own key at
+**dev.to → Settings → Extensions → "DEV Community API Keys" → Generate API Key**
+and pastes it into the connector. No platform-side setup, no secret.
+
+## 2. Blogger — enable an API on the existing Google app
+No new OAuth app (reuses your Google client, same as Drive/Gmail/YouTube):
+1. Google Cloud Console → the project behind `GOOGLE_OAUTH_CLIENT_ID` → **APIs & Services → Library → enable "Blogger API v3"**.
+2. OAuth consent screen → **add scope** `https://www.googleapis.com/auth/blogger`.
+   (It's a sensitive scope → may need Google verification, like youtube.upload.)
+3. No new env var needed.
+
+## 3. Reddit — register an OAuth app
+1. https://www.reddit.com/prefs/apps → **create app** → type **"web app"**.
+2. **redirect uri** = the Reddit callback above.
+3. Copy the client id (under the app name) + secret.
+4. Set K8s secret env on AuthBackend:
+   - `REDDIT_OAUTH_CLIENT_ID=...`
+   - `REDDIT_OAUTH_CLIENT_SECRET=...`
+
+## 4. LinkedIn — register an app + add products
+1. https://www.linkedin.com/developers/apps → **Create app** (needs a Company Page).
+2. **Products** tab → request **"Sign In with LinkedIn using OpenID Connect"** + **"Share on LinkedIn"** (the latter grants `w_member_social`).
+3. **Auth** tab → add the LinkedIn redirect uri above.
+4. Copy Client ID + Client Secret → set on AuthBackend:
+   - `LINKEDIN_OAUTH_CLIENT_ID=...`
+   - `LINKEDIN_OAUTH_CLIENT_SECRET=...`
+
+---
+
+## After setup (per deploy)
+```bash
+# AuthBackend pod — upsert the connector directory rows (idempotent)
+python manage.py sync_connectors
+```
+The 4 skills (devto / blogger / reddit / linkedin) ship in AceDataCloud/Skills and
+are pulled into the Skill catalog by the normal skills sync; each connector's
+`required_skills` auto-installs its skill on connect.
+
+## Verify it works (online)
+1. Open **auth.acedata.cloud → Browse connectors** → the 4 new cards appear.
+2. Click **Connect** on Dev.to (paste a key) and on Blogger/Reddit/LinkedIn (OAuth).
+3. In Studio chat: "把这段发到我的 dev.to / Blogger / Reddit r/test / LinkedIn" →
+   the matching skill runs with the injected token and posts.
+
+## Cost note
+Dev.to, Blogger, Reddit, LinkedIn — all free APIs. (We deliberately skipped X,
+which is now pay-per-use $0.01/post, and Facebook, which needs app review +
+Page-token complexity.)

--- a/skills/blogger/SKILL.md
+++ b/skills/blogger/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: blogger
+description: Publish posts to your Blogger blog and read your blogs / posts via the Blogger API v3. Use when the user mentions Blogger, blogspot, publishing a post to their blog, listing their blogs, or updating an existing Blogger post.
+when_to_use: |
+  Trigger when the user wants to publish a post to their Blogger blog,
+  list their blogs, list / read posts on a blog, or update an existing
+  post. The connector grants the Blogger scope (read + write); confirm
+  before publishing publicly (you can insert as a draft first).
+connections: [google/blogger]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **Blogger API v3** with `curl + jq`. The user's OAuth bearer token is
+in `$GOOGLE_BLOGGER_TOKEN`; every call needs
+`Authorization: Bearer $GOOGLE_BLOGGER_TOKEN`. Base URL:
+`https://www.googleapis.com/blogger/v3`.
+
+Errors are `{"error": {"code": ..., "message": ...}}` — show them verbatim.
+`401` → token expired, re-connect the Blogger connector.
+
+**Always start by listing the user's blogs** to get a `blogId`:
+
+```bash
+curl -sS -H "Authorization: Bearer $GOOGLE_BLOGGER_TOKEN" \
+  "https://www.googleapis.com/blogger/v3/users/self/blogs" \
+  | jq '.items[] | {id, name, url}'
+```
+
+## Publish a post
+
+**Confirm before publishing publicly.** Use `?isDraft=true` to stage a draft.
+
+```bash
+BLOG_ID="1234567890"
+jq -n --arg t "My title" --arg c "<p>HTML content of the post…</p>" \
+  '{kind:"blogger#post", title:$t, content:$c, labels:["ai","video"]}' \
+| curl -sS -X POST \
+    "https://www.googleapis.com/blogger/v3/blogs/$BLOG_ID/posts/?isDraft=false" \
+    -H "Authorization: Bearer $GOOGLE_BLOGGER_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @- \
+| jq '{id, url, status}'
+```
+
+`content` is **HTML** (not Markdown) — convert Markdown to HTML first
+(e.g. with `pandoc -f markdown -t html` or a simple converter).
+
+- Publish a staged draft: `POST /blogs/{blogId}/posts/{postId}/publish`.
+- Update a post: `PUT /blogs/{blogId}/posts/{postId}` with the same shape.
+
+## List / read posts
+
+```bash
+curl -sS -H "Authorization: Bearer $GOOGLE_BLOGGER_TOKEN" \
+  "https://www.googleapis.com/blogger/v3/blogs/$BLOG_ID/posts?maxResults=20&status=live" \
+  | jq '.items[] | {id, title, url, published}'
+```
+
+## Gotchas
+
+- **Enable the Blogger API** on the Google Cloud project backing the OAuth
+  client, or calls 403 with `accessNotConfigured`.
+- `content` must be HTML; passing raw Markdown will render literally.
+- Paginate with `&pageToken=$PAGE_TOKEN` from the previous `.nextPageToken`.

--- a/skills/devto/SKILL.md
+++ b/skills/devto/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: devto
+description: Publish, update and read articles on DEV (dev.to) via the Forem API v1. Use when the user mentions dev.to / DEV Community, publishing a blog post to dev.to, cross-posting an article, updating a published post, or listing their dev.to articles and stats.
+when_to_use: |
+  Trigger when the user wants to publish a Markdown article to their
+  dev.to account, update a previously published article, or list /
+  inspect their own dev.to articles (views, reactions, comments). The
+  connector stores a DEV API Key with full account access — confirm
+  before publishing publicly (you can publish as a draft with
+  published=false first).
+connections: [devto]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **Forem API v1** (dev.to) with `curl + jq`. The user's API key is in
+`$DEVTO_API_KEY`; every call needs the headers `api-key: $DEVTO_API_KEY` and
+`Accept: application/vnd.forem.api-v1+json`. Base URL: `https://dev.to/api`.
+
+Errors come back as JSON with an `error` / `status` field — show them verbatim.
+`401` means the API key is invalid → the user must re-connect the DEV connector.
+
+**Always start by confirming the key** and learning the account:
+
+```bash
+curl -sS -H "api-key: $DEVTO_API_KEY" -H "Accept: application/vnd.forem.api-v1+json" \
+  "https://dev.to/api/users/me" | jq '{username, name}'
+```
+
+## Publish an article
+
+**Confirm with the user before publishing publicly.** Default to a draft
+(`published:false`) unless they explicitly say publish/now.
+
+```bash
+TITLE="My title"
+BODY_MD="$(cat article.md)"   # full Markdown body
+jq -n --arg t "$TITLE" --arg b "$BODY_MD" \
+  '{article:{title:$t, body_markdown:$b, published:false, tags:["ai","webdev"]}}' \
+| curl -sS -X POST "https://dev.to/api/articles" \
+    -H "api-key: $DEVTO_API_KEY" \
+    -H "Accept: application/vnd.forem.api-v1+json" \
+    -H "Content-Type: application/json" \
+    -d @- \
+| jq '{id, url, published}'
+```
+
+To publish a draft later (or edit), `PUT /api/articles/{id}` with the same
+shape (set `published:true`). Front-matter inside `body_markdown` (a `---`
+block) can also carry `title`, `tags`, `series`, `canonical_url`, `cover_image`.
+
+- **Canonical URL:** when cross-posting, set
+  `"canonical_url":"https://your-blog/original"` so DEV points SEO back to the
+  source — important for the article→video / cross-publishing flow.
+
+## List / inspect my articles
+
+```bash
+# My published + draft articles (paginated; per_page max 1000).
+curl -sS -H "api-key: $DEVTO_API_KEY" -H "Accept: application/vnd.forem.api-v1+json" \
+  "https://dev.to/api/articles/me/all?per_page=30" \
+  | jq '.[] | {id, title, published, page_views_count, public_reactions_count, comments_count}'
+
+# A single article's full content + stats.
+curl -sS -H "api-key: $DEVTO_API_KEY" -H "Accept: application/vnd.forem.api-v1+json" \
+  "https://dev.to/api/articles/ARTICLE_ID" | jq '{title, url, reactions: .public_reactions_count, views: .page_views_count}'
+```
+
+## Gotchas
+
+- **Tags:** max 4, lowercase, no spaces (e.g. `webdev`, `machinelearning`).
+- **Rate limit:** article create/update is throttled (a few per 30s); space out
+  bulk publishes or you'll get `429`.
+- `body_markdown` is the source of truth — if you put a `---` front-matter block
+  at the top, its fields override the JSON `article` fields.

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: linkedin
+description: Publish text / link posts to your LinkedIn personal feed via the LinkedIn Posts API. Use when the user mentions LinkedIn, sharing or posting an update to LinkedIn, or cross-posting an article / link to their LinkedIn feed.
+when_to_use: |
+  Trigger when the user wants to publish a text or link share to their
+  own LinkedIn feed. Posting is public on their profile — confirm the
+  text (and link, if any) before publishing. Requires the
+  w_member_social scope (granted by the connector at install).
+connections: [linkedin]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **LinkedIn API** with `curl + jq`. The user's bearer token is in
+`$LINKEDIN_TOKEN`; every call needs `Authorization: Bearer $LINKEDIN_TOKEN`.
+
+LinkedIn posts must be authored by the member's URN. Get the member id from the
+OpenID userinfo endpoint, then build `urn:li:person:{sub}`.
+
+```bash
+SUB=$(curl -sS -H "Authorization: Bearer $LINKEDIN_TOKEN" \
+  "https://api.linkedin.com/v2/userinfo" | jq -r .sub)
+AUTHOR="urn:li:person:$SUB"
+echo "$AUTHOR"
+```
+
+Errors are JSON with `message` / `serviceErrorCode` — show them verbatim.
+`401` → token expired (tokens last ~60 days), re-connect the LinkedIn connector.
+
+## Publish a post (Posts API)
+
+**Confirm the text with the user first.** Use the versioned Posts API; set the
+`LinkedIn-Version` header to a recent `YYYYMM` (LinkedIn requires a valid recent
+version — if you get `426`/version errors, bump to the current month).
+
+```bash
+jq -n --arg a "$AUTHOR" --arg t "My update text. Check out https://studio.acedata.cloud" \
+  '{author:$a, commentary:$t, visibility:"PUBLIC",
+    distribution:{feedDistribution:"MAIN_FEED", targetEntities:[], thirdPartyDistributionChannels:[]},
+    lifecycleState:"PUBLISHED", isReshareDisabledByAuthor:false}' \
+| curl -sS -X POST "https://api.linkedin.com/rest/posts" \
+    -H "Authorization: Bearer $LINKEDIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "LinkedIn-Version: 202401" \
+    -H "X-Restli-Protocol-Version: 2.0.0" \
+    -d @- -D - -o /dev/null | tr -d '\r' | awk '/^[Xx]-[Rr]estli-[Ii]d:|^[Ll]ocation:/{print}'
+```
+
+A successful create returns `201` with the post URN in the `x-restli-id`
+(or `Location`) response header — report that URN / the resulting post URL.
+
+> Link posts: put the URL inline in `commentary` (LinkedIn auto-unfurls it).
+> Rich article attachments need the assets/images API — out of scope for a
+> simple text/link share; keep links inline.
+
+## Fallback: legacy ugcPosts
+
+If the versioned endpoint is unavailable for the app, the older
+`POST https://api.linkedin.com/v2/ugcPosts` with a
+`specificContent."com.linkedin.ugc.ShareContent"` body also works with
+`w_member_social`. Prefer `/rest/posts` above.
+
+## Gotchas
+
+- **Author URN** must match the token's member (`urn:li:person:{sub}`) — you
+  can't post as someone else.
+- `w_member_social` only allows posting to the **member's own feed**; company
+  Page posts need `w_organization_social` + an admin role (not in this connector).
+- The `LinkedIn-Version` header is mandatory for `/rest/*`; a stale value
+  returns a version error — bump to the current `YYYYMM`.

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: reddit
+description: Submit posts (link or text) to subreddits and read your Reddit identity / content via the Reddit API. Use when the user mentions Reddit, posting to a subreddit, submitting a link or self-post, or checking their Reddit profile / submissions.
+when_to_use: |
+  Trigger when the user wants to submit a post to a subreddit (link or
+  self/text post), or read their own Reddit identity and submissions.
+  Posting to a subreddit is public and subject to that subreddit's rules
+  / karma requirements — confirm the target subreddit, title and body
+  before submitting.
+connections: [reddit]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **Reddit API** (OAuth endpoints) with `curl + jq`. The user's bearer
+token is in `$REDDIT_TOKEN`. **Every call MUST send a `User-Agent` header** or
+Reddit returns `429`. Use the OAuth host `https://oauth.reddit.com`.
+
+```bash
+UA="web:cloud.acedata.connectors:v1.0 (by /u/acedatacloud)"
+```
+
+Errors are JSON; a submit returns `{"json":{"errors":[...], "data":{...}}}` —
+if `errors` is non-empty, show them verbatim. `401` → token expired, re-connect.
+
+**Always start by confirming identity:**
+
+```bash
+curl -sS -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
+  "https://oauth.reddit.com/api/v1/me" | jq '{name, total_karma, link_karma}'
+```
+
+## Submit a post
+
+**Confirm the subreddit + title + body with the user first.** `sr` is the
+subreddit name WITHOUT the `r/` prefix.
+
+```bash
+# Self (text) post: kind=self + text. Link post: kind=link + url.
+curl -sS -X POST "https://oauth.reddit.com/api/submit" \
+  -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
+  --data-urlencode "sr=test" \
+  --data-urlencode "kind=self" \
+  --data-urlencode "title=My title" \
+  --data-urlencode "text=My self-post body in markdown" \
+  --data-urlencode "api_type=json" \
+  | jq '.json | {errors, url: .data.url, id: .data.id}'
+```
+
+For a link post:
+
+```bash
+curl -sS -X POST "https://oauth.reddit.com/api/submit" \
+  -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
+  --data-urlencode "sr=test" --data-urlencode "kind=link" \
+  --data-urlencode "title=My title" --data-urlencode "url=https://example.com" \
+  --data-urlencode "api_type=json" | jq '.json'
+```
+
+## Read my submissions
+
+```bash
+curl -sS -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
+  "https://oauth.reddit.com/user/USERNAME/submitted?limit=10" \
+  | jq '.data.children[] | .data | {title, subreddit, ups, num_comments, permalink}'
+```
+
+## Gotchas
+
+- **User-Agent is mandatory** on every request — omitting it → `429`.
+- Many subreddits gate posting on **account age / karma / flair**; a submit can
+  return `errors` like `[["SUBREDDIT_NOTALLOWED", ...]]` — surface it and try
+  `r/test` to validate the flow.
+- Respect rate limits: read the `X-Ratelimit-Remaining` response header; space
+  out bulk submits.
+- Use `r/test` as a safe target when validating that the connection works.


### PR DESCRIPTION
Capability layer for the publisher connectors (AuthBackend PR #178) — without these, connecting only stores a token. Each skill calls the platform API with the connection-injected token (same pattern as youtube/google-drive):

- **devto** → `$DEVTO_API_KEY` → Forem v1: publish / list / update articles (with canonical_url for cross-posting)
- **blogger** → `$GOOGLE_BLOGGER_TOKEN` → Blogger v3: list blogs, insert/publish posts
- **reddit** → `$REDDIT_TOKEN` → `/api/submit` (+ mandatory User-Agent), read identity/submissions
- **linkedin** → `$LINKEDIN_TOKEN` → Posts API (author URN from OpenID `sub`)

Plus **PUBLISHER_CONNECTORS.md** — the exact human go-live steps (register Reddit/LinkedIn OAuth apps, enable Blogger API + scope, set env vars, run `sync_connectors`, verify online).

Pairs with AuthBackend#178. Part of: AceDataCloud/Index#79