### PR TITLE
fix(skills): sh-portable curl auth header (drop bash arrays)

### DIFF
--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -27,11 +27,11 @@ segment of a pasted URL. A **node id** is in `?node-id=1-23` (Figma shows `1:23`
 the API also accepts `1:23`).
 
 ```bash
-F="https://api.figma.com/v1"; AUTH=(-H "Authorization: Bearer $FIGMA_TOKEN")
+F="https://api.figma.com/v1"; AUTH="Authorization: Bearer $FIGMA_TOKEN"
 # Who am I (account card)
-curl -sS "${AUTH[@]}" "$F/me" | jq '{handle, email}'
+curl -sS -H "$AUTH" "$F/me" | jq '{handle, email}'
 # File document tree (name + top-level frames). Big files: prefer /nodes below.
-curl -sS "${AUTH[@]}" "$F/files/FILE_KEY?depth=2" \
+curl -sS -H "$AUTH" "$F/files/FILE_KEY?depth=2" \
   | jq '{name, pages: [.document.children[] | {name, frames: [.children[]?.name]}]}'
 ```
 
@@ -40,11 +40,11 @@ curl -sS "${AUTH[@]}" "$F/files/FILE_KEY?depth=2" \
 ```bash
 KEY="FILE_KEY"
 # Just the nodes you care about (faster than the whole file)
-curl -sS "${AUTH[@]}" "$F/files/$KEY/nodes?ids=1:23,1:45" \
+curl -sS -H "$AUTH" "$F/files/$KEY/nodes?ids=1:23,1:45" \
   | jq '.nodes | to_entries[] | {id: .key, name: .value.document.name, type: .value.document.type}'
 
 # Render nodes to images — returns temporary CDN URLs (this is the "see it" tool)
-curl -sS "${AUTH[@]}" "$F/images/$KEY?ids=1:23&format=png&scale=2" \
+curl -sS -H "$AUTH" "$F/images/$KEY?ids=1:23&format=png&scale=2" \
   | jq '.images'   # { "1:23": "https://...png" }
 ```
 
@@ -54,10 +54,10 @@ For design-to-code, render the frame to PNG (to view) and read its node JSON
 ## Comments & projects
 
 ```bash
-curl -sS "${AUTH[@]}" "$F/files/FILE_KEY/comments" \
+curl -sS -H "$AUTH" "$F/files/FILE_KEY/comments" \
   | jq '.comments[] | {user: .user.handle, at: .created_at, message}'
 # Team projects → files (needs a team id from the Figma URL /team/<id>/...)
-curl -sS "${AUTH[@]}" "$F/teams/TEAM_ID/projects" | jq '.projects'
+curl -sS -H "$AUTH" "$F/teams/TEAM_ID/projects" | jq '.projects'
 ```
 
 ## Gotchas

--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -35,16 +35,16 @@ say so rather than calling the API (it would 401/DEVELOPER_TOKEN_NOT_APPROVED).
 
 ```bash
 VER="v18"; BASE="https://googleads.googleapis.com/$VER"
-AUTH=(-H "Authorization: Bearer $GOOGLE_ADS_TOKEN" -H "developer-token: $GOOGLE_ADS_DEVELOPER_TOKEN")
+AUTH="Authorization: Bearer $GOOGLE_ADS_TOKEN"; DEV="developer-token: $GOOGLE_ADS_DEVELOPER_TOKEN"
 # Customers the OAuth user can access (ids are returned as customers/<id>)
-curl -sS "${AUTH[@]}" "$BASE/customers:listAccessibleCustomers" | jq '.resourceNames'
+curl -sS -H "$AUTH" -H "$DEV" "$BASE/customers:listAccessibleCustomers" | jq '.resourceNames'
 ```
 
 ## Report with GAQL (searchStream)
 
 ```bash
 CID="1234567890"   # target customer id, digits only
-curl -sS "${AUTH[@]}" -H "login-customer-id: ${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$CID}" \
+curl -sS -H "$AUTH" -H "$DEV" -H "login-customer-id: ${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$CID}" \
   -H "Content-Type: application/json" -d '{
   "query":"SELECT campaign.name, metrics.cost_micros, metrics.clicks, metrics.conversions FROM campaign WHERE segments.date DURING LAST_30_DAYS ORDER BY metrics.cost_micros DESC"
 }' "$BASE/customers/$CID/googleAds:searchStream" \

--- a/skills/google-analytics/SKILL.md
+++ b/skills/google-analytics/SKILL.md
@@ -24,9 +24,9 @@ Failures are `{"error":{"code","message","status"}}` — show verbatim. `401` =
 re-install.
 
 ```bash
