### PR TITLE
fix(csdn,bilibili): render Markdown→HTML for the published article body

### DIFF
--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import gzip
 import hashlib
+import html as _html
 import ipaddress
 import json
 import os
@@ -287,7 +288,7 @@ _IMG_SKIP = ("hdslb.com", "bilibili.com", "biliimg.com")
 # matches both HTML <img src="..."> and markdown ![alt](...)
 # <img ... src = "..."> / '...'  (tolerates spaces and either quote style)
 _HTML_IMG = re.compile(r"""(<img\b[^>]*?\bsrc\s*=\s*)(["'])(https?://[^"']+)(\2)""", re.IGNORECASE)
-_MD_IMG = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
+_MD_IMG = re.compile(r"!\[([^\]]{0,500})\]\((https?://[^)\s]{0,2000})\)")  # bounded: no O(n²) on "![" * N
 UPCOVER = "https://api.bilibili.com/x/article/creative/article/upcover"
 
 
@@ -429,6 +430,121 @@ def rehost_images(jar, csrf, content):
     return content
 
 
+# ── Markdown → HTML (专栏 body is HTML; convert if the caller passed Markdown) ──
+
+# Bounded so a single token can't scan to EOF — keeps these linear (no O(n²)
+# backtracking on malformed input like "![" * N). Real alt < 500 / URL < 2000.
+_IMG_RE = re.compile(r"!\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)")
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)")
+
+
+def _looks_like_markdown(s):
+    # Three-way classification (no full parser): block-level HTML ⇒ already an
+    # HTML document → pass through (even if it also contains markdown-looking
+    # text like **bold**); else markdown markers ⇒ render; else inline-only HTML
+    # ⇒ pass through; else plain text ⇒ render (md_to_html just wraps/escapes it).
+    s = s or ""
+    block_html = re.search(
+        r"</?(?:p|div|h[1-6]|ul|ol|li|table|thead|tbody|tr|td|th|blockquote|"
+        r"pre|figure|figcaption|section|article|header|footer|nav|aside|hr|"
+        r"main|details|summary)\b",
+        s, re.I,
+    )
+    if block_html:
+        return False
+    # ^-anchored (re.M) + horizontal-only whitespace + bounded {0,N} repeats so
+    # the scan can't backtrack across newlines or to EOF (no quadratic scanning).
+    has_md = re.search(
+        r"^#{1,6}\s|!\[[^\]]{0,500}\]\([^)]{0,2000}\)|^[ \t]*[-*+]\s|^[ \t]*\d+\.\s"
+        r"|\[[^\]]{0,500}\]\([^)]{0,2000}\)|`[^`]{1,500}`|\*\*[^*]{1,500}\*\*",
+        s, re.M,
+    )
+    if has_md:
+        return True
+    inline_html = re.search(
+        r"</?(?:a|strong|em|b|i|u|s|span|code|br|img|small|mark|sup|sub|"
+        r"video|audio|iframe)\b",
+        s, re.I,
+    )
+    return not inline_html
+
+
+def _attr_url(u):
+    # Strip C0 controls/space FIRST, then allow only http/https/mailto — otherwise
+    # `\x01javascript:` would slip past a literal scheme check yet be re-normalised
+    # to javascript: by the browser. Finally neutralise attribute-breaking quotes.
+    u = re.sub(r"[\x00-\x20\x7f]", "", u or "")
+    m = re.match(r"(?i)([a-z][a-z0-9+.\-]*):", u)
+    if m and m.group(1).lower() not in ("http", "https", "mailto"):
+        return "#"
+    return u.replace('"', "%22").replace("'", "%27")
+
+
+def _alt(s):
+    return (s or "").replace('"', "&quot;").replace("'", "&#x27;")
+
+
+def _inline_md(t):
+    t = _html.escape(t, quote=False).replace("\x00", "")
+    # Stash code spans FIRST so emphasis/link/image markup inside `…` stays
+    # literal (e.g. `**x**` must render as text, not bold).
+    spans = []
+
+    def _stash(m):
+        spans.append("<code>" + m.group(1) + "</code>")
+        return f"\x00{len(spans) - 1}\x00"
+
+    t = re.sub(r"`([^`]+)`", _stash, t)
+    t = _IMG_RE.sub(lambda m: f'<img src="{_attr_url(m.group(2))}" alt="{_alt(m.group(1))}">', t)
+    t = _LINK_RE.sub(lambda m: f'<a href="{_attr_url(m.group(2))}">{m.group(1)}</a>', t)
+    t = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", t)
+    t = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<em>\1</em>", t)
+    t = re.sub(r"\x00(\d+)\x00", lambda m: spans[int(m.group(1))], t)
+    return t
+
+
+def _md_block_to_html(b):
+    b = b.strip("\n")
+    if not b.strip():
+        return None
+    f = b.lstrip()
+    m = re.match(r"(#{1,6})\s+(.*)", f)
+    if m:
+        lvl = len(m.group(1))
+        return f"<h{lvl}>{_inline_md(m.group(2).strip())}</h{lvl}>"
+    if f.startswith(">"):
+        inner = re.sub(r"^>\s?", "", b, flags=re.M).replace("\n", " ")
+        return "<blockquote><p>" + _inline_md(inner) + "</p></blockquote>"
+    if re.match(r"[-*+]\s+", f):
+        items = [_inline_md(re.sub(r"^[-*+]\s+", "", ln)) for ln in b.split("\n") if ln.strip()]
+        return "<ul>" + "".join(f"<li>{x}</li>" for x in items) + "</ul>"
+    if re.match(r"\d+\.\s+", f):
+        items = [_inline_md(re.sub(r"^\d+\.\s+", "", ln)) for ln in b.split("\n") if ln.strip()]
+        return "<ol>" + "".join(f"<li>{x}</li>" for x in items) + "</ol>"
+    only = re.fullmatch(r"!\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)", f)
+    if only:
+        return f'<img src="{_attr_url(only.group(2))}" alt="{_alt(_html.escape(only.group(1), quote=False))}">'
+    return "<p>" + _inline_md(b.replace("\n", " ").strip()) + "</p>"
+
+
+def md_to_html(src):
+    src = (src or "").strip()
+    out = []
+    # Pull fenced code out FIRST (it may itself contain blank lines) so the
+    # blank-line block splitter below can never tear a ``` … ``` fence apart.
+    for i, part in enumerate(re.split(r"(?ms)^(```.*?(?:\n```[ \t]*$|\Z))", src)):
+        if i % 2 == 1:  # fenced code segment
+            code = re.sub(r"\A```[^\n]*\n?", "", part)
+            code = re.sub(r"\n?```[ \t]*\Z", "", code)
+            out.append("<pre><code>" + _html.escape(code) + "</code></pre>")
+            continue
+        for b in re.split(r"\n[ \t]*\n", part):  # blank-line split (no cross-newline \s*)
+            block = _md_block_to_html(b)
+            if block:
+                out.append(block)
+    return "\n".join(out)
+
+
 def cmd_publish(jar, args):
     if not args.title:
         die("--title is required")
