### PR TITLE
feat(skills): bilibili draft management + medium 403 auto-retry

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -38,6 +38,7 @@ BILI=$SKILL_DIR/scripts/bilibili.py
 python3 $BILI whoami                       # who is logged in (mid, name)
 python3 $BILI articles --limit 20          # my 专栏 articles + stats
 python3 $BILI article <cvid>               # one article's stats (cv id)
+python3 $BILI drafts --limit 50            # list saved drafts (aid + title)
 ```
 
 Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (评论),
@@ -69,6 +70,22 @@ python3 $BILI publish --title "标题" --content-file a.html --confirm          
 - The **submit** (go public) step is frequently rate-limited by Bilibili
   risk-control (HTTP 412). When that happens the CLI reports the saved draft +
   edit URL so the user can publish from the web editor. Default to `--draft-only`.
+
+## Managing drafts (the 999-draft cap)
+
+Bilibili caps 专栏 drafts at **999**; once full, saving a new draft fails with
+`code 37106 草稿数已达最大上限`. List drafts and delete the ones you don't need:
+
+```sh
+python3 $BILI drafts --limit 50                       # list (aid + title)
+python3 $BILI delete-draft <aid> <aid2> ...           # dry-run (shows what would delete)
+python3 $BILI delete-draft <aid> <aid2> ... --confirm # PERMANENTLY delete those drafts
+```
+
+- `delete-draft` is **GATED** (dry-run unless trailing `--confirm`) and deletion
+  is **permanent** — always show the dry-run + the titles and get an explicit
+  "yes" before `--confirm`. Pass multiple aids to batch a few per call.
+- Never bulk-delete blindly: list first, confirm the titles are junk/duplicates.
 
 ## Gotchas
 

--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -354,11 +354,60 @@ def cmd_publish(jar, args):
                      f"web editor. Detail: {(r or {}).get('message') if r else text[:200]}"})
 
 
+def _drafts_of(d: dict) -> list:
+    al = (d.get("data") or {}).get("artlist") or d.get("artlist") or {}
+    return al.get("drafts") or []
+
+
+def cmd_drafts(jar, args):
+    # 专栏 drafts are capped at 999; this lists them so they can be pruned.
+    d = get_json(f"{API}/x/article/creative/draft/list?pn={args.page}&ps={args.limit}",
+                 jar, referer="https://member.bilibili.com/")
+    if d.get("code"):  # 0 = ok; anything truthy is an auth/API error
+        die(f"draft list error (code={d.get('code')}): {d.get('message')} — "
+            f"cookie may be expired; reconnect at https://auth.acedata.cloud/user/connections.")
+    items = _drafts_of(d)
+    out({"page": args.page, "count": len(items), "drafts": [{
+        "aid": x.get("id"),
+        "title": x.get("title"),
+        "edit_url": f"https://member.bilibili.com/article-text/home?aid={x.get('id')}",
+    } for x in items]})
+
+
+def cmd_delete_draft(jar, args):
+    if not args.aids:
+        die("provide one or more draft aids: delete-draft <aid> [<aid> ...] --confirm")
+    bad = [a for a in args.aids if not str(a).isdigit()]
+    if bad:
+        die(f"invalid draft aid(s) — must be numeric: {bad}")
+    csrf = cookie_value(jar, "bili_jct")
+    if not csrf:
+        die("no bili_jct cookie (CSRF token) — reconnect Bilibili.")
+    if not CONFIRM:
+        out({"dry_run": True, "command": "delete-draft", "platform": "bilibili",
+             "aids": args.aids, "note": "Deletion is PERMANENT. Re-run with --confirm "
+             "as the LAST argument to actually delete these draft(s)."})
+        return
+    results = []
+    for aid in args.aids:
+        _, text = request("POST", f"{API}/x/article/creative/draft/delete", jar,
+                          referer="https://member.bilibili.com/", form={"aid": aid, "csrf": csrf})
+        try:
+            code = json.loads(text).get("code")
+        except json.JSONDecodeError:
+            code = None
+        results.append({"aid": aid, "deleted": code == 0, "code": code})
+    out({"command": "delete-draft", "deleted": sum(1 for r in results if r["deleted"]),
+         "results": results})
+
+
 COMMANDS = {
     "whoami": cmd_whoami,
     "articles": cmd_articles,
     "article": cmd_article,
     "publish": cmd_publish,
+    "drafts": cmd_drafts,
+    "delete-draft": cmd_delete_draft,
 }
 
 
@@ -375,6 +424,11 @@ def main() -> None:
     sp.add_argument("--content", help="HTML content inline")
     sp.add_argument("--content-file", help="path to an HTML file")
     sp.add_argument("--draft-only", action="store_true", help="save a draft; do NOT submit")
+    sp = sub.add_parser("drafts", help="list 专栏 drafts (id+title); use to prune the 999-draft cap")
+    sp.add_argument("--limit", type=int, default=50)
+    sp.add_argument("--page", type=int, default=1)
+    sp = sub.add_parser("delete-draft", help="delete draft(s) by aid (GATED by trailing --confirm)")
+    sp.add_argument("aids", nargs="*", help="one or more draft aids to delete")
     args = p.parse_args(ARGV)
     jar = load_cookies()
     COMMANDS[args.command](jar, args)

--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -71,6 +71,8 @@ publish). `--draft-only` stops at the draft (visible only at the user's
 - Markdown→Medium conversion is paragraph-level (headings, quotes, code, body);
   complex inline formatting / images aren't converted — the user can polish in
   the Medium editor before going public.
-- Medium sits behind Cloudflare; an occasional 403/429 is transient.
+- Medium sits behind Cloudflare; an occasional 403/429 is transient — the CLI
+  auto-retries once after a short pause. A *persistent* 403 means the cookie is
+  genuinely expired (reconnect).
 - **Never print `MEDIUM_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.

