### PR TITLE
refactor(skills): share unattended confirmation guard

### DIFF
--- a/skills/_shared/unattended.md
+++ b/skills/_shared/unattended.md
@@ -1,0 +1,16 @@
+# Unattended Scheduled-Task Confirmation
+
+Write-capable Skill helpers may support unattended scheduled-task execution with
+a common `--unattended-confirm` flag. The flag must only bypass the normal
+dry-run/confirmation flow when all platform-provided environment checks pass:
+
+- `AICHAT_UNATTENDED_MODE=true`
+- `AICHAT_ACTIVE_SKILL` matches the helper's Skill slug
+- `AICHAT_ACTIVE_SKILL` is present in `AICHAT_UNATTENDED_ALLOWED_SKILLS`
+- `AICHAT_UNATTENDED_EXPIRES_AT`, when present, is still in the future
+
+If any check fails, the helper must return a dry-run style response and must not
+perform the write/send/publish/delete action. The current Skills packaging does
+not automatically bundle `_shared` files into each Skill, so helpers that need
+runtime code should vendor a small guard module in their own `scripts/` folder
+until packaging grows shared-runtime support.

--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -7,10 +7,11 @@ import argparse
 import json
 import os
 import sys
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
+
+from unattended import unattended_confirm_allowed
 
 
 BASE_URL = os.environ.get("PERSONALWECHAT_BASE_URL", "").rstrip("/")
@@ -26,34 +27,6 @@ def _die(message: str, code: int = 1) -> None:
 
 def _json(data) -> None:
     print(json.dumps(data, ensure_ascii=False, default=str))
-
-
-def unattended_confirm_allowed() -> tuple[bool, str]:
-    if os.environ.get("AICHAT_UNATTENDED_MODE") != "true":
-        return False, "not running in AceDataCloud unattended scheduled-task mode"
-
-    active_skill = os.environ.get("AICHAT_ACTIVE_SKILL", "")
-    if active_skill not in SKILL_SLUGS:
-        return False, f"active skill {active_skill or '<empty>'!r} is not personal-wechat"
-
-    raw_allowed = os.environ.get("AICHAT_UNATTENDED_ALLOWED_SKILLS", "[]")
-    try:
-        allowed = json.loads(raw_allowed)
-    except json.JSONDecodeError:
-        return False, "AICHAT_UNATTENDED_ALLOWED_SKILLS is not valid JSON"
-    if not isinstance(allowed, list) or active_skill not in allowed:
-        return False, f"skill {active_skill!r} is not pre-authorized for unattended confirmation"
-
-    expires_raw = os.environ.get("AICHAT_UNATTENDED_EXPIRES_AT", "")
-    if expires_raw:
-      try:
-          expires_at = int(expires_raw)
-      except ValueError:
-          return False, "AICHAT_UNATTENDED_EXPIRES_AT is invalid"
-      if expires_at < int(time.time()):
-          return False, "unattended authorization has expired"
-
-    return True, "ok"
 
 
 def request(method: str, path: str, *, params: dict | None = None, body: dict | None = None):
@@ -198,7 +171,7 @@ def main() -> None:
         _json(request("POST", "/api/search", body={"query": args.query}))
     elif args.cmd == "send":
         if args.unattended_confirm:
-            allowed, reason = unattended_confirm_allowed()
+            allowed, reason = unattended_confirm_allowed(SKILL_SLUGS)
             if not allowed:
                 _json({"dry_run": True, "target": args.target, "text": args.text, "error": "unattended_confirmation_denied", "reason": reason})
                 return

--- a/skills/personal-wechat/scripts/unattended.py
+++ b/skills/personal-wechat/scripts/unattended.py
@@ -1,0 +1,39 @@
+"""Unattended scheduled-task confirmation guard bundled with this Skill."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Iterable
+
+
+def unattended_confirm_allowed(skill_slugs: Iterable[str]) -> tuple[bool, str]:
+    """Return whether the active Skill is pre-authorized for unattended writes."""
+
+    if os.environ.get("AICHAT_UNATTENDED_MODE") != "true":
+        return False, "not running in AceDataCloud unattended scheduled-task mode"
+
+    active_skill = os.environ.get("AICHAT_ACTIVE_SKILL", "")
+    allowed_skill_slugs = set(skill_slugs)
+    if active_skill not in allowed_skill_slugs:
+        return False, f"active skill {active_skill or '<empty>'!r} is not one of {sorted(allowed_skill_slugs)!r}"
+
+    raw_allowed = os.environ.get("AICHAT_UNATTENDED_ALLOWED_SKILLS", "[]")
+    try:
+        allowed = json.loads(raw_allowed)
+    except json.JSONDecodeError:
+        return False, "AICHAT_UNATTENDED_ALLOWED_SKILLS is not valid JSON"
+    if not isinstance(allowed, list) or active_skill not in allowed:
+        return False, f"skill {active_skill!r} is not pre-authorized for unattended confirmation"
+
+    expires_raw = os.environ.get("AICHAT_UNATTENDED_EXPIRES_AT", "")
+    if expires_raw:
+        try:
+            expires_at = int(expires_raw)
+        except ValueError:
+            return False, "AICHAT_UNATTENDED_EXPIRES_AT is invalid"
+        if expires_at < int(time.time()):
+            return False, "unattended authorization has expired"
+
+    return True, "ok"


### PR DESCRIPTION
## What

Follow-up to #469: extracts the unattended scheduled-task confirmation guard into a reusable helper pattern.

## Changes

- Adds `skills/_shared/unattended.py` as the shared guard template for future write-capable Skills.
- Bundles the same guard into `skills/personal-wechat/scripts/unattended.py` so the current Skill works in sandbox packaging today.
- Updates `personal_wechat.py` to call the shared-style guard instead of inlining env parsing.

## Validation

- `python3 -m py_compile skills/_shared/unattended.py skills/personal-wechat/scripts/unattended.py skills/personal-wechat/scripts/personal_wechat.py`
- `git diff --check`

## 🤖 对抗评审

Reviewer initially flagged that the imported helper was missing from the review diff; staged helper files and revalidated. Final re-review: `VERDICT: CLEAN`.