@@ -460,6 +576,11 @@ def cmd_publish(jar, args):
     # Bilibili hotlink-blocks external images → re-host them on its CDN first.
     if not args.no_rehost_images:
         content = rehost_images(jar, csrf, content)
+
+    # 专栏 content is HTML; if the caller passed Markdown, render it (else the
+    # article shows literal `##`/`![]()` and runs together as one paragraph).
+    if _looks_like_markdown(content):
+        content = md_to_html(content)
 
     ref = "https://member.bilibili.com/"
     base = {

--- a/skills/csdn/scripts/csdn.py
+++ b/skills/csdn/scripts/csdn.py
@@ -28,6 +28,7 @@ import base64
 import gzip
 import hashlib
 import hmac
+import html as _html
 import ipaddress
 import json
 import mimetypes
@@ -286,7 +287,7 @@ def cmd_article(jar, args):
 # Signed signature → Huawei OBS multipart → csdnimg.cn URL. Mirrors our
 # PlatformPublisher csdn.py flow.
 
-_MD_IMG = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
+_MD_IMG = re.compile(r"!\[([^\]]{0,500})\]\((https?://[^)\s]{0,2000})\)")  # bounded: no O(n²) on "![" * N
 _IMG_SKIP = ("csdnimg.cn", "csdn.net")
 
 
@@ -416,6 +417,126 @@ def rehost_images(jar, content):
     return _MD_IMG.sub(repl, content)
 
 
+# ── Markdown → HTML (CSDN renders the `content` HTML field, not the source) ──
+
+# Bounded so a single token can't scan to EOF — keeps these linear (no O(n²)
+# backtracking on malformed input like "![" * N). Real alt < 500 / URL < 2000.
+_IMG_RE = re.compile(r"!\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)")
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)")
+
+
+def _attr_url(u):
+    # Strip C0 controls/space FIRST, then allow only http/https/mailto — otherwise
+    # `\x01javascript:` would slip past a literal scheme check yet be re-normalised
+    # to javascript: by the browser. Finally neutralise attribute-breaking quotes.
+    u = re.sub(r"[\x00-\x20\x7f]", "", u or "")
+    m = re.match(r"(?i)([a-z][a-z0-9+.\-]*):", u)
+    if m and m.group(1).lower() not in ("http", "https", "mailto"):
+        return "#"
+    return u.replace('"', "%22").replace("'", "%27")
+
+
+def _alt(s):
+    # alt text is already &/</>-escaped by the line escape; only the attribute
+    # quote can still break out, so neutralise it.
+    return (s or "").replace('"', "&quot;").replace("'", "&#x27;")
+
+
+def _inline_md(t):
+    t = _html.escape(t, quote=False).replace("\x00", "")
+    # Stash code spans FIRST so emphasis/link/image markup inside `…` stays
+    # literal (e.g. `**x**` must render as text, not bold).
+    spans = []
+
+    def _stash(m):
+        spans.append("<code>" + m.group(1) + "</code>")
+        return f"\x00{len(spans) - 1}\x00"
+
+    t = re.sub(r"`([^`]+)`", _stash, t)
+    t = _IMG_RE.sub(lambda m: f'<img src="{_attr_url(m.group(2))}" alt="{_alt(m.group(1))}">', t)
+    t = _LINK_RE.sub(lambda m: f'<a href="{_attr_url(m.group(2))}">{m.group(1)}</a>', t)
+    t = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", t)
+    t = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<em>\1</em>", t)
+    t = re.sub(r"\x00(\d+)\x00", lambda m: spans[int(m.group(1))], t)
+    return t
+
+
+def _md_block_to_html(b):
+    b = b.strip("\n")
+    if not b.strip():
+        return None
+    f = b.lstrip()
+    m = re.match(r"(#{1,6})\s+(.*)", f)
+    if m:
+        lvl = len(m.group(1))
+        return f"<h{lvl}>{_inline_md(m.group(2).strip())}</h{lvl}>"
+    if f.startswith(">"):
+        inner = re.sub(r"^>\s?", "", b, flags=re.M).replace("\n", " ")
+        return "<blockquote><p>" + _inline_md(inner) + "</p></blockquote>"
+    if re.match(r"[-*+]\s+", f):
+        items = [_inline_md(re.sub(r"^[-*+]\s+", "", ln)) for ln in b.split("\n") if ln.strip()]
+        return "<ul>" + "".join(f"<li>{x}</li>" for x in items) + "</ul>"
+    if re.match(r"\d+\.\s+", f):
+        items = [_inline_md(re.sub(r"^\d+\.\s+", "", ln)) for ln in b.split("\n") if ln.strip()]
+        return "<ol>" + "".join(f"<li>{x}</li>" for x in items) + "</ol>"
+    only = re.fullmatch(r"!\[([^\]]{0,500})\]\(([^)\s]{0,2000})\)", f)
+    if only:
+        return f'<img src="{_attr_url(only.group(2))}" alt="{_alt(_html.escape(only.group(1), quote=False))}">'
+    return "<p>" + _inline_md(b.replace("\n", " ").strip()) + "</p>"
+
+
+def md_to_html(src):
+    """Minimal stdlib Markdown→HTML for the platforms whose body is HTML.
+    Covers headings, paragraphs, standalone images, links, bold/italic/code,
+    fenced code, blockquotes, and ordered/unordered lists."""
+    src = (src or "").strip()
+    out = []
+    # Pull fenced code out FIRST (it may itself contain blank lines) so the
+    # blank-line block splitter below can never tear a ``` … ``` fence apart.
+    for i, part in enumerate(re.split(r"(?ms)^(```.*?(?:\n```[ \t]*$|\Z))", src)):
+        if i % 2 == 1:  # fenced code segment
+            code = re.sub(r"\A```[^\n]*\n?", "", part)
+            code = re.sub(r"\n?```[ \t]*\Z", "", code)
+            out.append("<pre><code>" + _html.escape(code) + "</code></pre>")
+            continue
+        for b in re.split(r"\n[ \t]*\n", part):  # blank-line split (no cross-newline \s*)
+            block = _md_block_to_html(b)
+            if block:
+                out.append(block)
+    return "\n".join(out)
+
+
+def _looks_like_markdown(s):
+    # Three-way classification (no full parser): block-level HTML ⇒ already an
+    # HTML document → pass through (even if it also contains markdown-looking
+    # text like **bold**); else markdown markers ⇒ render; else inline-only HTML
+    # ⇒ pass through; else plain text ⇒ render (md_to_html just wraps/escapes it).
+    s = s or ""
+    block_html = re.search(
+        r"</?(?:p|div|h[1-6]|ul|ol|li|table|thead|tbody|tr|td|th|blockquote|"
+        r"pre|figure|figcaption|section|article|header|footer|nav|aside|hr|"
+        r"main|details|summary)\b",
+        s, re.I,
+    )
+    if block_html:
+        return False
+    # ^-anchored (re.M) + horizontal-only whitespace + bounded {0,N} repeats so
+    # the scan can't backtrack across newlines or to EOF (no quadratic scanning).
+    has_md = re.search(
+        r"^#{1,6}\s|!\[[^\]]{0,500}\]\([^)]{0,2000}\)|^[ \t]*[-*+]\s|^[ \t]*\d+\.\s"
+        r"|\[[^\]]{0,500}\]\([^)]{0,2000}\)|`[^`]{1,500}`|\*\*[^*]{1,500}\*\*",
+        s, re.M,
+    )
+    if has_md:
+        return True
+    inline_html = re.search(
+        r"</?(?:a|strong|em|b|i|u|s|span|code|br|img|small|mark|sup|sub|"
+        r"video|audio|iframe)\b",
+        s, re.I,
+    )
+    return not inline_html
+
+
 def cmd_publish(jar, args):
     if not args.title:
         die("--title is required")
