### PR TITLE
refactor(skills): rename cn-blog → zhihu (per-platform naming)

### DIFF
--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: cn-blog
-description: Read and publish on Chinese content platforms with the user's own login cookies (BYOC) — list their published articles with vote/comment stats, inspect one article, and publish a new article. Use when the user mentions 知乎 / Zhihu, "我的知乎文章", reading their article stats (点赞/评论), or publishing/发文 to Zhihu.
+name: zhihu
+description: Read and publish on Zhihu (知乎) with the user's own login cookies (BYOC) — list their published articles with vote/comment stats, inspect one article, and publish a new article. Use when the user mentions 知乎 / Zhihu, "我的知乎文章", reading their article stats (点赞/评论), or publishing/发文 to Zhihu.
 when_to_use: |
   Trigger for anything on the user's Zhihu (知乎) account driven by their own
   login cookie: show who they are, list their published articles with
@@ -15,7 +15,7 @@ metadata:
   version: "1.0"
 ---
 
-# cn-blog — Zhihu via your own cookies
+# zhihu — read & publish on Zhihu via your own cookies
 
 Drives the user's **real** Zhihu account through the same web APIs the site's
 own editor uses, authenticated by the login cookie they captured with the ACE
@@ -93,5 +93,6 @@ python3 $BLOG publish --title "标题" --content-file article.html --confirm    
   acts on the user's own account with their own captured cookie; the user owns
   that risk. Never use it to scrape other people's content at scale.
 - **Never print `ZHIHU_COOKIES`** — it is full account access.
-- **Scope today**: Zhihu only. 掘金 / CSDN connectors exist in the vault and are
-  planned next; this skill will grow a `--platform` switch for them.
+- **Scope**: Zhihu only. Other Chinese platforms (掘金 / CSDN / …) ship as their
+  own per-platform skills (e.g. `csdn`, `juejin`), each with its own connector —
+  not a `--platform` switch here.

--- a/skills/zhihu/scripts/blog.py
+++ b/skills/zhihu/scripts/blog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cn-blog — read & publish on Chinese content platforms with the user's own
+zhihu — read & publish on Zhihu (知乎) with the user's own
 login cookies (BYOC). Standard-library only (urllib), no third-party deps,
 so it runs in the bare sandbox without an image change.
 
@@ -319,7 +319,7 @@ COMMANDS = {
 
 
 def main() -> None:
-    p = argparse.ArgumentParser(prog="blog.py", description="cn-blog cookie CLI")
+    p = argparse.ArgumentParser(prog="blog.py", description="zhihu cookie CLI")
     p.add_argument("--platform", default="zhihu", choices=["zhihu"],
                    help="content platform (only zhihu is implemented today)")
     sub = p.add_subparsers(dest="command", required=True)


### PR DESCRIPTION
## Why

The `cn-blog` skill is **Zhihu-only** in practice — `connections: [zhihu]`, every line of SKILL.md and blog.py is about 知乎. The generic name was aspirational (it was going to grow a `--platform` switch). We're instead going **per-platform**, which matches this repo's existing convention (`blogger`, `devto`, `reddit`, `linkedin`, `wechat-official-account` are all one-platform-one-skill). csdn / juejin / etc. will ship as their own skills.

## Change

- `git mv skills/cn-blog → skills/zhihu` (history preserved)
- `SKILL.md`: `name: cn-blog` → `name: zhihu`; title + closing scope note updated
- `blog.py`: docstring + argparse description (cosmetic strings only — no behavior change)

No `cn-blog` / `cn_blog` references remain anywhere in the repo.

## Downstream (self-healing)

AuthBackend's `skill-catalog-sync` cron pulls the `acedatacloud` skills from this repo's **main** tarball and `_soft_hide_missing` auto-hides any slug that disappears — so the old `acedatacloud/cn-blog` Skill row self-hides on the next sync, and `acedatacloud/zhihu` is added. The connector `required_skills` reference is updated in companion **AuthBackend** PR (cn-blog → zhihu).

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`). One round.

**Findings:** None.
- Rename complete — no `cn-blog`/`cn_blog`/`acedatacloud/cn-blog` refs remain (incl. symlinked `.agents/skills`, `.github/skills`).
- `SKILL.md` frontmatter valid: `name: zhihu`, `connections: [zhihu]`, `allowed_tools: [Bash]`; matches conventions.
- `blog.py` change is cosmetic only (docstring + argparse description); AST parse + `--help` pass.
- Loading intact; package includes `skills/`.

**VERDICT: CLEAN**