### PR TITLE
Update Personal WeChat helper for task API

### DIFF
--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -27,7 +27,9 @@ Credentials are injected by the `personalwechat` BYOC connector:
 - `PERSONALWECHAT_API_TOKEN` — Wisdom `API_TOKEN`. Secret — never echo, print, or log it.
 
 The helper sends the token as `Authorization: Bearer ...`; it never puts the
-token in the URL.
+token in the URL. For queued UI operations such as search and send, the helper
+submits the task and waits for `/api/tasks/{id}` before printing the final
+result.
 
 This is the user's **real personal WeChat account**. Read operations can run
 directly. Sending messages or files must be dry-run first, then performed only

--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -93,6 +93,28 @@ def request(method: str, path: str, *, params: dict | None = None, body: dict | 
         _die(f"Cannot reach Wisdom at {BASE_URL}: {reason}", code=3)
 
 
+def wait_task(task_id: str, *, timeout: float = 600.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        task = request("GET", f"/api/tasks/{task_id}")
+        status = task.get("status")
+        if status == "succeeded":
+            return task.get("result")
+        if status == "failed":
+            error = task.get("error") or {}
+            _die(f"Task failed: {error.get('message') or error}", code=2)
+        time.sleep(0.35)
+    _die(f"Task {task_id} did not finish within {timeout:g}s", code=2)
+
+
+def request_task(method: str, path: str, *, params: dict | None = None, body: dict | None = None, timeout: float = 600.0):
+    task = request(method, path, params=params, body=body)
+    task_id = task.get("id")
+    if not task_id:
+        return task
+    return wait_task(task_id, timeout=timeout)
+
+
 def compact_conversation(item: dict) -> dict:
     return {
         "id": item.get("id") or item.get("strUsrName"),
@@ -195,7 +217,7 @@ def main() -> None:
         data = request("POST", "/api/messages/history/query", body={"db": args.db, "sql": args.sql})
         _json(data)
     elif args.cmd == "search":
-        _json(request("POST", "/api/search", body={"query": args.query}))
+        _json(request_task("POST", "/api/search", body={"query": args.query}, timeout=120))
     elif args.cmd == "send":
         if args.unattended_confirm:
             allowed, reason = unattended_confirm_allowed()
@@ -205,7 +227,7 @@ def main() -> None:
         elif not args.confirm:
             _json({"dry_run": True, "target": args.target, "text": args.text, "note": "Re-run with --confirm after explicit user approval, or --unattended-confirm when this Skill is pre-authorized for an AceDataCloud scheduled task."})
             return
-        _json(request("POST", "/api/messages/send", body={"target": args.target, "type": "text", "text": args.text}))
+        _json(request_task("POST", "/api/messages/send", body={"target": args.target, "type": "text", "text": args.text}))
     elif args.cmd == "refresh-history":
         _json(request("POST", "/api/messages/history/refresh"))
 


### PR DESCRIPTION
## Summary
- Update the Personal WeChat helper to handle queued `search` and confirmed `send` responses.
- Add task polling through `GET /api/tasks/{id}` while keeping the API token in the Authorization header.
- Document that queued UI operations are waited before printing final results.

## Validation
- `python3 -m py_compile skills/personal-wechat/scripts/personal_wechat.py`
- `git diff --check HEAD^ HEAD`
- GitHub compare: only `skills/personal-wechat/SKILL.md` and `skills/personal-wechat/scripts/personal_wechat.py`

## 对抗评审
- Verified search/send submit tasks and poll with auth header.
- Verified dry-run send gating remains intact.
- Verified helper remains stdlib-only and does not print the connector token.
- Verdict: `VERDICT: CLEAN`.
