### PR TITLE
feat(skills): per-platform cookie BYOC skills — csdn, juejin, bilibili, medium, weibo

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: bilibili
+description: Read and publish 专栏 articles on Bilibili (bilibili.com) with the user's own login cookies (BYOC) — list their published articles with view/like/comment stats, inspect one article, and publish a new article. Use when the user mentions Bilibili / B站 / 专栏, "我的B站专栏", reading article stats (阅读/点赞), or publishing/投稿 a 专栏 article.
+when_to_use: |
+  Trigger for anything on the user's Bilibili (bilibili.com) 专栏 account driven
+  by their own login cookie: show who they are, list their published 专栏
+  articles with view / like / comment counts, look at one article's stats, or
+  publish a new 专栏 article. This acts as the user's real account, so writes are
+  gated behind an explicit confirmation.
+connections: [bilibili]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# bilibili — read & publish 专栏 via your own cookies
+
+Drives the user's **real** Bilibili 专栏 (article) account through the same
+`api.bilibili.com` web endpoints the site uses, authenticated by the login
+cookie they captured with the ACE extension. No browser, no third-party deps —
+`urllib` + `hashlib` (the article-list read endpoint needs WBI signing, done
+with stdlib).
+
+The connector injects the cookie jar as an env var:
+
+- `BILIBILI_COOKIES` — a JSON array of cookies. **Secret — never echo or print
+  it.** It includes `SESSDATA` (auth) and `bili_jct` (the CSRF token used for
+  writes).
+
+## CLI
+
+The skill ships [`scripts/bilibili.py`](scripts/bilibili.py) — self-contained, stdlib only.
+
+```sh
+BILI=$SKILL_DIR/scripts/bilibili.py
+python3 $BILI whoami                       # who is logged in (mid, name)
+python3 $BILI articles --limit 20          # my 专栏 articles + stats
+python3 $BILI article <cvid>               # one article's stats (cv id)
+```
+
+Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (评论),
+`favorite` (收藏), `coin` (投币).
+
+## Verify the connection first
+
+```sh
+python3 $BILI whoami
+# → {"mid": 91207595, "name": "...", "level": 4}
+```
+
+On a not-logged-in / auth error the cookie is expired — have the user reconnect
+at <https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+
+## Publishing — GATED (dry-run unless trailing `--confirm`)
+
+`publish` writes to the user's real account. 专栏 content is **HTML**. Without a
+trailing `--confirm` it dry-runs. `--confirm` is honored **only as the last
+argument**. Always show the dry-run, get an explicit "yes", then re-run.
+
+```sh
+python3 $BILI publish --title "标题" --content-file a.html                       # dry-run
+python3 $BILI publish --title "标题" --content-file a.html --draft-only --confirm   # save a draft
+python3 $BILI publish --title "标题" --content-file a.html --confirm                # save draft + submit (publish)
+```
+
+- `--draft-only` saves a draft (no submit) — safe; finish/publish in the editor.
+- The **submit** (go public) step is frequently rate-limited by Bilibili
+  risk-control (HTTP 412). When that happens the CLI reports the saved draft +
+  edit URL so the user can publish from the web editor. Default to `--draft-only`.
+
+## Gotchas
+
+- **This is the user's real Bilibili account.** Confirm before any publish.
+- **submit may 412** (anti-bot) even when the draft saved fine — the draft is the
+  reliable result; don't loop-retry submit.
+- A wrong cover layout (`tid`) / category returns `-17`; the CLI auto-retries
+  common `tid` values.
+- **Never print `BILIBILI_COOKIES`** — it is full account access.
+- **ToS**: acts only on the user's own account with their own captured cookie.

