### PR TITLE
feat(skills): auto re-host images on publish (csdn, medium, bilibili)

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -87,6 +87,16 @@ python3 $BILI delete-draft <aid> <aid2> ... --confirm # PERMANENTLY delete those
   "yes" before `--confirm`. Pass multiple aids to batch a few per call.
 - Never bulk-delete blindly: list first, confirm the titles are junk/duplicates.
 
+## Images
+
+`publish` automatically re-hosts external images (both `<img src>` and markdown)
+onto Bilibili's CDN (`i0.hdslb.com` / `article.biliimg.com`) before saving —
+Bilibili hotlink-blocks external images and rejects the whole article (`37130`)
+if any external link remains. webp sources (which upcover rejects) are
+transcoded to png via the CDN when possible; an image that still can't upload is
+**dropped** from the article rather than failing the post. `--no-rehost-images`
+skips this.
+
 ## Gotchas
 
 - **This is the user's real Bilibili account.** Confirm before any publish.

--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -25,8 +25,12 @@ from __future__ import annotations
 import argparse
 import gzip
 import hashlib
+import ipaddress
 import json
 import os
+import random
+import re
+import socket
 import sys
 import time
 import urllib.error
@@ -276,6 +280,155 @@ def cmd_article(jar, args):
 _TID_CANDIDATES = ["4", "3", "6", "7", "2", "17", "28", "41"]
 
 