--- a/skills/medium/scripts/medium.py
+++ b/skills/medium/scripts/medium.py
@@ -30,6 +30,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -147,8 +148,15 @@ def request(method, url, jar, *, headers=None, body=None, accept="application/js
         die(f"network error reaching {url}: {e.reason}")
 
 
-def api(method, url, jar, *, body=None):
+def api(method, url, jar, *, body=None, _retried=False):
     status, text = request(method, url, jar, body=body)
+    # Medium sits behind Cloudflare, which intermittently 403s/429s an otherwise
+    # valid session; one retry after a short pause clears the transient block.
+    # Only retry idempotent GETs — never replay a POST (new-story/deltas/publish),
+    # which could duplicate a write if the origin already processed it.
+    if status in (403, 429) and method == "GET" and not _retried:
+        time.sleep(1.5)
+        return api(method, url, jar, body=body, _retried=True)
     if status in (401, 403):
         die(f"auth failed ({status}) on {url} — cookie likely expired. "
             f"Reconnect at https://auth.acedata.cloud/user/connections.")


### PR DESCRIPTION
Follow-up from live-testing the publish paths — bakes in two things we learned.

## bilibili — draft management (`drafts` + `delete-draft`)
Bilibili caps 专栏 drafts at **999**; once full, publishing fails with `code 37106 草稿数已达最大上限`. The auto-publisher (PlatformPublisher) fills it with duplicate drafts on 412'd submits. New commands so the agent can prune it from chat:
- `drafts [--limit N] [--page N]` → list saved drafts (`aid` + title)
- `delete-draft <aid> [<aid>...]` → **GATED** (dry-run unless trailing `--confirm`); deletion is permanent
- Verified live in-cluster: create draft → `drafts` lists it → dry-run → `--confirm` deletes (`code 0`) → gone.

## medium — transient-403 auto-retry
Medium sits behind Cloudflare and intermittently 403s a valid session (observed live: a draft-fetch GET 403'd, then succeeded on retry). `api()` now retries once (1.5s pause) — **GET only**, so a non-idempotent POST (new-story/deltas/publish) is never replayed.

## 🤖 对抗评审
Reviewer: **Codex**, 2 rounds.
- **Round 1 — 3 RISKs, all fixed:** (a) retry could replay non-idempotent POST writes → restricted to `method == "GET"`; (b) `delete-draft` accepted non-numeric aids → now validates `isdigit()` before any POST; (c) `drafts` ignored `code != 0` → now dies with the API message (auth errors no longer look like an empty list).
- **Round 2: VERDICT CLEAN** (no new/open risks).