-AUTH=(-H "Authorization: Bearer $GOOGLE_ANALYTICS_TOKEN")
+AUTH="Authorization: Bearer $GOOGLE_ANALYTICS_TOKEN"
 # List the GA4 properties the user can access (via their account summaries)
-curl -sS "${AUTH[@]}" "https://analyticsadmin.googleapis.com/v1beta/accountSummaries" \
+curl -sS -H "$AUTH" "https://analyticsadmin.googleapis.com/v1beta/accountSummaries" \
   | jq '.accountSummaries[]?.propertySummaries[]? | {property, displayName}'
 ```
 
@@ -36,7 +36,7 @@ curl -sS "${AUTH[@]}" "https://analyticsadmin.googleapis.com/v1beta/accountSumma
 
 ```bash
 PID="123456789"
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" -d '{
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" -d '{
   "dateRanges":[{"startDate":"28daysAgo","endDate":"today"}],
   "dimensions":[{"name":"pagePath"}],
   "metrics":[{"name":"screenPageViews"},{"name":"activeUsers"}],
@@ -54,7 +54,7 @@ Swap dimensions/metrics for other reports: `sessionDefaultChannelGroup` +
 ## Realtime
 
 ```bash
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"dimensions":[{"name":"country"}],"metrics":[{"name":"activeUsers"}]}' \
   "https://analyticsdata.googleapis.com/v1beta/properties/$PID:runRealtimeReport" | jq '.rows'
 ```

--- a/skills/google-docs/SKILL.md
+++ b/skills/google-docs/SKILL.md
@@ -26,9 +26,9 @@ re-install. `403 PERMISSION_DENIED` on a write = read-only scope.
 The doc id is the `…/document/d/<ID>/edit` segment of the URL.
 
 ```bash
-D="https://docs.googleapis.com/v1/documents"; AUTH=(-H "Authorization: Bearer $GOOGLE_DOCS_TOKEN")
+D="https://docs.googleapis.com/v1/documents"; AUTH="Authorization: Bearer $GOOGLE_DOCS_TOKEN"
 # Read the document. The body is a tree of structural elements; pull plain text:
-curl -sS "${AUTH[@]}" "$D/DOC_ID" \
+curl -sS -H "$AUTH" "$D/DOC_ID" \
   | jq -r '.title, ([.body.content[]?.paragraph?.elements[]?.textRun?.content] | join(""))'
 ```
 
@@ -36,16 +36,16 @@ curl -sS "${AUTH[@]}" "$D/DOC_ID" \
 
 ```bash
 # Create an empty doc
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"title":"Meeting notes 2026-06-21"}' "$D" | jq '{documentId, title}'
 
 # Insert text at the start (index 1) via batchUpdate (confirm first)
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"requests":[{"insertText":{"location":{"index":1},"text":"Hello\n"}}]}' \
   "$D/DOC_ID:batchUpdate" | jq '.documentId'
 
 # Replace all occurrences of a placeholder
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"requests":[{"replaceAllText":{"containsText":{"text":"{{name}}","matchCase":true},"replaceText":"Alex"}}]}' \
   "$D/DOC_ID:batchUpdate" | jq '.replies'
 ```

--- a/skills/google-search-console/SKILL.md
+++ b/skills/google-search-console/SKILL.md
@@ -24,9 +24,9 @@ Failures are `{"error":{"code","message","status"}}` — show verbatim. `401` =
 re-install. `403` = the token's account doesn't own/verify that site.
 
 ```bash
-AUTH=(-H "Authorization: Bearer $GOOGLE_SEARCH_CONSOLE_TOKEN")
+AUTH="Authorization: Bearer $GOOGLE_SEARCH_CONSOLE_TOKEN"
 # Verified sites (siteUrl is the property — URL-encode it in later calls)
-curl -sS "${AUTH[@]}" "https://searchconsole.googleapis.com/webmasters/v3/sites" \
+curl -sS -H "$AUTH" "https://searchconsole.googleapis.com/webmasters/v3/sites" \
   | jq '.siteEntry[] | {siteUrl, permissionLevel}'
 ```
 