+# ── image upload (Bilibili hotlink-blocks external imgs; re-host via
+#    upcover, mirroring our PlatformPublisher bilibili.py) ────────────
+
+_IMG_SKIP = ("hdslb.com", "bilibili.com", "biliimg.com")
+# matches both HTML <img src="..."> and markdown ![alt](...)
+# <img ... src = "..."> / '...'  (tolerates spaces and either quote style)
+_HTML_IMG = re.compile(r"""(<img\b[^>]*?\bsrc\s*=\s*)(["'])(https?://[^"']+)(\2)""", re.IGNORECASE)
+_MD_IMG = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
+UPCOVER = "https://api.bilibili.com/x/article/creative/article/upcover"
+
+
+def _rand_hex(n):
+    return "".join(random.choice("0123456789abcdef") for _ in range(n))
+
+
+MAX_IMG_BYTES = 12 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    # Refuse redirects on image fetches — a 30x could reach an internal host the
+    # _assert_public_url() check never saw (SSRF).
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise RuntimeError(f"image redirect blocked ({code}) -> {newurl[:80]}")
+
+
+_IMG_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _assert_public_url(url):
+    """SSRF guard — block non-http(s) and private/loopback/link-local hosts."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        raise RuntimeError(f"unsupported image URL: {url[:80]}")
+    try:
+        addrs = socket.getaddrinfo(parts.hostname, None)
+    except OSError as e:
+        raise RuntimeError(f"cannot resolve {parts.hostname}: {e}")
+    for info in addrs:
+        ip = ipaddress.ip_address(info[4][0])
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
+            raise RuntimeError(f"blocked non-public image host: {parts.hostname}")
+
+
+def _same_or_sub(host, suffix):
+    return host == suffix or host.endswith("." + suffix)
+
+
+def _get_bytes(url):
+    _assert_public_url(url)
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "image/*"})
+    with _IMG_OPENER.open(req, timeout=30) as r:
+        data = r.read(MAX_IMG_BYTES + 1)
+    if len(data) > MAX_IMG_BYTES:
+        raise RuntimeError(f"image exceeds {MAX_IMG_BYTES} bytes")
+    return data
+
+
+def _is_webp(data):
+    return data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+
+
+def _download_image(url):
+    # Bilibili's upcover rejects webp. Many of our images live on Tencent COS
+    # (cdn.acedata.cloud) which can transcode server-side, so on a webp body
+    # retry with the COS format param to get a png Bilibili accepts.
+    data = _get_bytes(url)
+    if _is_webp(data):
+        sep = "&" if "?" in url else "?"
+        try:
+            conv = _get_bytes(f"{url}{sep}imageMogr2/format/png")
+            if not _is_webp(conv):
+                return conv
+        except Exception:  # noqa: BLE001 — fall through with original bytes
+            pass
+    return data
+
+
+def _sniff_image(data):
+    """Real (ext, mime) from magic bytes — a URL's extension or the CDN's
+    Content-Type can lie (e.g. a `.png` URL serving webp bytes), and Bilibili
+    rejects a filename/format mismatch."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png", "image/png"
+    if data[:2] == b"\xff\xd8":
+        return "jpg", "image/jpeg"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif", "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp", "image/webp"
+    return "jpg", "image/jpeg"
+
+
+def bili_upload_image(jar, csrf, src):
+    img = _download_image(src)
+    ext, ct = _sniff_image(img)
+    boundary = "----acedata" + _rand_hex(20)
+    body = (
+        f'--{boundary}\r\nContent-Disposition: form-data; name="binary";'
+        f' filename="image.{ext}"\r\nContent-Type: {ct}\r\n\r\n'.encode()
+        + img + f'\r\n--{boundary}\r\nContent-Disposition: form-data; name="csrf"'
+        f"\r\n\r\n{csrf}\r\n--{boundary}--\r\n".encode()
+    )
+    hdrs = {"User-Agent": UA, "Origin": "https://member.bilibili.com",
+            "Referer": "https://member.bilibili.com/",
+            "Content-Type": f"multipart/form-data; boundary={boundary}"}
+    req = urllib.request.Request(UPCOVER, data=body, headers=hdrs, method="POST")
+    req.add_unredirected_header("Cookie", cookie_header(jar, UPCOVER))
+    with urllib.request.urlopen(req, timeout=60) as r:
+        d = json.loads(r.read().decode("utf-8", "replace"))
+    if d.get("code") == 0 and (d.get("data") or {}).get("url"):
+        return d["data"]["url"]
+    raise RuntimeError(f"upcover failed (code={d.get('code')}): {d.get('message')}")
+
+
+def rehost_images(jar, csrf, content):
+    """Re-host external images (both <img src> and markdown) on Bilibili's CDN.
+    An image that can't be uploaded is DROPPED (not kept as an external link) —
+    Bilibili rejects the whole article with code 37130 if any external image
+    link remains. Rate-limited to dodge code -1."""
+    def _one(src):
+        host = (urllib.parse.urlsplit(src).hostname or "").lower()
+        if any(_same_or_sub(host, s) for s in _IMG_SKIP):
+            return "keep", src
+        try:
+            new = bili_upload_image(jar, csrf, src)
+            sys.stderr.write(f"[img] rehosted {src} -> {new}\n")
+            time.sleep(0.3)
+            return "ok", new
+        except Exception as e:  # noqa: BLE001 — drop the image rather than fail
+            sys.stderr.write(f"[img] dropped {src} (upload failed: {e})\n")
+            return "drop", None
+
+    def html_repl(m):
+        # groups: 1=<img ... src= , 2=quote, 3=url, 4=closing quote (backref)
+        st, new = _one(m.group(3))
+        if st == "drop":
+            return ""
+        return m.group(1) + m.group(2) + (new or m.group(3)) + m.group(2)
+
+    def md_repl(m):
+        st, new = _one(m.group(2))
+        return "" if st == "drop" else f"![{m.group(1)}]({new or m.group(2)})"
+
+    content = _HTML_IMG.sub(html_repl, content)
+    content = _MD_IMG.sub(md_repl, content)
+    return content
+
+
 def cmd_publish(jar, args):
     if not args.title:
         die("--title is required")
@@ -303,6 +456,10 @@ def cmd_publish(jar, args):
                     "the saved draft is the reliable result.",
         })
         return
