### PR TITLE
feat(skills): add personal WeChat service skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These skills drive third-party connectors users wire up at [auth.acedata.cloud/u
 | [notion](skills/notion/) | Read and search Notion pages, databases, and blocks | `notion` |
 | [slack](skills/slack/) | Read Slack channels, messages, and user info via Web API | `slack` |
 | [wechat-official-account](skills/wechat-official-account/) | Manage WeChat MP — drafts, publishing, materials, user tags | `wechat` (BYOC) |
+| [personal-wechat](skills/personal-wechat/) | Operate a personal WeChat account through a self-hosted Wisdom service | `personalwechat` (BYOC) |
 
 ## Prerequisites
 

--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: personal-wechat
+description: Operate the user's personal WeChat account through their self-hosted Wisdom service (BYOC) — check login status, list contacts/conversations, read and summarize history, search contacts, refresh the local history DB, and send messages only after explicit confirmation. Use when the user mentions 个人微信, 我的微信, WeChat personal chat, 微信聊天记录, 微信联系人, reading/summarizing WeChat messages, or sending a WeChat message.
+when_to_use: |
+  Trigger for the user's personal WeChat account via their own Wisdom server:
+  check status/account, list contacts, list recent conversations, read or
+  summarize a chat, query local history, search contacts, or send a message.
+  This acts on the user's real desktop WeChat, so writes are gated behind
+  explicit confirmation.
+connections: [personalwechat]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# Personal WeChat via Wisdom
+
+Use the user's self-hosted **Wisdom** service to operate their personal WeChat
+account. Wisdom runs on a Windows host with WeChat Desktop logged in and exposes
+an HTTP API.
+
+Credentials are injected by the `personalwechat` BYOC connector:
+
+- `PERSONALWECHAT_BASE_URL` — Wisdom server base URL, e.g. `http://82.156.126.14:8000`.
+- `PERSONALWECHAT_API_TOKEN` — Wisdom `API_TOKEN`. Secret — never echo, print, or log it.
+
+The helper sends the token as `Authorization: Bearer ...`; it never puts the
+token in the URL.
+
+This is the user's **real personal WeChat account**. Read operations can run
+directly. Sending messages or files must be dry-run first, then performed only
+after the user explicitly approves the exact target and content.
+
+## CLI
+
+The skill ships a stdlib-only helper:
+
+```bash
+WX=$SKILL_DIR/scripts/personal_wechat.py
+```
+
+## Verify Connection First
+
+Always start with status when the user asks to use WeChat:
+
+```bash
+python3 $WX status
+```
+
+Expected healthy shape:
+
+```json
+{"auth":{"logged_in":true,"wechat_running":true,"page":"logged_in"}}
+```
+
+If `logged_in=false`, tell the user to open the Wisdom web UI / RDP and scan the
+WeChat QR code. If the API returns 401, ask the user to reconnect the Personal
+WeChat connector with the current Wisdom API token.
+
+## Read Workflows
+
+### Current Account
+
+```bash
+python3 $WX account
+```
+
+### Contacts
+
+```bash
+python3 $WX contacts --limit 50
+```
+
+### Recent Conversations
+
+Use the normal conversations endpoint first; it prefers WeChat DB when ready and
+falls back to Wisdom's app DB.
+
+```bash
+python3 $WX conversations --limit 20
+```
+
+For decrypted local WeChat history sessions:
+
+```bash
+python3 $WX conversations --history --limit 20
+```
+
+### Messages in a Conversation
+
+First list conversations, then use the `id` as `conversation_id`:
+
+```bash
+python3 $WX messages "34642176898@chatroom" --limit 50 --order asc
+```
+
+### Historical Messages
+
+Read from Wisdom's decrypted WeChat local databases:
+
+```bash
+python3 $WX history --limit 50
+python3 $WX history --talker "34642176898@chatroom" --limit 50
+python3 $WX history --limit 20 --offset 20
+```
+
+### Raw SQL, Read-Only Only
+
+Wisdom permits only `SELECT` and `PRAGMA`:
+
+```bash
+python3 $WX sql MicroMsg.db 'SELECT count(*) AS cnt FROM Session'
+```
+
+Use raw SQL only for diagnostics or targeted metadata queries. Do not dump large
+message tables unless the user explicitly asks.
+
+### Refresh History DB
+
+If history looks stale, refresh the decrypted DB snapshot:
+
+```bash
+python3 $WX refresh-history
+```
+
+## Search
+
+```bash
+python3 $WX search "Alice"
+```
+
+Search drives the WeChat UI, so it may be slower than local DB history reads.
+
+## Sending Messages — GATED
+
+`send` dry-runs by default. It never sends unless `--confirm` is present.
+
+```bash
+python3 $WX send "Alice" "今晚 8 点开会吗？"
+# -> {"dry_run": true, ...}
+```
+
+Show the dry-run output to the user and ask for explicit approval of the exact
+recipient and text. Only then run:
+
+```bash
+python3 $WX send "Alice" "今晚 8 点开会吗？" --confirm
+```
+
+Never add `--confirm` in the first attempt. Never infer consent from vague text.
+The user must clearly approve sending this exact message.
+
+## Safety Rules
+
+- Never print `PERSONALWECHAT_API_TOKEN`.
+- Treat `PERSONALWECHAT_BASE_URL + API_TOKEN` as full remote control of the user's WeChat.
+- For any write/send operation: dry-run first, ask for explicit approval, then re-run with `--confirm`.
+- Do not call logout/restart endpoints from the skill unless the user explicitly asks to repair the Wisdom service.
+- If Wisdom returns 503 for history, run `python3 $WX refresh-history` once, then retry the read.
+- If the server is unreachable, ask the user to check the Windows host / security group / port 8000.
+
+## Endpoint Mapping
+
+The helper wraps these Wisdom endpoints:
+
+- `GET /api/status`
+- `GET /api/auth/status`
+- `GET /api/account`
+- `GET /api/contacts?version=2.0`
+- `GET /api/conversations`
+- `GET /api/conversations/history`
+- `GET /api/messages`
+- `GET /api/messages/history`
+- `POST /api/messages/history/query`
+- `POST /api/messages/history/refresh`
+- `POST /api/search`
+- `POST /api/messages/send` (only after `--confirm`)

--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Small CLI for the Personal WeChat / Wisdom BYOC skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+BASE_URL = os.environ.get("PERSONALWECHAT_BASE_URL", "").rstrip("/")
+API_TOKEN = os.environ.get("PERSONALWECHAT_API_TOKEN", "")
+MAX_TEXT_CHARS = 800
+
+
+def _die(message: str, code: int = 1) -> None:
+    print(json.dumps({"error": message}, ensure_ascii=False), file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _json(data) -> None:
+    print(json.dumps(data, ensure_ascii=False, default=str))
+
+
+def request(method: str, path: str, *, params: dict | None = None, body: dict | None = None):
+    if not BASE_URL:
+        _die("PERSONALWECHAT_BASE_URL is not set. Reconnect the Personal WeChat connector.")
+    if not API_TOKEN:
+        _die("PERSONALWECHAT_API_TOKEN is not set. Reconnect the Personal WeChat connector.")
+
+    query = dict(params or {})
+    suffix = f"?{urllib.parse.urlencode(query)}" if query else ""
+    url = f"{BASE_URL}{path}{suffix}"
+    payload = None
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {API_TOKEN}"}
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=payload, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=45) as response:
+            raw = response.read().decode("utf-8", "replace")
+            if not raw:
+                return {}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"raw": raw}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", "replace")
+        try:
+            body = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = {"raw": raw}
+        _die(f"HTTP {exc.code}: {body}", code=2)
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", None) or "connection failed"
+        _die(f"Cannot reach Wisdom at {BASE_URL}: {reason}", code=3)
+
+
+def compact_conversation(item: dict) -> dict:
+    return {
+        "id": item.get("id") or item.get("strUsrName"),
+        "name": item.get("name") or item.get("display_name") or item.get("strNickName"),
+        "type": item.get("type"),
+        "unread_count": item.get("unread_count") if "unread_count" in item else item.get("nUnReadCount"),
+        "last_active_at": item.get("last_active_at") or item.get("nTime"),
+        "last_message_count": len(item.get("messages") or []),
+    }
+
+
+def compact_message(item: dict) -> dict:
+    text = item.get("text") or item.get("StrContent") or item.get("DisplayContent")
+    if isinstance(text, str) and len(text) > MAX_TEXT_CHARS:
+        text = text[:MAX_TEXT_CHARS] + f"... [truncated {len(text) - MAX_TEXT_CHARS} chars]"
+    return {
+        "id": item.get("id") or item.get("MsgSvrID") or item.get("localId"),
+        "conversation_id": item.get("conversation_id") or item.get("StrTalker"),
+        "conversation_name": item.get("conversation_name"),
+        "sender_id": item.get("sender_id"),
+        "sender_name": item.get("sender_name"),
+        "direction": item.get("direction"),
+        "type": item.get("type") or item.get("Type"),
+        "text": text,
+        "sent_at": item.get("sent_at") or item.get("CreateTime"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Personal WeChat (Wisdom) CLI")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status")
+    sub.add_parser("account")
+
+    contacts = sub.add_parser("contacts")
+    contacts.add_argument("--limit", type=int, default=20)
+
+    convs = sub.add_parser("conversations")
+    convs.add_argument("--limit", type=int, default=20)
+    convs.add_argument("--history", action="store_true")
+
+    msgs = sub.add_parser("messages")
+    msgs.add_argument("conversation_id")
+    msgs.add_argument("--limit", type=int, default=50)
+    msgs.add_argument("--offset", type=int, default=0)
+    msgs.add_argument("--order", choices=["asc", "desc"], default="asc")
+
+    hist = sub.add_parser("history")
+    hist.add_argument("--talker", default="")
+    hist.add_argument("--limit", type=int, default=50)
+    hist.add_argument("--offset", type=int, default=0)
+
+    sql = sub.add_parser("sql")
+    sql.add_argument("db")
+    sql.add_argument("sql")
+
+    search = sub.add_parser("search")
+    search.add_argument("query")
+
+    send = sub.add_parser("send")
+    send.add_argument("target")
+    send.add_argument("text")
+    send.add_argument("--confirm", action="store_true")
+
+    refresh = sub.add_parser("refresh-history")
+    refresh.set_defaults(cmd="refresh-history")
+
+    args = parser.parse_args()
+
+    if args.cmd == "status":
+        _json({"status": request("GET", "/api/status"), "auth": request("GET", "/api/auth/status")})
+    elif args.cmd == "account":
+        _json(request("GET", "/api/account"))
+    elif args.cmd == "contacts":
+        data = request("GET", "/api/contacts", params={"limit": args.limit, "version": "2.0"})
+        _json({"total": data.get("total"), "contacts": data.get("contacts", [])})
+    elif args.cmd == "conversations":
+        if args.history:
+            data = request("GET", "/api/conversations/history", params={"limit": args.limit})
+            _json({"count": data.get("count"), "conversations": [compact_conversation(i) for i in data.get("conversations", [])]})
+        else:
+            data = request("GET", "/api/conversations", params={"limit": args.limit})
+            _json({"total": data.get("total"), "conversations": [compact_conversation(i) for i in data.get("conversations", [])]})
+    elif args.cmd == "messages":
+        data = request(
+            "GET",
+            "/api/messages",
+            params={"conversation_id": args.conversation_id, "limit": args.limit, "offset": args.offset, "order": args.order},
+        )
+        _json([compact_message(i) for i in data])
+    elif args.cmd == "history":
+        params = {"limit": args.limit, "offset": args.offset}
+        if args.talker:
+            params["talker"] = args.talker
+        data = request("GET", "/api/messages/history", params=params)
+        _json({"count": data.get("count"), "db_ready": data.get("db_ready"), "messages": [compact_message(i) for i in data.get("messages", [])]})
+    elif args.cmd == "sql":
+        data = request("POST", "/api/messages/history/query", body={"db": args.db, "sql": args.sql})
+        _json(data)
+    elif args.cmd == "search":
+        _json(request("POST", "/api/search", body={"query": args.query}))
+    elif args.cmd == "send":
+        if not args.confirm:
+            _json({"dry_run": True, "target": args.target, "text": args.text, "note": "Re-run with --confirm only after the user explicitly approves sending this exact message."})
+            return
+        _json(request("POST", "/api/messages/send", body={"target": args.target, "type": "text", "text": args.text}))
+    elif args.cmd == "refresh-history":
+        _json(request("POST", "/api/messages/history/refresh"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a new `personal-wechat` Skill for operating a user's personal WeChat account through their deployed Personal WeChat service.

## Why

The matching AuthBackend connector (`personalwechat/personalwechat`) stores the user's Personal WeChat service base URL + API token as BYOC credentials. aichat2 injects those credentials into the sandbox as:

- `PERSONALWECHAT_BASE_URL`
- `PERSONALWECHAT_API_TOKEN`

This Skill gives the model a safe, documented way to call the service for status, account, contacts, conversations, history, raw read-only SQL, search, history refresh, and gated message sending.

## Change

- New `skills/personal-wechat/SKILL.md`
- New stdlib-only helper `scripts/personal_wechat.py`
- README connector table entry

Safety details:

- Users are instructed to deploy from <https://platform.acedata.cloud/services/wechat-bot> and copy the deployment URL/token from deployment details.
- API token is sent via `Authorization: Bearer ...`, not in the URL.
- Token is never printed or logged.
- Message sending is dry-run by default and only sends with `--confirm` after explicit user approval.
- Long message payloads are truncated in helper output.

## Validation

- Parsed Skill frontmatter with PyYAML
- `python3 -m py_compile skills/personal-wechat/scripts/personal_wechat.py`
- Live helper smoke against the deployed Personal WeChat service using simulated BYOC env vars:
  - `status` → `logged_in=true`, `page=logged_in`
  - `history --limit 1` → `count=1`, `db_ready=true`, `messages_len=1`
- Verified user-facing copy contains no internal service codename and no hardcoded default deployment IP.

## 🤖 对抗评审

Read-only adversarial review checked aichat2 BYOC alias/env compatibility, connector/skill alignment, secret handling, and send gating. It found one medium risk (token in URL on errors); fixed by moving the token to the Authorization header and sanitizing connection errors. Final result: `VERDICT: CLEAN`.