@@ -36,7 +36,7 @@ curl -sS "${AUTH[@]}" "https://searchconsole.googleapis.com/webmasters/v3/sites"
 # Top queries by clicks for the last 28 days. siteUrl must be URL-encoded
 # (https%3A%2F%2Fexample.com%2F  or  sc-domain%3Aexample.com).
 SITE="https%3A%2F%2Fexample.com%2F"
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" -d '{
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" -d '{
   "startDate":"2026-05-24","endDate":"2026-06-21",
   "dimensions":["query"],"rowLimit":10
 }' "https://searchconsole.googleapis.com/webmasters/v3/sites/$SITE/searchAnalytics/query" \
@@ -50,11 +50,11 @@ Swap `dimensions` for `["page"]`, `["country"]`, `["date"]`, or combine
 
 ```bash
 # Submitted sitemaps
-curl -sS "${AUTH[@]}" "https://searchconsole.googleapis.com/webmasters/v3/sites/$SITE/sitemaps" \
+curl -sS -H "$AUTH" "https://searchconsole.googleapis.com/webmasters/v3/sites/$SITE/sitemaps" \
   | jq '.sitemap[] | {path, lastDownloaded, errors, warnings}'
 
 # Is a URL indexed?
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"inspectionUrl":"https://example.com/page","siteUrl":"https://example.com/"}' \
   "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect" \
   | jq '.inspectionResult.indexStatusResult | {verdict, coverageState, lastCrawlTime}'

--- a/skills/google-sheets/SKILL.md
+++ b/skills/google-sheets/SKILL.md
@@ -29,9 +29,9 @@ with read+write.
 The spreadsheet id is the `…/spreadsheets/d/<ID>/edit` segment of the URL.
 
 ```bash
-S="https://sheets.googleapis.com/v4/spreadsheets"; AUTH=(-H "Authorization: Bearer $GOOGLE_SHEETS_TOKEN")
+S="https://sheets.googleapis.com/v4/spreadsheets"; AUTH="Authorization: Bearer $GOOGLE_SHEETS_TOKEN"
 # Tabs + title
-curl -sS "${AUTH[@]}" "$S/SPREADSHEET_ID?fields=properties.title,sheets.properties(title,sheetId)" \
+curl -sS -H "$AUTH" "$S/SPREADSHEET_ID?fields=properties.title,sheets.properties(title,sheetId)" \
   | jq '{title: .properties.title, tabs: [.sheets[].properties.title]}'
 ```
 
@@ -40,15 +40,15 @@ curl -sS "${AUTH[@]}" "$S/SPREADSHEET_ID?fields=properties.title,sheets.properti
 ```bash
 ID="SPREADSHEET_ID"
 # Read a range (A1 notation; values are rows of cells)
-curl -sS "${AUTH[@]}" "$S/$ID/values/Sheet1!A1:D20" | jq '.values'
+curl -sS -H "$AUTH" "$S/$ID/values/Sheet1!A1:D20" | jq '.values'
 
 # Append rows (confirm first). valueInputOption=USER_ENTERED parses formulas/dates.
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"values":[["2026-06-21","Acme",4200]]}' \
   "$S/$ID/values/Sheet1!A1:append?valueInputOption=USER_ENTERED" | jq '.updates'
 
 # Update a fixed range: PUT /values/{range}?valueInputOption=USER_ENTERED