--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+bilibili — read & publish 专栏 articles on Bilibili (bilibili.com) with the
+user's own login cookies (BYOC). Standard-library only (urllib + hashlib for
+WBI signing), no third-party deps.
+
+The connector injects the cookie jar as a JSON env var ``BILIBILI_COOKIES``.
+Reads use the login cookies; the article-list endpoint needs WBI signing
+(keys come from the nav response). Writes need ``csrf`` = the ``bili_jct`` cookie.
+
+Read commands run directly. ``publish`` is GATED by a trailing ``--confirm``
+(honored only as the last arg). ``--draft-only`` saves a draft (no submit).
+Note: Bilibili 专栏 content is HTML. The publish *submit* step is often
+rate-limited (HTTP 412) by risk-control; the draft is the reliable result.
+
+Examples:
+  python3 bilibili.py whoami
+  python3 bilibili.py articles --limit 20
+  python3 bilibili.py article <cvid>
+  python3 bilibili.py publish --title T --content-file a.html --draft-only --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+PLATFORM = "bilibili"
+API = "https://api.bilibili.com"
+
+# Fixed permutation table for WBI mixin-key derivation (from bilibili web JS).
+MIXIN_KEY_ENC_TAB = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49,
+    33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40,
+    61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11,
+    36, 20, 34, 44, 52,
+]
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar ──────────────────────────────────────────────────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect Bilibili at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def cookie_value(jar: list, name: str):
+    for c in jar:
+        if c.get("name") == name:
+            return c.get("value")
+    return None
+
+
+# ── HTTP ────────────────────────────────────────────────────────────
+
+def request(method, url, jar, *, referer=None, headers=None, body=None, form=None):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "application/json, text/plain, */*",
+    }
+    if referer:
+        hdrs["Referer"] = referer
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if form is not None:
+        data = urllib.parse.urlencode(form).encode("utf-8")
+        hdrs["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+    elif body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def get_json(url, jar, *, referer=None):
+    status, text = request("GET", url, jar, referer=referer)
+    try:
+        d = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {url}: {text[:300]}")
+    return d
+
+
+# ── WBI signing (for x/space/wbi/article) ───────────────────────────
+
+def _wbi_keys(jar):
+    nav = get_json(f"{API}/x/web-interface/nav", jar)
+    data = nav.get("data") or {}
+    img = ((data.get("wbi_img") or {}).get("img_url") or "")
+    sub = ((data.get("wbi_img") or {}).get("sub_url") or "")
+    img_key = img.rsplit("/", 1)[-1].split(".")[0]
+    sub_key = sub.rsplit("/", 1)[-1].split(".")[0]
+    return nav, img_key, sub_key
+
+
+def _mixin_key(img_key, sub_key):
+    orig = img_key + sub_key
+    return "".join(orig[i] for i in MIXIN_KEY_ENC_TAB if i < len(orig))[:32]
+
+
+def _wbi_sign(params: dict, img_key, sub_key) -> dict:
+    mixin = _mixin_key(img_key, sub_key)
+    params = dict(params)
+    params["wts"] = int(time.time())
+    params = {k: params[k] for k in sorted(params)}
+    # bilibili drops these chars from values before signing
+    cleaned = {k: "".join(ch for ch in str(v) if ch not in "!'()*") for k, v in params.items()}
+    query = urllib.parse.urlencode(cleaned)
+    params["w_rid"] = hashlib.md5((query + mixin).encode()).hexdigest()
+    return params
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def bili_nav(jar):
+    nav = get_json(f"{API}/x/web-interface/nav", jar)
+    data = nav.get("data") or {}
+    if not data.get("isLogin"):
+        die("not logged in (cookie expired?) — reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    return data
+
+
+def cmd_whoami(jar, _args):
+    d = bili_nav(jar)
+    out({
+        "mid": d.get("mid"),
+        "name": d.get("uname"),
+        "url": f"https://space.bilibili.com/{d.get('mid')}",
+        "level": (d.get("level_info") or {}).get("current_level"),
+        "vip": (d.get("vipStatus") or d.get("vip", {}).get("status")),
+    })
+
+
+def _fmt(a: dict) -> dict:
+    st = a.get("stats") or {}
+    cvid = a.get("id")
+    return {
+        "id": str(cvid) if cvid is not None else None,
+        "title": a.get("title"),
+        "url": f"https://www.bilibili.com/read/cv{cvid}" if cvid else None,
+        "view": st.get("view"),
+        "like": st.get("like"),
+        "reply": st.get("reply"),
+        "favorite": st.get("favorite"),
+        "coin": st.get("coin"),
+        "publish_time": a.get("publish_time"),
+    }
+
+
+def cmd_articles(jar, args):
+    nav, img_key, sub_key = _wbi_keys(jar)
+    mid = (nav.get("data") or {}).get("mid")
+    if not mid:
+        die("could not resolve your mid from nav (cookie expired?).")
+    collected, pn = [], 1
+    while len(collected) < args.limit:
+        signed = _wbi_sign({"mid": mid, "pn": pn, "ps": 30, "sort": "publish_time"},
+                           img_key, sub_key)
+        url = f"{API}/x/space/wbi/article?" + urllib.parse.urlencode(signed)
+        # WBI endpoints penalize a Referer header — omit it.
+        d = get_json(url, jar)
+        if d.get("code") != 0:
+            die(f"article list error (code={d.get('code')}): {d.get('message')}")
+        data = d.get("data") or {}
+        items = data.get("articles") or []
+        if not items:
+            break
+        collected.extend(items)
+        total = data.get("count")
+        if total is not None and len(collected) >= total:
+            break
+        pn += 1
+    items = collected[: args.limit]
+    out({"count": len(items), "articles": [_fmt(a) for a in items]})
+
+
+def cmd_article(jar, args):
+    cvid = str(args.id).lstrip("cv")
+    d = get_json(f"{API}/x/article/viewinfo?id={cvid}", jar)
+    if d.get("code") != 0:
+        die(f"article {args.id} not found (code={d.get('code')}): {d.get('message')}")
+    data = d.get("data") or {}
+    st = data.get("stats") or {}
+    out({
+        "id": cvid,
+        "title": data.get("title"),
+        "url": f"https://www.bilibili.com/read/cv{cvid}",
+        "author": data.get("author_name"),
+        "view": st.get("view"), "like": st.get("like"), "reply": st.get("reply"),
+        "favorite": st.get("favorite"), "coin": st.get("coin"),
+    })
+
+
+# tid = cover layout; a wrong one returns code -17 / "分类". Try common ones.
+_TID_CANDIDATES = ["4", "3", "6", "7", "2", "17", "28", "41"]
+
+
+def cmd_publish(jar, args):
+    if not args.title:
+        die("--title is required")
+    if not args.content_file and args.content is None:
+        die("provide --content-file <path.html> or --content <html>")
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    content = content or ""
+    csrf = cookie_value(jar, "bili_jct")
+    if not csrf:
+        die("no bili_jct cookie (CSRF token) — reconnect Bilibili.")
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "publish", "platform": "bilibili",
+            "title": args.title, "draft_only": args.draft_only,
+            "content_bytes": len(content),
+            "note": "Bilibili 专栏 content is HTML. Re-run with --confirm as the "
+                    "LAST argument to write. The submit step is often 412-limited; "
+                    "the saved draft is the reliable result.",
+        })
+        return
+
+    ref = "https://member.bilibili.com/"
+    base = {
+        "title": args.title, "content": content, "csrf": csrf,
+        "category": "0", "list_id": "0", "reprint": "0", "original": "1",
+        "media_id": "0", "spoiler": "0", "save": "0", "pgc_id": "0",
+    }
+    # 1. save draft, retrying tid until the category is accepted
+    aid, last = None, None
+    for tid in _TID_CANDIDATES:
+        body = dict(base, tid=tid)
+        status, text = request("POST", f"{API}/x/article/creative/draft/addupdate",
+                               jar, referer=ref, form=body)
+        try:
+            r = json.loads(text)
+        except json.JSONDecodeError:
+            last = f"non-JSON ({status}): {text[:200]}"
+            continue
+        if r.get("code") == 0:
+            aid = (r.get("data") or {}).get("aid")
+            chosen_tid = tid
+            break
+        last = f"code={r.get('code')} {r.get('message')}"
+        if "分类" not in str(r.get("message", "")) and r.get("code") != -17:
+            break  # a non-category error won't be fixed by another tid
+    if not aid:
+        die(f"save-draft failed: {last}")
+
+    if args.draft_only:
+        out({"ok": True, "draft_only": True, "aid": str(aid),
+             "edit_url": f"https://member.bilibili.com/article-text/home?aid={aid}"})
+        return
+
+    # 2. submit (publish) — may be 412 risk-controlled; report draft if so
+    body = dict(base, tid=chosen_tid, aid=aid)
+    status, text = request("POST", f"{API}/x/article/creative/article/submit",
+                           jar, referer=ref, form=body)
+    try:
+        r = json.loads(text)
+    except json.JSONDecodeError:
+        r = None
+    if r and r.get("code") == 0:
+        out({"ok": True, "published": True, "aid": str(aid),
+             "url": f"https://www.bilibili.com/read/cv{aid}"})
+    else:
+        out({"ok": False, "published": False, "draft_saved": True, "aid": str(aid),
+             "edit_url": f"https://member.bilibili.com/article-text/home?aid={aid}",
+             "note": f"submit blocked ({status}); the draft is saved — finish in the "
+                     f"web editor. Detail: {(r or {}).get('message') if r else text[:200]}"})
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "articles": cmd_articles,
+    "article": cmd_article,
+    "publish": cmd_publish,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="bilibili.py", description="bilibili 专栏 cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("articles", help="list the user's 专栏 articles + stats")
+    sp.add_argument("--limit", type=int, default=20)
+    sp = sub.add_parser("article", help="one article's stats (by cvid)")
+    sp.add_argument("id")
+    sp = sub.add_parser("publish", help="create/publish a 专栏 article (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="HTML content inline")
+    sp.add_argument("--content-file", help="path to an HTML file")
+    sp.add_argument("--draft-only", action="store_true", help="save a draft; do NOT submit")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: csdn
+description: Read and publish on CSDN (blog.csdn.net) with the user's own login cookies (BYOC) — list their published articles with view/like/comment stats, inspect one article, and publish a new article. Use when the user mentions CSDN, "我的 CSDN 文章", reading their article stats (阅读/点赞), or publishing/发文 to CSDN.
+when_to_use: |
+  Trigger for anything on the user's CSDN (blog.csdn.net) account driven by
+  their own login cookie: show who they are, list their published articles with
+  view / like / comment counts, look at one article's stats, or publish a new
+  article. This acts as the user's real account, so writes are gated behind an
+  explicit confirmation.
+connections: [csdn]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# csdn — read & publish on CSDN via your own cookies
+
+Drives the user's **real** CSDN account through the same web APIs the site's own
+editor uses, authenticated by the login cookie they captured with the ACE
+extension. No browser, no third-party deps — `urllib` + `hmac` (the editor's
+save endpoint requires an HMAC signature, computed with stdlib).
+
+The connector injects the cookie jar as an env var:
+
+- `CSDN_COOKIES` — a JSON array of cookies. **Secret — never echo or print it.**
+  The CLI reads it for you.
+
+> CSDN fronts its APIs with a WAF; the CLI already sends a full browser
+> fingerprint so reads aren't 403'd. If you still get a WAF 403, the cookie
+> expired — have the user reconnect.
+
+## CLI
+
+The skill ships [`scripts/csdn.py`](scripts/csdn.py) — self-contained, stdlib only.
+
+```sh
+CSDN=$SKILL_DIR/scripts/csdn.py
+python3 $CSDN whoami                       # who is logged in (+ total article count)
+python3 $CSDN articles --limit 20          # my published articles + stats
+python3 $CSDN article <article-id>         # one article's stats
+```
+
+Stats come straight from CSDN: `view_count` (阅读), `digg_count` (点赞),
+`comment_count` (评论), `collect_count` (收藏).
+
+## Verify the connection first
+
+```sh
+python3 $CSDN whoami
+# → {"username": "...", "nickname": "...", "articles_total": 1597}
+```
+
+On a WAF 403 / auth error the cookie is expired — tell the user to reconnect at
+<https://auth.acedata.cloud/user/connections>. Do **not** retry in a loop.
+
+## Publishing — GATED (dry-run unless trailing `--confirm`)
+
+`publish` writes to the user's real account. Content is **Markdown**. Without a
+trailing `--confirm` it dry-runs. `--confirm` is honored **only as the last
+argument**. Always show the dry-run, get an explicit "yes", then re-run with
+`--confirm` last.
+
+```sh
+python3 $CSDN publish --title "标题" --content-file a.md                      # dry-run
+python3 $CSDN publish --title "标题" --content-file a.md --draft-only --confirm  # private draft (status=2)
+python3 $CSDN publish --title "标题" --content-file a.md --tags "AI,Python" --confirm  # PUBLIC, goes live
+```
+
+- `--draft-only` saves a private draft (CSDN `status=2`) — safe, nothing public.
+- Without `--draft-only` the article is **published publicly** under the user's
+  name. Default to `--draft-only` unless the user clearly asked to go live.
+- `--tags` is a comma-separated list of article tags.
+
+## Gotchas — surface before the user is surprised
+
+- **This is the user's real CSDN account.** Confirm before any publish.
+- **Cookie expiry / WAF 403**: reconnect at auth.acedata.cloud/user/connections —
+  never loop-retry a WAF block.
+- The editor save endpoint is signed with an HMAC key baked into CSDN's web
+  bundle; if CSDN rotates it, publish fails loudly (reads still work).
+- **Never print `CSDN_COOKIES`** — it is full account access.
+- **ToS**: cookie automation acts only on the user's own account with their own
+  captured cookie; the user owns that risk.

--- a/skills/csdn/scripts/csdn.py
+++ b/skills/csdn/scripts/csdn.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+csdn — read & publish on CSDN (blog.csdn.net) with the user's own login cookies
+(BYOC). Standard-library only (urllib + hmac/hashlib for the editor signature),
+no third-party deps, so it runs in the bare sandbox without an image change.
+
+The connector injects the user's cookie jar as a JSON env var ``CSDN_COOKIES``.
+
+CSDN fronts its APIs with a WAF that 403s requests lacking a full browser
+fingerprint, so every request sends the complete header set. Reads
+(get-business-list) are cookie-only; the editor's saveArticle is on bizapi and
+needs an HMAC ``x-ca-*`` signature (the key/secret are baked into CSDN's web JS).
+
+Read commands run directly. ``publish`` is GATED by a trailing ``--confirm``
+(honored only as the last arg). ``--draft-only`` saves a private draft (status=2).
+
+Examples:
+  python3 csdn.py whoami
+  python3 csdn.py articles --limit 20
+  python3 csdn.py article <article-id>
+  python3 csdn.py publish --title T --content-file a.md --draft-only --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+import hmac
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+PLATFORM = "csdn"
+# x-ca signing constants — hard-coded in CSDN's editor web bundle (public).
+CA_KEY = "203803574"
+CA_SECRET = b"9znpamsyl2c7cdrr9sas0le9vbc3r6ba"
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar ──────────────────────────────────────────────────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect CSDN at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def cookie_value(jar: list, name: str):
+    for c in jar:
+        if c.get("name") == name:
+            return c.get("value")
+    return None
+
+
+# ── HTTP with a full browser fingerprint (CSDN WAF needs it) ────────
+
+def _browser_headers(jar: list, url: str, referer: str, origin: str) -> dict:
+    return {
+        "User-Agent": UA,
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Referer": referer,
+        "Origin": origin,
+        "sec-ch-ua": '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"macOS"',
+        "Sec-Fetch-Dest": "empty",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Site": "same-origin",
+    }
+
+
+def request(method: str, url: str, jar: list, *, referer, origin, headers=None, body=None):
+    hdrs = _browser_headers(jar, url, referer, origin)
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → urllib will NOT re-send the cookie if the API 30x-redirects
+    # to a different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def get_json(url: str, jar: list, *, referer, origin):
+    status, text = request("GET", url, jar, referer=referer, origin=origin)
+    if "WAF" in text and "403" in text:
+        die("CSDN WAF blocked the request (403). The cookie may be expired or "
+            "the account needs to re-pass CSDN's captcha; reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    if status in (401, 403):
+        die(f"auth failed ({status}) on {url} — cookie likely expired. "
+            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {url}: {text[:300]}")
+
+
+def ca_sign(method: str, path_with_query: str, content_type: str) -> dict:
+    """Aliyun-API-Gateway style HMAC-SHA256 signature CSDN's bizapi requires."""
+    nonce = str(uuid.uuid4())
+    string_to_sign = (
+        f"{method}\n*/*\n\n{content_type}\n\n"
+        f"x-ca-key:{CA_KEY}\nx-ca-nonce:{nonce}\n{path_with_query}"
+    )
+    sig = base64.b64encode(
+        hmac.new(CA_SECRET, string_to_sign.encode("utf-8"), hashlib.sha256).digest()
+    ).decode()
+    return {
+        "x-ca-key": CA_KEY,
+        "x-ca-nonce": nonce,
+        "x-ca-signature": sig,
+        "x-ca-signature-headers": "x-ca-key,x-ca-nonce",
+    }
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+BLOG = "https://blog.csdn.net"
+BIZ = "https://bizapi.csdn.net"
+
+
+def csdn_username(jar):
+    u = cookie_value(jar, "UserName")
+    if not u:
+        die("no UserName cookie — reconnect CSDN at "
+            "https://auth.acedata.cloud/user/connections.")
+    return u
+
+
+def _list_page(jar, username, page, size):
+    url = f"{BLOG}/community/home-api/v1/get-business-list?" + urllib.parse.urlencode(
+        {"page": page, "size": size, "businessType": "blog", "username": username})
+    d = get_json(url, jar, referer=f"{BLOG}/{username}?type=blog", origin=BLOG)
+    if d.get("code") != 200:
+        die(f"CSDN list error ({d.get('code')}): {d.get('message')}")
+    data = d.get("data") or {}
+    return data.get("list") or [], data.get("total")
+
+
+def cmd_whoami(jar, _args):
+    username = csdn_username(jar)
+    nick = cookie_value(jar, "UserNick")
+    if nick:
+        nick = urllib.parse.unquote(str(nick))
+    # verify the session is live + surface the article total
+    _, total = _list_page(jar, username, 1, 1)
+    out({
+        "username": username,
+        "nickname": nick,
+        "url": f"{BLOG}/{username}",
+        "articles_total": total,
+    })
+
+
+def _fmt(a: dict) -> dict:
+    return {
+        "id": str(a.get("articleId")) if a.get("articleId") is not None else None,
+        "title": a.get("title"),
+        "url": a.get("url"),
+        "view_count": a.get("viewCount"),
+        "digg_count": a.get("diggCount"),
+        "comment_count": a.get("commentCount"),
+        "collect_count": a.get("collectCount"),
+        "post_time": a.get("postTime") or a.get("formatTime"),
+    }
+
+
+def cmd_articles(jar, args):
+    username = csdn_username(jar)
+    collected, page, total = [], 1, None
+    while len(collected) < args.limit:
+        items, total = _list_page(jar, username, page, min(100, args.limit))
+        if not items:
+            break
+        collected.extend(items)
+        if total is not None and len(collected) >= total:
+            break
+        page += 1
+    items = collected[: args.limit]
+    out({"total": total, "count": len(items), "articles": [_fmt(a) for a in items]})
+
+
+def cmd_article(jar, args):
+    username = csdn_username(jar)
+    page = 1
+    while True:
+        items, total = _list_page(jar, username, page, 100)
+        if not items:
+            break
+        for a in items:
+            if str(a.get("articleId")) == str(args.id):
+                out(_fmt(a))
+                return
+        page += 1
+        if total is not None and page * 100 > total:
+            break
+    die(f"article {args.id} not found among your published articles")
+
+
+def cmd_publish(jar, args):
+    if not args.title:
+        die("--title is required")
+    if not args.content_file and args.content is None:
+        die("provide --content-file <path.md> or --content <markdown>")
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    content = content or ""
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "publish", "platform": "csdn",
+            "title": args.title, "draft_only": args.draft_only,
+            "content_bytes": len(content),
+            "note": "CSDN content is Markdown. Re-run with --confirm as the LAST "
+                    "argument to actually write. Without --draft-only it publishes "
+                    "a PUBLIC article on the user's real account.",
+        })
+        return
+
+    path = "/blog-console-api/v3/mdeditor/saveArticle"
+    url = f"{BIZ}{path}"
+    status_code = 2 if args.draft_only else 0
+    body = {
+        "title": args.title,
+        "markdowncontent": content,
+        "content": content,
+        "readType": "public",
+        "status": status_code,
+        "categories": "",
+        "tags": args.tags or "",
+        "type": "original",
+        "original_link": "",
+        "authorized_status": False,
+        "Description": content[:200],
+        "not_auto_saved": "1",
+        "source": "pc_mdeditor",
+        "cover_images": [],
+        "cover_type": 0,
+        "is_new": 1,
+        "vote_id": 0,
+        "pubStatus": "draft" if args.draft_only else "publish",
+    }
+    sign = ca_sign("POST", path, "application/json")
+    # The signature signs Accept=*/* and Content-Type=application/json verbatim,
+    # so the request must send exactly those (override the browser default Accept).
+    sign["Accept"] = "*/*"
+    status, text = request("POST", url, jar, referer="https://editor.csdn.net/",
+                           origin="https://editor.csdn.net", headers=sign, body=body)
+    try:
+        res = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"saveArticle returned non-JSON ({status}): {text[:300]}")
+    if res.get("code") != 200:
+        die(f"saveArticle failed (code={res.get('code')}): {res.get('msg') or res.get('message')}")
+    data = res.get("data") or {}
+    aid = data.get("id")
+    if args.draft_only:
+        out({"ok": True, "draft_only": True, "article_id": str(aid),
+             "edit_url": f"https://editor.csdn.net/md/?articleId={aid}"})
+    else:
+        out({"ok": True, "published": True, "article_id": str(aid),
+             "url": data.get("url") or f"{BLOG}/{csdn_username(jar)}/article/details/{aid}"})
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "articles": cmd_articles,
+    "article": cmd_article,
+    "publish": cmd_publish,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="csdn.py", description="csdn cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("articles", help="list the user's published articles + stats")
+    sp.add_argument("--limit", type=int, default=20)
+    sp = sub.add_parser("article", help="one article's stats")
+    sp.add_argument("id")
+    sp = sub.add_parser("publish", help="create/publish an article (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="Markdown content inline")
+    sp.add_argument("--content-file", help="path to a Markdown file")
+    sp.add_argument("--draft-only", action="store_true", help="save a private draft; do NOT go public")
+    sp.add_argument("--tags", help="comma-separated article tags")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/juejin/SKILL.md
+++ b/skills/juejin/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: juejin
+description: Read and publish on 掘金 / Juejin (juejin.cn) with the user's own login cookies (BYOC) — list their published articles with view/like/comment stats, inspect one article, and publish a new article. Use when the user mentions 掘金 / Juejin, "我的掘金文章", reading their article stats (阅读/点赞), or publishing/发文 to 掘金.
+when_to_use: |
+  Trigger for anything on the user's 掘金 (juejin.cn) account driven by their own
+  login cookie: show who they are, list their published articles with view /
+  like / comment counts, look at one article, or publish a new article. This
+  acts as the user's real account, so writes are gated behind an explicit
+  confirmation.
+connections: [juejin]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# juejin — read & publish on 掘金 via your own cookies
+
+Drives the user's **real** 掘金 account through the same `api.juejin.cn` web
+endpoints the site uses, authenticated by the login cookie they captured with
+the ACE extension. No browser, no third-party deps — just `urllib`.
+
+The connector injects the cookie jar as an env var:
+
+- `JUEJIN_COOKIES` — a JSON array of cookies. **Secret — never echo or print it.**
+
+## CLI
+
+The skill ships [`scripts/juejin.py`](scripts/juejin.py) — self-contained, stdlib only.
+
+```sh
+JJ=$SKILL_DIR/scripts/juejin.py
+python3 $JJ whoami                       # who is logged in (+ totals)
+python3 $JJ articles --limit 20          # my published articles + stats
+python3 $JJ article <article-id>         # one article's stats
+```
+
+Stats come straight from 掘金: `view_count` (阅读), `digg_count` (点赞),
+`comment_count` (评论), `collect_count` (收藏). `audit_status` 2 = online.
+
+## Verify the connection first
+
+```sh
+python3 $JJ whoami
+# → {"user_id": "...", "name": "...", "post_article_count": 336}
+```
+
+On an auth error (`err_no` 401 / "请登录") the cookie is expired — have the user
+reconnect at <https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+
+## Publishing — GATED (dry-run unless trailing `--confirm`)
+
+`publish` writes to the user's real account. Content is **Markdown**. Without a
+trailing `--confirm` it dry-runs. `--confirm` is honored **only as the last
+argument**. Always show the dry-run, get an explicit "yes", then re-run.
+
+```sh
+python3 $JJ publish --title "标题" --content-file a.md                       # dry-run
+python3 $JJ publish --title "标题" --content-file a.md --draft-only --confirm   # private draft
+python3 $JJ publish --title "标题" --content-file a.md \
+    --category-id 6809637769959178254 --tag-ids 6809640407484334093 --confirm # PUBLIC
+```
+
+- `--draft-only` creates a private draft (掘金 `article_draft`) — safe.
+- To **actually publish** (go through 审核), 掘金 requires a valid `--category-id`
+  and at least one `--tag-id`. Without them, use `--draft-only` and let the user
+  pick category/tags in the 掘金 editor. Default to `--draft-only`.
+
+## Gotchas
+
+- **This is the user's real 掘金 account.** Confirm before any publish.
+- Publishing without a category + tag is rejected in 审核; prefer `--draft-only`.
+- **Never print `JUEJIN_COOKIES`** — it is full account access.
+- **ToS**: acts only on the user's own account with their own captured cookie.

--- a/skills/juejin/scripts/juejin.py
+++ b/skills/juejin/scripts/juejin.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+juejin — read & publish on 掘金 (juejin.cn) with the user's own login cookies
+(BYOC). Standard-library only (urllib), no third-party deps, so it runs in the
+bare sandbox without an image change.
+
+The connector injects the user's cookie jar as a JSON env var ``JUEJIN_COOKIES``
+— a list of ``{name, value, domain, ...}`` dicts captured by the ACE extension.
+
+Read commands run directly. ``publish`` is GATED: without a trailing
+``--confirm`` it only dry-runs. ``--confirm`` is honored ONLY as the last
+argument, so a title/content that merely contains "--confirm" can never silently
+go live. ``--draft-only`` stops after creating a private draft.
+
+Examples:
+  python3 juejin.py whoami
+  python3 juejin.py articles --limit 20
+  python3 juejin.py article <article-id>
+  python3 juejin.py publish --title T --content-file a.md --draft-only --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+PLATFORM = "juejin"
+API = "https://api.juejin.cn"
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar (shared pattern across the cookie-BYOC skills) ────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect 掘金 at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def request(method: str, url: str, jar: list, *, headers=None, body=None):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "*/*",
+        "Origin": "https://juejin.cn",
+        "Referer": "https://juejin.cn/",
+    }
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def api_env(method: str, path: str, jar: list, *, body=None) -> dict:
+    """Return the full {err_no, data, cursor, has_more, ...} envelope, dying on
+    a non-zero err_no. Juejin returns HTTP 200 even on logical errors."""
+    url = f"{API}{path}"
+    status, text = request(method, url, jar, body=body)
+    try:
+        env = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {path}: {text[:300]}")
+    if not isinstance(env, dict):
+        die(f"unexpected response from {path}: {text[:300]}")
+    err = env.get("err_no")
+    if err and err != 0:
+        msg = env.get("err_msg", "")
+        if err in (401, 403) or "登录" in str(msg):
+            die(f"auth failed (err_no={err}: {msg}) — cookie likely expired. "
+                f"Reconnect at https://auth.acedata.cloud/user/connections.")
+        die(f"juejin API error on {path} (err_no={err}): {msg}")
+    return env
+
+
+def api_call(method: str, path: str, jar: list, *, body=None):
+    return api_env(method, path, jar, body=body).get("data")
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def jj_me(jar):
+    me = api_call("GET", "/user_api/v1/user/get", jar)
+    if not isinstance(me, dict) or not me.get("user_id"):
+        die(f"could not read 掘金 profile (cookie expired?): {str(me)[:300]}")
+    return me
+
+
+def cmd_whoami(jar, _args):
+    me = jj_me(jar)
+    out({
+        "user_id": me.get("user_id"),
+        "name": me.get("user_name"),
+        "url": f"https://juejin.cn/user/{me.get('user_id')}",
+        "post_article_count": me.get("post_article_count"),
+        "got_view_count": me.get("got_view_count"),
+        "got_digg_count": me.get("got_digg_count"),
+        "follower_count": me.get("follower_count"),
+    })
+
+
+def _fmt_article(item: dict) -> dict:
+    info = item.get("article_info") or {}
+    aid = item.get("article_id") or info.get("article_id")
+    return {
+        "id": str(aid) if aid is not None else None,
+        "title": info.get("title"),
+        "url": f"https://juejin.cn/post/{aid}" if aid else None,
+        "view_count": info.get("view_count"),
+        "digg_count": info.get("digg_count"),
+        "comment_count": info.get("comment_count"),
+        "collect_count": info.get("collect_count"),
+        "audit_status": info.get("audit_status"),
+        "ctime": info.get("ctime"),
+    }
+
+
+def _iter_my_articles(jar, uid):
+    cursor = "0"
+    for _ in range(50):  # hard cap so a bad has_more can't loop forever
+        env = api_env("POST", "/content_api/v1/article/query_list", jar,
+                      body={"user_id": str(uid), "cursor": cursor, "sort_type": 2})
+        items = env.get("data") or []
+        for it in items:
+            yield it
+        if not items or not env.get("has_more"):
+            break
+        cursor = env.get("cursor") or "0"
+
+
+def cmd_articles(jar, args):
+    me = jj_me(jar)
+    items = []
+    for it in _iter_my_articles(jar, me.get("user_id")):
+        items.append(it)
+        if len(items) >= args.limit:
+            break
+    out({"count": len(items), "articles": [_fmt_article(a) for a in items]})
+
+
+def cmd_article(jar, args):
+    # The detail endpoint is finicky for own cross-posted articles; the user's
+    # own list already carries the stats, so fall back to scanning it.
+    me = jj_me(jar)
+    for it in _iter_my_articles(jar, me.get("user_id")):
+        if str(it.get("article_id")) == str(args.id):
+            res = _fmt_article(it)
+            res["brief"] = ((it.get("article_info") or {}).get("brief_content") or "")[:200]
+            out(res)
+            return
+    die(f"article {args.id} not found among your published articles")
+
+
+def cmd_publish(jar, args):
+    if not args.title:
+        die("--title is required")
+    if not args.content_file and args.content is None:
+        die("provide --content-file <path.md> or --content <markdown>")
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "publish", "platform": "juejin",
+            "title": args.title, "draft_only": args.draft_only,
+            "content_bytes": len(content or ""),
+            "note": "掘金 content is Markdown. Re-run with --confirm as the LAST "
+                    "argument to actually write. Publishing (without --draft-only) "
+                    "needs a category + tag and goes through 审核.",
+        })
+        return
+
+    # 1. create draft
+    draft = api_call("POST", "/content_api/v1/article_draft/create", jar, body={
+        "category_id": args.category_id or "0",
+        "tag_ids": [t for t in (args.tag_ids or "").split(",") if t],
+        "link_url": "", "cover_image": "",
+        "title": args.title, "brief_content": (content or "")[:100],
+        "edit_type": 10, "html_content": "deprecated", "mark_content": content or "",
+        "theme_ids": [],
+    })
+    draft_id = draft.get("id") if isinstance(draft, dict) else None
+    if not draft_id:
+        die(f"create-draft failed: {str(draft)[:300]}")
+
+    if args.draft_only:
+        out({"ok": True, "draft_only": True, "draft_id": str(draft_id),
+             "edit_url": f"https://juejin.cn/editor/drafts/{draft_id}"})
+        return
+
+    # 2. publish (needs valid category + >=1 tag for 审核)
+    pub = api_call("POST", "/content_api/v1/article/publish", jar,
+                   body={"draft_id": str(draft_id), "sync_to_org": False,
+                         "column_ids": [], "theme_ids": []})
+    aid = pub.get("article_id") if isinstance(pub, dict) else None
+    if not aid:
+        die(f"publish failed (draft saved as {draft_id}): {str(pub)[:300]}")
+    out({"ok": True, "published": True, "article_id": str(aid),
+         "url": f"https://juejin.cn/post/{aid}"})
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "articles": cmd_articles,
+    "article": cmd_article,
+    "publish": cmd_publish,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="juejin.py", description="juejin cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("articles", help="list the user's published articles + stats")
+    sp.add_argument("--limit", type=int, default=20)
+    sp = sub.add_parser("article", help="one article's details + stats")
+    sp.add_argument("id")
+    sp = sub.add_parser("publish", help="create/publish an article (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="Markdown content inline")
+    sp.add_argument("--content-file", help="path to a Markdown file")
+    sp.add_argument("--draft-only", action="store_true", help="create a draft only; do NOT go public")
+    sp.add_argument("--category-id", help="掘金 category id (required to actually publish)")
+    sp.add_argument("--tag-ids", help="comma-separated tag ids (required to actually publish)")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: medium
+description: Read and publish on Medium (medium.com) with the user's own login cookies (BYOC) — list their posts with clap/response stats, inspect one post, and publish a new story. Use when the user mentions Medium, "my Medium posts", reading their post stats (claps/reads), or publishing a story to Medium.
+when_to_use: |
+  Trigger for anything on the user's Medium (medium.com) account driven by their
+  own login cookie: show who they are, list their posts with clap / response /
+  reading-time data, look at one post, or publish a new story. This acts as the
+  user's real account, so writes are gated behind an explicit confirmation.
+connections: [medium]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# medium — read & publish on Medium via your own cookies
+
+Drives the user's **real** Medium account through the same internal web API the
+site uses (Medium retired its public write API in 2023), authenticated by the
+login cookie they captured with the ACE extension. No browser, no third-party
+deps — just `urllib`.
+
+The connector injects the cookie jar as an env var:
+
+- `MEDIUM_COOKIES` — a JSON array of cookies (`sid`, `uid`, `xsrf`). **Secret —
+  never echo or print it.** The CLI echoes the `xsrf` cookie as the
+  `x-xsrf-token` header on writes for you.
+
+## CLI
+
+The skill ships [`scripts/medium.py`](scripts/medium.py) — self-contained, stdlib only.
+
+```sh
+MED=$SKILL_DIR/scripts/medium.py
+python3 $MED whoami                       # who is logged in
+python3 $MED articles --limit 20          # my posts + clap/response stats
+python3 $MED article <post-id>            # one post's details
+```
+
+## Verify the connection first
+
+```sh
+python3 $MED whoami
+# → {"user_id": "...", "name": "...", "username": "..."}
+```
+
+On an auth error the cookie is expired — have the user reconnect at
+<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+
+## Publishing — GATED (dry-run unless trailing `--confirm`)
+
+`publish` writes to the user's real account. Content is **Markdown** (converted
+to Medium paragraph blocks: `#`→H1, `##`→H2, `>`→quote, ```` ``` ````→code).
+Without a trailing `--confirm` it dry-runs. `--confirm` is honored **only as the
+last argument**. Always show the dry-run, get an explicit "yes", then re-run.
+
+```sh
+python3 $MED publish --title "Title" --content-file a.md                       # dry-run
+python3 $MED publish --title "Title" --content-file a.md --draft-only --confirm   # private draft
+python3 $MED publish --title "Title" --content-file a.md --confirm                # PUBLIC story
+```
+
+Publishing is Medium's multi-step editor flow (new-story → write deltas →
+publish). `--draft-only` stops at the draft (visible only at the user's
+`/me/stories/drafts`). Default to `--draft-only` unless the user asked to go live.
+
+## Gotchas
+
+- **This is the user's real Medium account.** Confirm before any publish.
+- Markdown→Medium conversion is paragraph-level (headings, quotes, code, body);
+  complex inline formatting / images aren't converted — the user can polish in
+  the Medium editor before going public.
+- Medium sits behind Cloudflare; an occasional 403/429 is transient.
+- **Never print `MEDIUM_COOKIES`** — it is full account access.
+- **ToS**: acts only on the user's own account with their own captured cookie.

--- a/skills/medium/scripts/medium.py
+++ b/skills/medium/scripts/medium.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+medium — read & publish on Medium (medium.com) with the user's own login cookies
+(BYOC). Standard-library only (urllib), no third-party deps.
+
+Medium retired its public write API in 2023, so this drives the same internal
+endpoints the website uses, authenticated by the session cookies (``sid``,
+``uid``, ``xsrf``). State-changing calls must echo the ``xsrf`` cookie as the
+``x-xsrf-token`` header. Internal ``/_/api`` responses are prefixed with
+``])}while(1);</x>`` which is stripped before parsing.
+
+The connector injects the cookie jar as a JSON env var ``MEDIUM_COOKIES``.
+
+Read commands run directly. ``publish`` is GATED by a trailing ``--confirm``
+(honored only as the last arg). ``--draft-only`` stops at a private draft.
+Publishing uses Medium's multi-step editor flow (new-story → deltas → publish).
+
+Examples:
+  python3 medium.py whoami
+  python3 medium.py articles --limit 20
+  python3 medium.py article <post-id>
+  python3 medium.py publish --title T --content-file a.md --draft-only --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+PLATFORM = "medium"
+BASE = "https://medium.com"
+_PREFIX = re.compile(r"^\s*\]\)\}while\(1\);(?:</x>)?")
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar ──────────────────────────────────────────────────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect Medium at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def cookie_value(jar: list, name: str):
+    for c in jar:
+        if c.get("name") == name:
+            return c.get("value")
+    return None
+
+
+# ── HTTP ────────────────────────────────────────────────────────────
+
+def request(method, url, jar, *, headers=None, body=None, accept="application/json"):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": accept,
+        "Origin": BASE,
+        "Referer": BASE + "/",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    xsrf = cookie_value(jar, "xsrf")
+    if xsrf and method != "GET":
+        hdrs["x-xsrf-token"] = xsrf
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def api(method, url, jar, *, body=None):
+    status, text = request(method, url, jar, body=body)
+    if status in (401, 403):
+        die(f"auth failed ({status}) on {url} — cookie likely expired. "
+            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+    clean = _PREFIX.sub("", text)
+    try:
+        d = json.loads(clean)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {url}: {clean[:300]}")
+    if isinstance(d, dict) and d.get("success") is False:
+        die(f"Medium API error ({status}) on {url}: {d.get('error')}")
+    return d
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def md_me(jar):
+    uid = cookie_value(jar, "uid")
+    if not uid:
+        die("no uid cookie — reconnect Medium at "
+            "https://auth.acedata.cloud/user/connections.")
+    d = api("GET", f"{BASE}/_/api/users/{uid}", jar)
+    val = (d.get("payload") or {}).get("value") or {}
+    if not val.get("userId"):
+        die(f"could not read Medium profile (cookie expired?): {str(d)[:200]}")
+    return val
+
+
+def cmd_whoami(jar, _args):
+    me = md_me(jar)
+    out({
+        "user_id": me.get("userId"),
+        "name": me.get("name"),
+        "username": me.get("username"),
+        "url": f"{BASE}/@{me.get('username')}",
+        "bio": me.get("bio"),
+    })
+
+
+_USER_POSTS_QUERY = (
+    "query UserProfileQuery($username: ID, $homepagePostsLimit: PaginationLimit) "
+    "{ userResult(username: $username) { __typename ... on User { id name "
+    "homepagePostsConnection(paging: {limit: $homepagePostsLimit}) { posts { "
+    "id title clapCount postResponses { count } readingTime "
+    "firstPublishedAt } } } } }"
+)
+
+
+def gql(jar, operation, variables):
+    status, text = request("POST", f"{BASE}/_/graphql", jar,
+                           headers={"graphql-operation": operation},
+                           body={"operationName": operation, "variables": variables,
+                                 "query": _USER_POSTS_QUERY})
+    if status in (401, 403):
+        die(f"auth failed ({status}) on GraphQL — cookie likely expired.")
+    try:
+        d = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON GraphQL response ({status}): {text[:300]}")
+    if d.get("errors"):
+        die(f"GraphQL error: {str(d['errors'])[:300]}")
+    return d.get("data") or {}
+
+
+def cmd_articles(jar, args):
+    me = md_me(jar)
+    data = gql(jar, "UserProfileQuery",
+               {"username": me.get("username"), "homepagePostsLimit": args.limit})
+    posts = (((data.get("userResult") or {}).get("homepagePostsConnection")) or {}).get("posts") or []
+    out({"count": len(posts), "articles": [{
+        "id": p.get("id"),
+        "title": p.get("title"),
+        "url": f"{BASE}/p/{p.get('id')}",
+        "claps": p.get("clapCount"),
+        "responses": (p.get("postResponses") or {}).get("count"),
+        "reading_time_min": round(p.get("readingTime"), 1) if p.get("readingTime") else None,
+        "first_published_at": p.get("firstPublishedAt"),
+    } for p in posts]})
+
+
+def cmd_article(jar, args):
+    d = api("GET", f"{BASE}/_/api/posts/{args.id}", jar)
+    val = (d.get("payload") or {}).get("value") or {}
+    if not val.get("id"):
+        die(f"post {args.id} not found or not accessible")
+    vc = val.get("virtuals") or {}
+    out({
+        "id": val.get("id"),
+        "title": val.get("title"),
+        "url": val.get("mediumUrl") or f"{BASE}/p/{val.get('id')}",
+        "claps": vc.get("totalClapCount"),
+        "reading_time": vc.get("readingTime"),
+        "word_count": vc.get("wordCount"),
+        "created_at": val.get("createdAt"),
+    })
+
+
+def _markdown_to_deltas(title: str, content: str) -> list:
+    """Minimal Markdown → Medium paragraph deltas. Title is a type-3 paragraph;
+    body blocks split on blank lines; ``#``/``##``/``###`` map to h1/h2/h3,
+    ``>`` to blockquote, ``` ``` to code, everything else to body text."""
+    paras = [{"type": 3, "text": title}]
+    blocks = re.split(r"\n\s*\n", content.strip())
+    in_code = False
+    code_buf = []
+    for block in blocks:
+        b = block.strip("\n")
+        if not b.strip():
+            continue
+        first = b.lstrip()
+        if first.startswith("```"):
+            # toggle / inline fenced block
+            body = re.sub(r"^```[^\n]*\n?|\n?```$", "", b)
+            paras.append({"type": 8, "text": body})
+            continue
+        if first.startswith("# "):
+            paras.append({"type": 12, "text": first[2:].strip()})
+        elif first.startswith("## "):
+            paras.append({"type": 2, "text": first[3:].strip()})
+        elif first.startswith("### "):
+            paras.append({"type": 3, "text": first[4:].strip()})
+        elif first.startswith("> "):
+            paras.append({"type": 6, "text": first[2:].strip()})
+        else:
+            paras.append({"type": 1, "text": b.replace("\n", " ").strip()})
+    deltas = []
+    for i, p in enumerate(paras):
+        deltas.append({"type": 1, "index": i,
+                       "paragraph": {"type": p["type"], "text": p["text"], "markups": []}})
+    return deltas
+
+
+def cmd_publish(jar, args):
+    if not args.title:
+        die("--title is required")
+    if not args.content_file and args.content is None:
+        die("provide --content-file <path.md> or --content <markdown>")
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    content = content or ""
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "publish", "platform": "medium",
+            "title": args.title, "draft_only": args.draft_only,
+            "content_bytes": len(content),
+            "note": "Medium content is Markdown (converted to paragraph deltas). "
+                    "Re-run with --confirm as the LAST argument to write. Without "
+                    "--draft-only it publishes a PUBLIC story on the user's account.",
+        })
+        return
+
+    # 1. create empty draft
+    d = api("POST", f"{BASE}/new-story", jar, body={})
+    payload = d.get("payload") or {}
+    post_id = payload.get("id") or (payload.get("value") or {}).get("id")
+    if not post_id:
+        die(f"new-story did not return a post id: {str(d)[:200]}")
+
+    # 2. read the draft for the base revision
+    d2 = api("GET", f"{BASE}/_/api/posts/{post_id}/draft", jar)
+    val = (d2.get("payload") or {}).get("value") or {}
+    base_rev = val.get("latestRev")
+    if base_rev is None:
+        base_rev = 0
+
+    # 3. write the body as paragraph deltas
+    deltas = _markdown_to_deltas(args.title, content)
+    api("POST", f"{BASE}/p/{post_id}/deltas", jar,
+        body={"baseRev": base_rev, "deltas": deltas})
+
+    if args.draft_only:
+        out({"ok": True, "draft_only": True, "post_id": post_id,
+             "edit_url": f"{BASE}/p/{post_id}/edit"})
+        return
+
+    # 4. publish (go public)
+    api("POST", f"{BASE}/p/{post_id}/publish", jar, body={})
+    out({"ok": True, "published": True, "post_id": post_id,
+         "url": f"{BASE}/p/{post_id}"})
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "articles": cmd_articles,
+    "article": cmd_article,
+    "publish": cmd_publish,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="medium.py", description="medium cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("articles", help="list the user's posts + stats")
+    sp.add_argument("--limit", type=int, default=20)
+    sp = sub.add_parser("article", help="one post's details + stats")
+    sp.add_argument("id")
+    sp = sub.add_parser("publish", help="create/publish a story (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="Markdown content inline")
+    sp.add_argument("--content-file", help="path to a Markdown file")
+    sp.add_argument("--draft-only", action="store_true", help="create a draft only; do NOT go public")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/weibo/SKILL.md
+++ b/skills/weibo/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: weibo
+description: Read and post on 微博 / Weibo (weibo.com) with the user's own login cookies (BYOC) — list their recent posts with repost/comment/like counts and publish a new 微博. Use when the user mentions 微博 / Weibo, "我的微博", reading their post engagement, or 发微博 / posting to Weibo.
+when_to_use: |
+  Trigger for anything on the user's 微博 (weibo.com) account driven by their own
+  login cookie: show who they are, list their recent 微博 with repost / comment /
+  like counts, or publish a new 微博. This acts as the user's real account, so
+  posting is gated behind an explicit confirmation.
+connections: [weibo]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# weibo — read & post on 微博 via your own cookies
+
+Drives the user's **real** 微博 account through the same `weibo.com/ajax` web API
+the site uses, authenticated by the login cookie they captured with the ACE
+extension. No browser, no third-party deps — just `urllib`.
+
+> ⚠️ **Not yet E2E-verified.** Unlike the other cookie skills (csdn / juejin /
+> bilibili / medium), this one was built from the documented web API but could
+> not be tested against a live account (no 微博 connection existed at build
+> time). The first live run is the verification; if an endpoint shape drifted it
+> will surface as a clear error rather than silent breakage.
+
+The connector injects the cookie jar as an env var:
+
+- `WEIBO_COOKIES` — a JSON array of cookies. **Secret — never echo or print it.**
+  Writes send the `XSRF-TOKEN` cookie as both the `x-xsrf-token` header and the
+  `st` form field (the CLI does this for you).
+
+## CLI
+
+The skill ships [`scripts/weibo.py`](scripts/weibo.py) — self-contained, stdlib only.
+
+```sh
+WB=$SKILL_DIR/scripts/weibo.py
+python3 $WB whoami                       # who is logged in (+ counts)
+python3 $WB posts --limit 20             # my recent 微博 + engagement
+```
+
+Engagement comes straight from 微博: `reposts_count` (转发), `comments_count`
+(评论), `attitudes_count` (赞).
+
+## Verify the connection first
+
+```sh
+python3 $WB whoami
+# → {"uid": "...", "name": "...", "statuses_count": ...}
+```
+
+On an auth error the cookie is expired — have the user reconnect at
+<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+
+## Posting — GATED (dry-run unless trailing `--confirm`)
+
+微博 are short-form, so there is **no draft step** — a confirmed post goes live.
+Without a trailing `--confirm` it dry-runs. `--confirm` is honored **only as the
+last argument**. Always show the dry-run, get an explicit "yes", then re-run.
+
+```sh
+python3 $WB post --content "你好，这是一条微博"            # dry-run
+python3 $WB post --content "你好，这是一条微博" --confirm   # PUBLIC 微博 (immediate)
+```
+
+- There is **no draft and no private mode** on 微博 — a confirmed post is
+  immediately **public**. Always show the dry-run and get explicit approval of
+  the exact text before adding `--confirm`.
+
+## Gotchas
+
+- **This is the user's real 微博 account.** Confirm before any post — it is
+  immediate and public by default.
+- **Not E2E-verified** (see the warning above) — expect to validate the first run.
+- **Never print `WEIBO_COOKIES`** — it is full account access.
+- **ToS**: acts only on the user's own account with their own captured cookie.

--- a/skills/weibo/scripts/weibo.py
+++ b/skills/weibo/scripts/weibo.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+weibo — read & post on 微博 (weibo.com) with the user's own login cookies (BYOC).
+Standard-library only (urllib), no third-party deps.
+
+Drives Weibo's web ``ajax`` API (the same one weibo.com's SPA uses), authenticated
+by the login cookies. State-changing calls send the ``XSRF-TOKEN`` cookie both as
+the ``x-xsrf-token`` header and as the ``st`` form field.
+
+The connector injects the cookie jar as a JSON env var ``WEIBO_COOKIES``.
+
+⚠️ NOT YET E2E-VERIFIED: unlike the other cookie skills, this one was built from
+the documented web API but could not be tested against a live account (no 微博
+connection was present at build time). Treat the first live run as the
+verification — if an endpoint shape drifted, it will surface as a clear error.
+
+Weibo posts are short-form (a 微博), so there is no draft step and no private
+mode — a confirmed post is immediately public. ``post`` is GATED by a trailing
+``--confirm`` (honored only as the last arg); without it, it dry-runs.
+
+Examples:
+  python3 weibo.py whoami
+  python3 weibo.py posts --limit 20
+  python3 weibo.py post --content "hello" --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+PLATFORM = "weibo"
+BASE = "https://weibo.com"
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect 微博 at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def cookie_value(jar: list, name: str):
+    for c in jar:
+        if c.get("name") == name:
+            return c.get("value")
+    return None
+
+
+def request(method, url, jar, *, headers=None, form=None):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "application/json, text/plain, */*",
+        "Referer": BASE + "/",
+    }
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if form is not None:
+        data = urllib.parse.urlencode(form).encode("utf-8")
+        hdrs["Content-Type"] = "application/x-www-form-urlencoded"
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def get_json(url, jar):
+    status, text = request("GET", url, jar)
+    if status in (401, 403):
+        die(f"auth failed ({status}) on {url} — cookie likely expired. "
+            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {url}: {text[:300]}")
+
+
+def st_token(jar):
+    tok = cookie_value(jar, "XSRF-TOKEN")
+    if not tok:
+        die("no XSRF-TOKEN cookie — reconnect 微博 at "
+            "https://auth.acedata.cloud/user/connections.")
+    return tok
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def wb_uid(jar):
+    cfg = get_json(f"{BASE}/ajax/setting/getConfig", jar)
+    data = cfg.get("data") or {}
+    uid = data.get("uid")
+    if not uid:
+        die("not logged in or uid unavailable (cookie expired?) — reconnect 微博 "
+            "at https://auth.acedata.cloud/user/connections.")
+    return uid
+
+
+def cmd_whoami(jar, _args):
+    uid = wb_uid(jar)
+    info = get_json(f"{BASE}/ajax/profile/info?uid={uid}", jar)
+    u = (info.get("data") or {}).get("user") or {}
+    out({
+        "uid": str(uid),
+        "name": u.get("screen_name"),
+        "url": f"{BASE}/u/{uid}",
+        "followers_count": u.get("followers_count"),
+        "friends_count": u.get("friends_count"),
+        "statuses_count": u.get("statuses_count"),
+    })
+
+
+def _fmt(m: dict) -> dict:
+    mid = m.get("mblogid") or m.get("id")
+    return {
+        "id": str(m.get("id")),
+        "mblogid": m.get("mblogid"),
+        "text": (m.get("text_raw") or m.get("text") or "")[:140],
+        "url": f"{BASE}/{m.get('user', {}).get('idstr', '')}/{mid}" if mid else None,
+        "reposts_count": m.get("reposts_count"),
+        "comments_count": m.get("comments_count"),
+        "attitudes_count": m.get("attitudes_count"),
+        "created_at": m.get("created_at"),
+    }
+
+
+def cmd_posts(jar, args):
+    uid = wb_uid(jar)
+    collected, page = [], 1
+    while len(collected) < args.limit:
+        url = f"{BASE}/ajax/statuses/mymblog?uid={uid}&page={page}&feature=0"
+        d = get_json(url, jar)
+        items = (d.get("data") or {}).get("list") or []
+        if not items:
+            break
+        collected.extend(items)
+        page += 1
+    items = collected[: args.limit]
+    out({"count": len(items), "posts": [_fmt(m) for m in items]})
+
+
+def cmd_post(jar, args):
+    if not args.content and not args.content_file:
+        die("provide --content <text> or --content-file <path>")
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    content = (content or "").strip()
+    if not content:
+        die("content is empty")
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "post", "platform": "weibo",
+            "content_preview": content[:140],
+            "note": "Re-run with --confirm as the LAST argument to actually post. "
+                    "This posts a PUBLIC 微博 on the user's real account (微博 has no "
+                    "draft; a confirmed post is immediately public).",
+        })
+        return
+
+    tok = st_token(jar)
+    form = {"content": content, "st": tok, "visible": 0,
+            "pic_id": "", "pdetail": "", "media": "", "vote": ""}
+    status, text = request("POST", f"{BASE}/ajax/statuses/update", jar,
+                           headers={"x-xsrf-token": tok, "Origin": BASE}, form=form)
+    try:
+        r = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"post returned non-JSON ({status}): {text[:300]}")
+    data = r.get("data") or {}
+    if r.get("ok") == 1 or data.get("id"):
+        mid = data.get("mblogid") or data.get("id")
+        out({"ok": True, "posted": True, "id": str(data.get("id")),
+             "url": f"{BASE}/detail/{mid}" if mid else None})
+    else:
+        die(f"post failed ({status}): {str(r)[:300]}")
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "posts": cmd_posts,
+    "post": cmd_post,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="weibo.py", description="weibo cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("posts", help="list the user's recent 微博 + engagement")
+    sp.add_argument("--limit", type=int, default=20)
+    sp = sub.add_parser("post", help="publish a 微博 (GATED by trailing --confirm)")
+    sp.add_argument("--content", help="post text inline")
+    sp.add_argument("--content-file", help="path to a text file")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Five new cookie-jar **BYOC** skills, same pattern as `zhihu`: each drives the user's **real** account on a content platform through the site's own web APIs, authenticated by the login cookie the ACE extension captured. **stdlib-only** (`urllib` + `hmac`/`hashlib` for signing) — no sandbox image change. Each skill = `skills/<platform>/SKILL.md` + `scripts/<platform>.py` with `whoami` / list / one / `publish`.

