### PR TITLE
feat(personal-wechat): support unattended scheduled confirmation

### DIFF
--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -135,7 +135,9 @@ Search drives the WeChat UI, so it may be slower than local DB history reads.
 
 ## Sending Messages — GATED
 
-`send` dry-runs by default. It never sends unless `--confirm` is present.
+`send` dry-runs by default. It never sends unless `--confirm` is present, or
+unless an AceDataCloud scheduled task pre-authorized this Skill and you use
+`--unattended-confirm`.
 
 ```bash
 python3 $WX send "Alice" "今晚 8 点开会吗？"
@@ -152,11 +154,32 @@ python3 $WX send "Alice" "今晚 8 点开会吗？" --confirm
 Never add `--confirm` in the first attempt. Never infer consent from vague text.
 The user must clearly approve sending this exact message.
 
+### Scheduled-task unattended confirmation
+
+When running inside an AceDataCloud scheduled task, the platform may pre-authorize
+specific Skills for unattended execution. If all of these are true:
+
+- `AICHAT_UNATTENDED_MODE=true`
+- `AICHAT_ACTIVE_SKILL` is `personal-wechat` or `acedatacloud/personal-wechat`
+- `AICHAT_ACTIVE_SKILL` appears in `AICHAT_UNATTENDED_ALLOWED_SKILLS`
+
+then the user has pre-authorized this Skill for that scheduled task. In that
+case, use:
+
+```bash
+python3 $WX send "Alice" "今晚 8 点开会吗？" --unattended-confirm
+```
+
+If the helper returns `unattended_confirmation_denied`, do not retry with
+`--confirm`; report the dry-run and explain that the task needs this Skill to be
+selected in its unattended authorization settings.
+
 ## Safety Rules
 
 - Never print `PERSONALWECHAT_API_TOKEN`.
 - Treat `PERSONALWECHAT_BASE_URL + API_TOKEN` as full remote control of the user's WeChat.
-- For any write/send operation: dry-run first, ask for explicit approval, then re-run with `--confirm`.
+- For normal chat write/send operations: dry-run first, ask for explicit approval, then re-run with `--confirm`.
+- For scheduled-task unattended writes: use `--unattended-confirm` only when the platform env says this Skill is pre-authorized.
 - Do not call logout/restart endpoints from the skill unless the user explicitly asks to repair the Wisdom service.
 - If Wisdom returns 503 for history, run `python3 $WX refresh-history` once, then retry the read.
 - If the server is unreachable, ask the user to check the Windows host / security group / port 8000.
@@ -176,4 +199,4 @@ The helper wraps these Wisdom endpoints:
 - `POST /api/messages/history/query`
 - `POST /api/messages/history/refresh`
 - `POST /api/search`
-- `POST /api/messages/send` (only after `--confirm`)
+- `POST /api/messages/send` (only after `--confirm` or verified `--unattended-confirm`)

--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -15,6 +16,7 @@ import urllib.request
 BASE_URL = os.environ.get("PERSONALWECHAT_BASE_URL", "").rstrip("/")
 API_TOKEN = os.environ.get("PERSONALWECHAT_API_TOKEN", "")
 MAX_TEXT_CHARS = 800
+SKILL_SLUGS = {"personal-wechat", "acedatacloud/personal-wechat"}
 
 
 def _die(message: str, code: int = 1) -> None:
@@ -24,6 +26,34 @@ def _die(message: str, code: int = 1) -> None:
 
 def _json(data) -> None:
     print(json.dumps(data, ensure_ascii=False, default=str))
+
+
+def unattended_confirm_allowed() -> tuple[bool, str]:
+    if os.environ.get("AICHAT_UNATTENDED_MODE") != "true":
+        return False, "not running in AceDataCloud unattended scheduled-task mode"
+
+    active_skill = os.environ.get("AICHAT_ACTIVE_SKILL", "")
+    if active_skill not in SKILL_SLUGS:
+        return False, f"active skill {active_skill or '<empty>'!r} is not personal-wechat"
+
+    raw_allowed = os.environ.get("AICHAT_UNATTENDED_ALLOWED_SKILLS", "[]")
+    try:
+        allowed = json.loads(raw_allowed)
+    except json.JSONDecodeError:
+        return False, "AICHAT_UNATTENDED_ALLOWED_SKILLS is not valid JSON"
+    if not isinstance(allowed, list) or active_skill not in allowed:
+        return False, f"skill {active_skill!r} is not pre-authorized for unattended confirmation"
+
+    expires_raw = os.environ.get("AICHAT_UNATTENDED_EXPIRES_AT", "")
+    if expires_raw:
+      try:
+          expires_at = int(expires_raw)
+      except ValueError:
+          return False, "AICHAT_UNATTENDED_EXPIRES_AT is invalid"
+      if expires_at < int(time.time()):
+          return False, "unattended authorization has expired"
+
+    return True, "ok"
 
 
 def request(method: str, path: str, *, params: dict | None = None, body: dict | None = None):
@@ -127,6 +157,7 @@ def main() -> None:
     send.add_argument("target")
     send.add_argument("text")
     send.add_argument("--confirm", action="store_true")
+    send.add_argument("--unattended-confirm", action="store_true")
 
     refresh = sub.add_parser("refresh-history")
     refresh.set_defaults(cmd="refresh-history")
@@ -166,8 +197,13 @@ def main() -> None:
     elif args.cmd == "search":
         _json(request("POST", "/api/search", body={"query": args.query}))
     elif args.cmd == "send":
-        if not args.confirm:
-            _json({"dry_run": True, "target": args.target, "text": args.text, "note": "Re-run with --confirm only after the user explicitly approves sending this exact message."})
+        if args.unattended_confirm:
+            allowed, reason = unattended_confirm_allowed()
+            if not allowed:
+                _json({"dry_run": True, "target": args.target, "text": args.text, "error": "unattended_confirmation_denied", "reason": reason})
+                return
+        elif not args.confirm:
+            _json({"dry_run": True, "target": args.target, "text": args.text, "note": "Re-run with --confirm after explicit user approval, or --unattended-confirm when this Skill is pre-authorized for an AceDataCloud scheduled task."})
             return
         _json(request("POST", "/api/messages/send", body={"target": args.target, "type": "text", "text": args.text}))
     elif args.cmd == "refresh-history":


### PR DESCRIPTION
## What

Adds the generic unattended scheduled-task confirmation contract to the Personal WeChat Skill.

## Changes

- Adds `--unattended-confirm` to `personal_wechat.py send`.
- Allows unattended send only when platform env proves:
  - scheduled unattended mode is active,
  - active skill is personal-wechat,
  - active skill is included in `AICHAT_UNATTENDED_ALLOWED_SKILLS`,
  - optional expiry has not passed.
- Keeps normal chat behavior unchanged: no flag means dry-run; `--confirm` still requires explicit user approval.
- Documents the common `--unattended-confirm` pattern for scheduled tasks.

## Validation

- `python3 -m py_compile skills/personal-wechat/scripts/personal_wechat.py`
- Denied-path smoke test returns `unattended_confirmation_denied`.
- Allowed-path smoke test passes authorization and attempts the Wisdom request (localhost refused as expected in local test).

## 🤖 对抗评审

Included in the cross-repo review. Runtime expiry filtering was strengthened in the PlatformService companion PR; this helper also checks expiry defensively.