-curl -sS -X PUT "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X PUT -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"values":[["done"]]}' \
   "$S/$ID/values/Sheet1!E2?valueInputOption=USER_ENTERED" | jq '.updatedCells'
 ```
@@ -57,11 +57,11 @@ curl -sS -X PUT "${AUTH[@]}" -H "Content-Type: application/json" \
 
 ```bash
 # New spreadsheet
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"properties":{"title":"Report 2026"}}' "$S" | jq '{spreadsheetId, spreadsheetUrl}'
 
 # Add a tab via batchUpdate (addSheet request)
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"requests":[{"addSheet":{"properties":{"title":"Q3"}}}]}' \
   "$S/$ID:batchUpdate" | jq '.replies'
 ```

--- a/skills/microsoft-excel/SKILL.md
+++ b/skills/microsoft-excel/SKILL.md
@@ -25,12 +25,12 @@ Failures are `{"error":{"code","message"}}` — show `message` verbatim. `401` =
 token expired (re-install). `403` on a write = the user granted read-only.
 
 ```bash
-G="https://graph.microsoft.com/v1.0"; AUTH=(-H "Authorization: Bearer $MICROSOFT_EXCEL_TOKEN")
+G="https://graph.microsoft.com/v1.0"; AUTH="Authorization: Bearer $MICROSOFT_EXCEL_TOKEN"
 # Find the workbook by name (then take .id as ITEM_ID)
-curl -sS "${AUTH[@]}" "$G/me/drive/root/search(q='budget.xlsx')" \
+curl -sS -H "$AUTH" "$G/me/drive/root/search(q='budget.xlsx')" \
   | jq '.value[] | {id, name, webUrl}'
 # Worksheets in the workbook
-curl -sS "${AUTH[@]}" "$G/me/drive/items/ITEM_ID/workbook/worksheets" \
+curl -sS -H "$AUTH" "$G/me/drive/items/ITEM_ID/workbook/worksheets" \
   | jq '.value[] | {id, name, position}'
 ```
 
@@ -39,16 +39,16 @@ curl -sS "${AUTH[@]}" "$G/me/drive/items/ITEM_ID/workbook/worksheets" \
 ```bash
 ITEM="ITEM_ID"; WS="Sheet1"
 # Used range (values + formulas + formats)
-curl -sS "${AUTH[@]}" \
+curl -sS -H "$AUTH" \
   "$G/me/drive/items/$ITEM/workbook/worksheets/$WS/usedRange" \
   | jq '{address, values: .values}'
 
 # Read a specific range
-curl -sS "${AUTH[@]}" \
+curl -sS -H "$AUTH" \
   "$G/me/drive/items/$ITEM/workbook/worksheets/$WS/range(address='A1:C5')" | jq '.values'
 
 # Update a range (confirm first). values is a 2-D array matching the address shape.
-curl -sS -X PATCH "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"values":[["Q3",1200],["Q4",1580]]}' \
   "$G/me/drive/items/$ITEM/workbook/worksheets/$WS/range(address='A2:B3')" | jq '.address'
 ```
@@ -56,7 +56,7 @@ curl -sS -X PATCH "${AUTH[@]}" -H "Content-Type: application/json" \
 ## Append a row to a table
 
 ```bash
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"values":[["2026-06-21","Acme",4200]]}' \
   "$G/me/drive/items/$ITEM/workbook/tables/Table1/rows/add" | jq '.index'
 ```

--- a/skills/microsoft-teams/SKILL.md
+++ b/skills/microsoft-teams/SKILL.md
@@ -25,9 +25,9 @@ re-install. `403`/`Forbidden` on send = the user granted read-only
 (`Chat.Read`) → re-connect with `Chat.ReadWrite` + `ChatMessage.Send`.
 
 ```bash
-G="https://graph.microsoft.com/v1.0"; AUTH=(-H "Authorization: Bearer $MICROSOFT_TEAMS_TOKEN")
+G="https://graph.microsoft.com/v1.0"; AUTH="Authorization: Bearer $MICROSOFT_TEAMS_TOKEN"
 # My chats (1:1 + group), most recent first; expand members for names
-curl -sS "${AUTH[@]}" "$G/me/chats?\$top=20&\$expand=members" \
+curl -sS -H "$AUTH" "$G/me/chats?\$top=20&\$expand=members" \
   | jq '.value[] | {id, chatType, topic, members: [.members[].displayName]}'
 ```
 
@@ -36,11 +36,11 @@ curl -sS "${AUTH[@]}" "$G/me/chats?\$top=20&\$expand=members" \
 ```bash
 CHAT="CHAT_ID"
 # Recent messages