**Publish is safety-gated** (same as zhihu): a write happens only if the **last** argv token is exactly `--confirm` (so a title/content containing `--confirm` can't trigger a write), and `--draft-only` keeps it private. Reads run directly.

## E2E-verified in-cluster against the real account

| Skill | Read | Write | Notes |
|---|---|---|---|
| **csdn** | ✅ whoami + articles + article (view/like/comment) | ✅ **x-ca HMAC-signed** draft (`162179886`) | WAF needs full browser headers (handled) |
| **juejin** | ✅ whoami + articles + article | ✅ draft (`7653708807582793774`) | cookie-only |
| **bilibili** | ✅ whoami + 专栏 list (**WBI-signed**) + viewinfo | ✅ write path reached API (`csrf=bili_jct`) | test draft blocked only by the account's 999-draft cap — auth correct |
| **medium** | ✅ whoami + posts (**GraphQL**) + article | ✅ **delta-flow** draft (`74a2dcf9f3bd`) | internal API (public API retired 2023) |
| **weibo** | ⚠️ built per web ajax API | ⚠️ | **NOT E2E-verified** — no 微博 cookie was connected at build time; flagged in its SKILL.md |

*(The 4 test drafts are private and safe to delete.)*

## Companion
AuthBackend PR wires each connector's `required_skills: [acedatacloud/<platform>]` so installing the connector auto-installs the skill.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`), **2 rounds**.

**Round 1 — 3 RISKs, all fixed:**
- **Cookie leak on redirect** (all 5): `urlopen` followed redirects re-sending the manually-set `Cookie` header to the redirect host → now set via `add_unredirected_header("Cookie", …)` so urllib never forwards the jar across a redirect (sent on the initial request as before; re-verified all 4 reads still work).
- **weibo `--private` fail-open**: an unverifiable privacy flag could post publicly while the user thought it was private → flag removed; weibo posts are public, `--confirm`-gated, documented as such.
- **weibo `uid=None`**: treated `login=true` as enough → now requires `uid`, dies clearly otherwise.

**Round 2 — 1 nit, fixed:** stale `--private` mention in the weibo module docstring → removed.

**VERDICT: CLEAN** (converged round 2).