+
+    # Bilibili hotlink-blocks external images → re-host them on its CDN first.
+    if not args.no_rehost_images:
+        content = rehost_images(jar, csrf, content)
 
     ref = "https://member.bilibili.com/"
     base = {
@@ -424,6 +581,8 @@ def main() -> None:
     sp.add_argument("--content", help="HTML content inline")
     sp.add_argument("--content-file", help="path to an HTML file")
     sp.add_argument("--draft-only", action="store_true", help="save a draft; do NOT submit")
+    sp.add_argument("--no-rehost-images", action="store_true",
+                    help="keep external image URLs as-is (skip Bilibili CDN re-host)")
     sp = sub.add_parser("drafts", help="list 专栏 drafts (id+title); use to prune the 999-draft cap")
     sp.add_argument("--limit", type=int, default=50)
     sp.add_argument("--page", type=int, default=1)

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -73,6 +73,14 @@ python3 $CSDN publish --title "标题" --content-file a.md --tags "AI,Python" --
   name. Default to `--draft-only` unless the user clearly asked to go live.
 - `--tags` is a comma-separated list of article tags.
 
+## Images
+
+`publish` automatically re-hosts external markdown images (`![](url)`) onto
+CSDN's own CDN (`i-blog.csdnimg.cn`) before saving — CSDN 防盗链 blocks external
+images, and saving an article full of external URLs can even time out. Images
+already on `csdnimg.cn` are left alone; pass `--no-rehost-images` to skip. An
+image that fails to upload keeps its original URL (never blocks the post).
+
 ## Gotchas — surface before the user is surprised
 
 - **This is the user's real CSDN account.** Confirm before any publish.

--- a/skills/csdn/scripts/csdn.py
+++ b/skills/csdn/scripts/csdn.py
@@ -28,8 +28,13 @@ import base64
 import gzip
 import hashlib
 import hmac
+import ipaddress
 import json
+import mimetypes
 import os
+import random
+import re
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -127,7 +132,8 @@ def _browser_headers(jar: list, url: str, referer: str, origin: str) -> dict:
     }
 
 
-def request(method: str, url: str, jar: list, *, referer, origin, headers=None, body=None):
+def request(method: str, url: str, jar: list, *, referer, origin, headers=None, body=None,
+            nonfatal=False):
     hdrs = _browser_headers(jar, url, referer, origin)
     if headers:
         hdrs.update(headers)