-curl -sS "${AUTH[@]}" "$G/chats/$CHAT/messages?\$top=20" \
+curl -sS -H "$AUTH" "$G/chats/$CHAT/messages?\$top=20" \
   | jq '.value[] | {from: .from.user.displayName, created: .createdDateTime, text: .body.content}'
 
 # Send a message (confirm content with the user first). contentType html|text.
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"body":{"contentType":"html","content":"Hi from the assistant 👋"}}' \
   "$G/chats/$CHAT/messages" | jq '{id, created: .createdDateTime}'
 ```

--- a/skills/microsoft-todo/SKILL.md
+++ b/skills/microsoft-todo/SKILL.md
@@ -25,9 +25,9 @@ means the token expired (re-install). `403`/`ErrorAccessDenied` on a write means
 the user only granted `Tasks.Read` → ask them to re-connect with read+write.
 
 ```bash
-G="https://graph.microsoft.com/v1.0"; AUTH=(-H "Authorization: Bearer $MICROSOFT_TODO_TOKEN")
+G="https://graph.microsoft.com/v1.0"; AUTH="Authorization: Bearer $MICROSOFT_TODO_TOKEN"
 # Task lists
-curl -sS "${AUTH[@]}" "$G/me/todo/lists" | jq '.value[] | {id, displayName, wellknownListName}'
+curl -sS -H "$AUTH" "$G/me/todo/lists" | jq '.value[] | {id, displayName, wellknownListName}'
 ```
 
 ## Tasks
@@ -35,17 +35,17 @@ curl -sS "${AUTH[@]}" "$G/me/todo/lists" | jq '.value[] | {id, displayName, well
 ```bash
 LIST="LIST_ID"
 # Open tasks in a list (filter notStarted/inProgress; $top caps page size)
-curl -sS "${AUTH[@]}" \
+curl -sS -H "$AUTH" \
   "$G/me/todo/lists/$LIST/tasks?\$filter=status ne 'completed'&\$top=50" \
   | jq '.value[] | {id, title, status, due: .dueDateTime.dateTime}'
 
 # Create (confirm first). dueDateTime/reminderDateTime are optional.
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"title":"Follow up with Alex","dueDateTime":{"dateTime":"2026-06-30T17:00:00","timeZone":"UTC"}}' \
   "$G/me/todo/lists/$LIST/tasks" | jq '{id, title, status}'
 
 # Complete: PATCH the task with {"status":"completed"}
-curl -sS -X PATCH "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"status":"completed"}' "$G/me/todo/lists/$LIST/tasks/TASK_ID" | jq '{title, status}'
 ```
 

--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -24,9 +24,9 @@ Responses wrap everything in `{"data":...,"error":{"code","message","log_id"}}` 
 `401`/`access_token_invalid` = re-connect TikTok.
 
 ```bash
-T="https://open.tiktokapis.com/v2"; AUTH=(-H "Authorization: Bearer $TIKTOK_TOKEN")
+T="https://open.tiktokapis.com/v2"; AUTH="Authorization: Bearer $TIKTOK_TOKEN"
 # Profile (account card)
-curl -sS "${AUTH[@]}" "$T/user/info/?fields=open_id,display_name,avatar_url" \
+curl -sS -H "$AUTH" "$T/user/info/?fields=open_id,display_name,avatar_url" \
   | jq '.data.user'
 ```
 
@@ -37,7 +37,7 @@ on a **verified domain** (AceData's `cdn.acedata.cloud` is verified for this app
 
 ```bash
 VIDEO_URL="https://cdn.acedata.cloud/...mp4"   # must be on a verified domain
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" -d "$(jq -n --arg u "$VIDEO_URL" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" -d "$(jq -n --arg u "$VIDEO_URL" \
   '{source_info:{source:"PULL_FROM_URL", video_url:$u}}')" \
   "$T/post/publish/inbox/video/init/" | jq '{publish_id: .data.publish_id, error}'
 ```
@@ -46,7 +46,7 @@ This drops the video into the user's TikTok **inbox** — they open the TikTok a
 to add caption / sound / privacy and post. Poll status:
 
 ```bash
-curl -sS -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+curl -sS -X POST -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"publish_id":"PUBLISH_ID"}' "$T/post/publish/status/fetch/" \
   | jq '.data | {status, fail_reason}'
 ```

--- a/skills/vercel/SKILL.md
+++ b/skills/vercel/SKILL.md
@@ -29,18 +29,18 @@ Helper for the optional team param:
 
 ```bash
 TEAM=""; [ -n "$VERCEL_TEAM_ID" ] && TEAM="?teamId=$VERCEL_TEAM_ID"