@@ -450,8 +571,12 @@ def cmd_publish(jar, args):
     status_code = 2 if args.draft_only else 0
     body = {
         "title": args.title,
+        # markdowncontent = the editor source; content = the RENDERED HTML CSDN
+        # actually displays. Sending raw markdown as `content` shows literal
+        # `##`/`![]()` and collapses newlines — it MUST be HTML. Already-HTML
+        # callers are passed through untouched (don't double-escape).
         "markdowncontent": content,
-        "content": content,
+        "content": md_to_html(content) if _looks_like_markdown(content) else content,
         "readType": "public",
         "status": status_code,
         "categories": "",


### PR DESCRIPTION
## Problem

Both the **csdn** and **bilibili** publish skills wrote the raw Markdown
source into the platform's `content` field — the field the site renders as
HTML. Result: published articles displayed literal `##` / `![]()` and
collapsed every paragraph onto a single line. The studio-overview test
publish rendered as a wall of raw Markdown (the reported breakage).

The live CSDN article that triggered this (`162213879`) was already fixed
in place; this PR fixes the **skills** so future publishes render correctly.

## Fix

- Add a minimal, stdlib-only `md_to_html()` (no deps — these skills are
  self-contained `urllib` CLIs) covering: headings, paragraphs, standalone
  images, links, **bold**/*italic*/`code`, fenced code, blockquotes, and
  ordered/unordered lists.
- **CSDN**: keep the Markdown source in `markdowncontent`; send rendered
  HTML in `content`.
- **Bilibili 专栏**: body is HTML — convert only when the input is Markdown.
- **Gate** (`_looks_like_markdown`) classifies the body three ways so
  already-HTML callers pass through untouched (no double-escaping):
  block-level HTML ⇒ pass through · markdown markers ⇒ render ·
  inline-only HTML ⇒ pass through · plain text ⇒ render.

## Scope / non-goals

This is a **minimal converter**, not a CommonMark parser. Deep edge cases
(nested emphasis, reference links, setext headings, tables, and rendering
the markdown portion of a body that *embeds raw HTML blocks*) are out of
scope by design.

## Verification

- 27-check local suite green: studio doc → 10 `<img>` / 6 `<h2>` / no
  literal `## `; bold+code/links/lists; HTML pass-through; code fences with
  blank lines; code-span literal; XSS; ReDoS bounds. Both files parity.
- CLI loads for both scripts.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). Ran to
convergence — **8 rounds**, every `RISK` fixed (no rebuttals needed), final
**VERDICT: CLEAN**.

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | inline-image `alt` unescaped → attribute breakout | `_alt()` escapes `"`/`'` |
| 2a | always-converting CSDN double-escaped real HTML | added the markdown-vs-HTML gate |
| 2b | bilibili gate was all-or-nothing (a stray inline tag killed conversion) | gate reworked |
| 3 | ReDoS — `_looks_like_markdown` `\s*` crossed newlines | `^`-anchored `re.M` + `[ \t]*` |
| 4a | `_attr_url` C0-control scheme bypass (`\x01javascript:`) → `href` XSS | strip C0/space, then http/https/mailto allowlist |
| 4b | fenced code containing a blank line was torn apart | extract fences before the blank-line split |
| 4c | ReDoS — unbounded `![…](…)` in gate + inline | bounded `{0,500}`/`{0,2000}` |
| 5 | ReDoS — unbounded `_MD_IMG` rehost regex (pre-existing, same path) | bounded `{0,500}`/`{0,2000}` |
| 6 | emphasis parsed inside `` `code` `` (`` `**x**` `` → bold) | stash code spans first, restore last |
| 7 | HTML containing markdown text (`<p>…**bold**…</p>`) mis-classified | block-vs-inline gate (resolves the round-1/2/7 tension) |

ReDoS bounds (post-fix): 240KB `[` 0.48s · gate `![`×120k 0.09s · `_MD_IMG`
128KB 0.13s · realistic 190KB article 0.01s (all were super-linear before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)