@@ -154,6 +160,8 @@ def request(method: str, url: str, jar: list, *, referer, origin, headers=None, 
             pass
         return e.code, raw.decode("utf-8", "replace")
     except urllib.error.URLError as e:
+        if nonfatal:
+            raise RuntimeError(f"network error reaching {url}: {e.reason}")
         die(f"network error reaching {url}: {e.reason}")
 
 
@@ -274,6 +282,140 @@ def cmd_article(jar, args):
     die(f"article {args.id} not found among your published articles")
 
 
+# ── image upload (CSDN 防盗链s external images; re-host them first) ───
+# Signed signature → Huawei OBS multipart → csdnimg.cn URL. Mirrors our
+# PlatformPublisher csdn.py flow.
+
+_MD_IMG = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
+_IMG_SKIP = ("csdnimg.cn", "csdn.net")
+
+
+def _rand_hex(n):
+    return "".join(random.choice("0123456789abcdef") for _ in range(n))
+
+
+def _multipart(files, data):
+    boundary = "----acedata" + _rand_hex(20)
+    parts = []
+    for k, v in data.items():
+        parts.append((f'--{boundary}\r\nContent-Disposition: form-data; name="{k}"'
+                      f"\r\n\r\n{v}\r\n").encode())
+    for field, (filename, blob, ctype) in files.items():
+        parts.append((f'--{boundary}\r\nContent-Disposition: form-data; name="{field}";'
+                      f' filename="{filename}"\r\nContent-Type: {ctype}\r\n\r\n').encode())
+        parts.append(blob)
+        parts.append(b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts), boundary
+
+
+MAX_IMG_BYTES = 12 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    # Refuse redirects on image fetches — otherwise a 30x could send the request
+    # to an internal host that the _assert_public_url() check never saw (SSRF).
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise RuntimeError(f"image redirect blocked ({code}) -> {newurl[:80]}")
+
+
+_IMG_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _assert_public_url(url):
+    """Block non-http(s) and private/loopback/link-local hosts (SSRF guard) —
+    article content can carry arbitrary image URLs."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        raise RuntimeError(f"unsupported image URL: {url[:80]}")
+    try:
+        addrs = socket.getaddrinfo(parts.hostname, None)
+    except OSError as e:
+        raise RuntimeError(f"cannot resolve {parts.hostname}: {e}")
+    for info in addrs:
+        ip = ipaddress.ip_address(info[4][0])
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
+            raise RuntimeError(f"blocked non-public image host: {parts.hostname}")
+
+
+def _download_image(url):
+    _assert_public_url(url)
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with _IMG_OPENER.open(req, timeout=30) as r:
+        data = r.read(MAX_IMG_BYTES + 1)
+    if len(data) > MAX_IMG_BYTES:
+        raise RuntimeError(f"image exceeds {MAX_IMG_BYTES} bytes")
+    return data
+
+
+def _same_or_sub(host, suffix):
+    return host == suffix or host.endswith("." + suffix)
+
+
+def _ext_of(url, default="png"):
+    tail = url.rsplit("/", 1)[-1].split("?")[0]
+    if "." in tail:
+        e = tail.rsplit(".", 1)[-1].lower()
+        if e in ("jpg", "jpeg", "png", "gif", "webp"):
+            return e
+    return default
+
+
+def csdn_upload_image(jar, src) -> str:
+    img = _download_image(src)
+    ext = _ext_of(src)
+    # 1. signed signature request
+    sig_path = "/resource-api/v1/image/direct/upload/signature"
+    sign = ca_sign("POST", sig_path, "application/json")
+    sign["Accept"] = "*/*"
+    status, text = request("POST", f"{BIZ}{sig_path}", jar, referer="https://editor.csdn.net/",
+                           origin="https://editor.csdn.net", headers=sign, nonfatal=True,
+                           body={"imageTemplate": "", "appName": "direct_blog_markdown",
+                                 "imageSuffix": ext})
+    sd = json.loads(text)
+    if sd.get("code") != 200 or not sd.get("data"):
+        raise RuntimeError(f"signature failed ({sd.get('code')}): {sd.get('message')}")
+    info = sd["data"]
+    cp = info.get("customParam") or {}
+    # 2. multipart POST to Huawei OBS (no signing/cookies — the policy authorizes it)
+    form = {
+        "key": info["filePath"], "policy": info["policy"], "signature": info["signature"],
+        "callbackBody": info["callbackBody"], "callbackBodyType": info["callbackBodyType"],
+        "callbackUrl": info["callbackUrl"], "AccessKeyId": info["accessId"],
+        "x:rtype": cp.get("rtype", ""), "x:filePath": cp.get("filePath", ""),
+        "x:isAudit": str(cp.get("isAudit", 0)), "x:x-image-app": cp.get("x-image-app", ""),
+        "x:type": cp.get("type", ""), "x:x-image-suffix": cp.get("x-image-suffix", ""),
+        "x:username": cp.get("username", ""),
+    }
+    body, boundary = _multipart({"file": (f"image.{ext}", img, f"image/{ext}")}, form)
+    req = urllib.request.Request(info["host"], data=body, method="POST", headers={
+        "User-Agent": UA, "Content-Type": f"multipart/form-data; boundary={boundary}"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        od = json.loads(r.read().decode("utf-8", "replace"))
+    if od.get("code") == 200 and (od.get("data") or {}).get("imageUrl"):
+        return od["data"]["imageUrl"]
+    raise RuntimeError(f"OBS upload failed: {str(od)[:200]}")
+
+
+def rehost_images(jar, content):
+    """Re-host external markdown images on CSDN's CDN (防盗链 blocks external).
+    Best-effort: keep the original URL if an image fails."""
+    def repl(m):
+        alt, src = m.group(1), m.group(2)
+        host = (urllib.parse.urlsplit(src).hostname or "").lower()
+        if any(_same_or_sub(host, s) for s in _IMG_SKIP):
+            return m.group(0)
+        try:
+            new = csdn_upload_image(jar, src)
+            sys.stderr.write(f"[img] rehosted {src} -> {new}\n")
+            return f"![{alt}]({new})"
+        except Exception as e:  # noqa: BLE001 — best-effort
+            sys.stderr.write(f"[img] kept {src} (upload failed: {e})\n")
+            return m.group(0)
+    return _MD_IMG.sub(repl, content)
+
+
 def cmd_publish(jar, args):
     if not args.title:
         die("--title is required")
@@ -298,6 +440,10 @@ def cmd_publish(jar, args):
                     "a PUBLIC article on the user's real account.",
         })
         return
+
+    # CSDN 防盗链s external images → re-host them on CSDN's CDN first.
+    if not args.no_rehost_images:
+        content = rehost_images(jar, content)
 
     path = "/blog-console-api/v3/mdeditor/saveArticle"
     url = f"{BIZ}{path}"
@@ -366,6 +512,8 @@ def main() -> None:
     sp.add_argument("--content-file", help="path to a Markdown file")
     sp.add_argument("--draft-only", action="store_true", help="save a private draft; do NOT go public")
     sp.add_argument("--tags", help="comma-separated article tags")
+    sp.add_argument("--no-rehost-images", action="store_true",
+                    help="keep external image URLs as-is (skip CSDN CDN re-host)")
     args = p.parse_args(ARGV)
     jar = load_cookies()
     COMMANDS[args.command](jar, args)

--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -65,6 +65,14 @@ Publishing is Medium's multi-step editor flow (new-story → write deltas →
 publish). `--draft-only` stops at the draft (visible only at the user's
 `/me/stories/drafts`). Default to `--draft-only` unless the user asked to go live.
 
+## Images
+
+`publish` automatically uploads each external markdown image (`![](url)`) to
+Medium and inserts it as a real image block — Medium has no markdown-image
+syntax, so this is the only way images render. Pass `--no-rehost-images` to
+degrade images to link-only paragraphs. An image that fails to upload falls back
+to a link paragraph (never blocks the post).
+
 ## Gotchas
 
 - **This is the user's real Medium account.** Confirm before any publish.

--- a/skills/medium/scripts/medium.py
+++ b/skills/medium/scripts/medium.py
@@ -26,9 +26,13 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import ipaddress
 import json
+import mimetypes
 import os
+import random
 import re
+import socket
 import sys
 import time
 import urllib.error
@@ -253,25 +257,117 @@ def cmd_article(jar, args):
     })
 
 
-def _markdown_to_deltas(title: str, content: str) -> list:
-    """Minimal Markdown → Medium paragraph deltas. Title is a type-3 paragraph;
-    body blocks split on blank lines; ``#``/``##``/``###`` map to h1/h2/h3,
-    ``>`` to blockquote, ``` ``` to code, everything else to body text."""
+# ── image upload (Medium has no markdown image; upload bytes → image
+#    paragraph delta type 4) ─────────────────────────────────────────
+
+_MD_IMG = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
+
+
+def _rand_hex(n):
+    return "".join(random.choice("0123456789abcdef") for _ in range(n))
+
+
+MAX_IMG_BYTES = 12 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    # Refuse redirects on image fetches — a 30x could reach an internal host the
+    # _assert_public_url() check never saw (SSRF).
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise RuntimeError(f"image redirect blocked ({code}) -> {newurl[:80]}")
+
+
+_IMG_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _assert_public_url(url):
+    """SSRF guard — block non-http(s) and private/loopback/link-local hosts."""
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        raise RuntimeError(f"unsupported image URL: {url[:80]}")
+    try:
+        addrs = socket.getaddrinfo(parts.hostname, None)
+    except OSError as e:
+        raise RuntimeError(f"cannot resolve {parts.hostname}: {e}")
+    for info in addrs:
+        ip = ipaddress.ip_address(info[4][0])
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
+            raise RuntimeError(f"blocked non-public image host: {parts.hostname}")
+
+
+def _download_image(url):
+    _assert_public_url(url)
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with _IMG_OPENER.open(req, timeout=30) as r:
+        data = r.read(MAX_IMG_BYTES + 1)
+        ct = (r.headers.get("Content-Type") or "image/png").split(";")[0].strip()
+    if len(data) > MAX_IMG_BYTES:
+        raise RuntimeError(f"image exceeds {MAX_IMG_BYTES} bytes")
+    return data, (ct if ct.startswith("image/") else "image/png")
+
+
+def medium_upload_image(jar, post_id, img_bytes, content_type):
+    """POST the bytes to Medium's /_/upload and return (fileId, w, h)."""
+    ext = (mimetypes.guess_extension(content_type) or ".png").lstrip(".")
+    boundary = "----acedata" + _rand_hex(20)
+    body = (
+        f'--{boundary}\r\nContent-Disposition: form-data; name="uploadedFile";'
+        f' filename="image.{ext}"\r\nContent-Type: {content_type}\r\n\r\n'.encode()
+        + img_bytes + f"\r\n--{boundary}--\r\n".encode()
+    )
+    xsrf = cookie_value(jar, "xsrf")
+    hdrs = {
+        "User-Agent": UA, "Accept": "application/json, text/plain, */*",
+        "Origin": BASE, "Referer": f"{BASE}/p/{post_id}/edit",
+        "X-Requested-With": "XMLHttpRequest",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+    if xsrf:
+        hdrs["x-xsrf-token"] = xsrf
+    url = f"{BASE}/_/upload?is2x=true"
+    req = urllib.request.Request(url, data=body, headers=hdrs, method="POST")
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    with urllib.request.urlopen(req, timeout=60) as r:
+        text = r.read().decode("utf-8", "replace")
+    val = (json.loads(_PREFIX.sub("", text)).get("payload") or {}).get("value") or {}
+    if not val.get("fileId"):
+        raise RuntimeError(f"upload returned no fileId: {text[:200]}")
+    return val["fileId"], val.get("imgWidth"), val.get("imgHeight")
+
+
+def _build_deltas(jar, post_id, title, content, rehost=True):
+    """Markdown → Medium paragraph deltas (image-aware). A standalone
+    ``![alt](url)`` block is uploaded to Medium and emitted as an image
+    paragraph (type 4); on upload failure it degrades to a link paragraph."""
     paras = [{"type": 3, "text": title}]
-    blocks = re.split(r"\n\s*\n", content.strip())
-    in_code = False
-    code_buf = []
-    for block in blocks:
+    for block in re.split(r"\n\s*\n", content.strip()):
         b = block.strip("\n")
         if not b.strip():
             continue
         first = b.lstrip()
-        if first.startswith("```"):
-            # toggle / inline fenced block
-            body = re.sub(r"^```[^\n]*\n?|\n?```$", "", b)
-            paras.append({"type": 8, "text": body})
+        m = _MD_IMG.fullmatch(first)
+        if m:
+            alt, src = m.group(1), m.group(2)
+            if rehost:
+                try:
+                    data, ct = _download_image(src)
+                    fid, w, h = medium_upload_image(jar, post_id, data, ct)
+                    sys.stderr.write(f"[img] uploaded {src} -> {fid}\n")
+                    meta = {"id": fid}
+                    if w:
+                        meta["originalWidth"] = w
+                    if h:
+                        meta["originalHeight"] = h
+                    paras.append({"type": 4, "text": alt or "", "layout": 1, "metadata": meta})
+                    continue
+                except Exception as e:  # noqa: BLE001 — degrade to a link
+                    sys.stderr.write(f"[img] link-only {src} (upload failed: {e})\n")
+            paras.append({"type": 1, "text": f"{alt or 'image'}: {src}"})
             continue
-        if first.startswith("# "):
+        if first.startswith("```"):
+            paras.append({"type": 8, "text": re.sub(r"^```[^\n]*\n?|\n?```$", "", b)})
+        elif first.startswith("# "):
             paras.append({"type": 12, "text": first[2:].strip()})
         elif first.startswith("## "):
             paras.append({"type": 2, "text": first[3:].strip()})
@@ -281,11 +377,15 @@ def _markdown_to_deltas(title: str, content: str) -> list:
             paras.append({"type": 6, "text": first[2:].strip()})
         else:
             paras.append({"type": 1, "text": b.replace("\n", " ").strip()})
-    deltas = []
+    out_deltas = []
     for i, p in enumerate(paras):
-        deltas.append({"type": 1, "index": i,
-                       "paragraph": {"type": p["type"], "text": p["text"], "markups": []}})
-    return deltas
+        para = {"type": p["type"], "text": p["text"], "markups": []}
+        if "layout" in p:
+            para["layout"] = p["layout"]
+        if "metadata" in p:
+            para["metadata"] = p["metadata"]
+        out_deltas.append({"type": 1, "index": i, "paragraph": para})
+    return out_deltas
 
 
 def cmd_publish(jar, args):
@@ -327,8 +427,9 @@ def cmd_publish(jar, args):
     if base_rev is None:
         base_rev = 0
 
-    # 3. write the body as paragraph deltas
-    deltas = _markdown_to_deltas(args.title, content)
+    # 3. write the body as paragraph deltas (images uploaded to Medium inline)
+    deltas = _build_deltas(jar, post_id, args.title, content,
+                           rehost=not args.no_rehost_images)
     api("POST", f"{BASE}/p/{post_id}/deltas", jar,
         body={"baseRev": base_rev, "deltas": deltas})
 
@@ -364,6 +465,8 @@ def main() -> None:
     sp.add_argument("--content", help="Markdown content inline")
     sp.add_argument("--content-file", help="path to a Markdown file")
     sp.add_argument("--draft-only", action="store_true", help="create a draft only; do NOT go public")
+    sp.add_argument("--no-rehost-images", action="store_true",
+                    help="don't upload images to Medium (degrade to link-only paragraphs)")
     args = p.parse_args(ARGV)
     jar = load_cookies()
     COMMANDS[args.command](jar, args)


### PR DESCRIPTION
## Why

Publishing a real article (e.g. our 6-image `headshots` use-case doc) broke on images: **CSDN** 防盗链 blocks external images and `saveArticle` even *timed out* on a page of them; **Bilibili** hotlink-blocks external images and rejects the whole article (`37130`); **Medium** has no markdown-image syntax so images simply never appeared. Only **juejin** renders external images natively.

So `publish` now uploads each external image to the platform's own CDN first.

## Per-platform (all E2E-verified in-cluster against the real account)

| Skill | Upload path | Verified |
|---|---|---|
| **csdn** | signed signature → Huawei OBS multipart → `i-blog.csdnimg.cn` (reuses x-ca HMAC) | ✅ 6/6 images |
| **medium** | `POST /_/upload` (`uploadedFile` + `x-xsrf-token`) → image-paragraph delta (type 4) | ✅ 6/6 images |
| **bilibili** | `upcover` (`binary` + `csrf=bili_jct`) → `article.biliimg.com`; webp→png via COS param; un-uploadable images **dropped** | ✅ draft created |
| **juejin** | unchanged — renders external markdown images; no usable API upload path (our own publisher uses browser automation) | n/a |

Each adds `--no-rehost-images` to opt out. Already-platform-hosted images are skipped. A per-image failure degrades gracefully (csdn/juejin keep original; medium → link paragraph; bilibili → drop) — never aborts the publish. Re-hosting runs only after the `--confirm` write gate.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`), **2 rounds**.

**Round 1 — 4 RISKs, all fixed:**
- **SSRF + no size guard**: arbitrary image URLs fetched server-side → added `_assert_public_url()` (reject non-http(s) + private/loopback/link-local/reserved/multicast via `getaddrinfo`+`ipaddress`) and a 12MB read cap.
- **csdn fatal abort**: the per-image signature fetch used the dying `request()`; a network error `die()`'d the whole publish → added `nonfatal=True` so it raises and the image degrades.
- **substring host-skip** (`csdnimg.cn.evil` bypass) → exact `_same_or_sub(host, suffix)` on the parsed hostname.
- **bilibili `<img>` regex** missed single-quotes/spaces → broadened to `src\s*=\s*["']…["']` with a quote backref.

**Round 2 — 1 RISK, fixed:**
- **redirect-based SSRF bypass**: `urlopen` followed redirects to an unchecked host → image fetches now use a `build_opener(HTTPRedirectHandler-that-raises)` so 30x is refused.

**Residual (accepted):** DNS-rebinding (host resolves public at check, private at connect) isn't fully closed without IP-pinning; this is a best-effort defense-in-depth on the agent's own sandbox/content — the sandbox egress is the primary control. **VERDICT: CLEAN** (converged round 2).