-AUTH=(-H "Authorization: Bearer $VERCEL_ACCESS_TOKEN")
+AUTH="Authorization: Bearer $VERCEL_ACCESS_TOKEN"
 ```
 
 ## Projects & deployments
 
 ```bash
 # Projects
-curl -sS "${AUTH[@]}" "https://api.vercel.com/v9/projects$TEAM" \
+curl -sS -H "$AUTH" "https://api.vercel.com/v9/projects$TEAM" \
   | jq '.projects[] | {name, framework, latestProduction: .latestDeployments[0].url}'
 
 # Recent deployments (optionally filter by ?projectId=… or &state=ERROR)
-curl -sS "${AUTH[@]}" "https://api.vercel.com/v6/deployments${TEAM:-?}&limit=20" \
+curl -sS -H "$AUTH" "https://api.vercel.com/v6/deployments${TEAM:-?}&limit=20" \
   | jq '.deployments[] | {uid, name, url, state, readyState, created}'
 ```
 
@@ -48,11 +48,11 @@ curl -sS "${AUTH[@]}" "https://api.vercel.com/v6/deployments${TEAM:-?}&limit=20"
 
 ```bash
 # Deployment detail
-curl -sS "${AUTH[@]}" "https://api.vercel.com/v13/deployments/DEPLOYMENT_ID${TEAM:+&teamId=$VERCEL_TEAM_ID}" \
+curl -sS -H "$AUTH" "https://api.vercel.com/v13/deployments/DEPLOYMENT_ID${TEAM:+&teamId=$VERCEL_TEAM_ID}" \
   | jq '{name, url, state: .readyState, error: .errorMessage}'
 
 # Build / runtime events (the actual logs)
-curl -sS "${AUTH[@]}" "https://api.vercel.com/v3/deployments/DEPLOYMENT_ID/events${TEAM:+?teamId=$VERCEL_TEAM_ID}" \
+curl -sS -H "$AUTH" "https://api.vercel.com/v3/deployments/DEPLOYMENT_ID/events${TEAM:+?teamId=$VERCEL_TEAM_ID}" \
   | jq -r '.[] | select(.type=="stdout" or .type=="stderr") | .payload.text'
 ```
 
@@ -60,7 +60,7 @@ curl -sS "${AUTH[@]}" "https://api.vercel.com/v3/deployments/DEPLOYMENT_ID/event
 
 ```bash
 # Project domains
-curl -sS "${AUTH[@]}" "https://api.vercel.com/v9/projects/PROJECT_ID/domains${TEAM:+?teamId=$VERCEL_TEAM_ID}" \
+curl -sS -H "$AUTH" "https://api.vercel.com/v9/projects/PROJECT_ID/domains${TEAM:+?teamId=$VERCEL_TEAM_ID}" \
   | jq '.domains[] | {name, verified}'
 ```
 


### PR DESCRIPTION
The connector curl skills used a Bash array `AUTH=(-H "Authorization: Bearer $TOKEN")` + `"${AUTH[@]}"`, but the aichat2 sandbox shell is **sh/dash** — `AUTH=(...)` errors with `Syntax error: "(" unexpected` (seen live in a Teams test transcript; the model recovered via `bash -lc` but the first curl always failed). Replaced with a plain `AUTH="Authorization: Bearer $TOKEN"` + `-H "$AUTH"` (portable in sh **and** bash); google-ads keeps its 2nd header as `DEV`. 11 skills fixed. No frontmatter/scope changes.