### PR TITLE
fix(zhihu): store durable public image URLs

### DIFF
--- a/skills/zhihu/scripts/blog.py
+++ b/skills/zhihu/scripts/blog.py
@@ -257,9 +257,29 @@ ZH_UPLOADED_IMAGES = "https://zhuanlan.zhihu.com/api/uploaded_images"
 ZH_IMAGES = "https://api.zhihu.com/images"
 OSS_ENDPOINT = "https://zhihu-pics-upload.zhimg.com"
 OSS_BUCKET = "zhihu-pics"
-_ZHIMG = "zhimg.com"  # a src already on Zhihu's CDN needs no re-upload
+# A src already on Zhihu's own CDN needs no re-upload. uploaded_images hands back
+# a pic-private.zhihu.com URL for draft-scoped images, so skip those too.
+_ZHIMG_HOSTS = ("zhimg.com", "pic-private.zhihu.com")
 _IMG_SRC_RE = re.compile(r'(<img[^>]*?\ssrc=["\'])([^"\']+)(["\'])', re.IGNORECASE)
 _MD_IMG_RE = re.compile(r'(!\[[^\]]*\]\()(\s*<?)([^)\s>]+)(>?\s*\))')
+# uploaded_images returns a DRAFT-SCOPED signed pic-private URL whose auth_key
+# expires; reduce any Zhihu image URL to the durable public form Zhihu serves
+# after publish (picx.zhimg.com/v2-<hash>.<ext>).
+_ZH_IMG_HASH = re.compile(r'(v2-[0-9a-f]+)(?:~[^."?\']*)?\.(png|jpe?g|gif|webp)', re.IGNORECASE)
+
+
+def _on_zhihu_cdn(src: str) -> bool:
+    # Match on the parsed host (not a substring) so an external host that merely
+    # contains "zhimg.com" (e.g. my-zhimg.com) isn't wrongly treated as hosted.
+    host = (urllib.parse.urlsplit(src).hostname or "") if src else ""
+    return any(host == h or host.endswith("." + h) for h in _ZHIMG_HOSTS)
+
+
+def _canonical_zhimg(url):
+    if not url:
+        return url
+    m = _ZH_IMG_HASH.search(url)
+    return f"https://picx.zhimg.com/{m.group(1)}.{m.group(2).lower()}" if m else url
 
 
 def _raw(method, url, jar, *, headers=None, data=None, timeout=60):
@@ -312,7 +332,7 @@ def _upload_image_url(jar, src: str):
         except json.JSONDecodeError:
             return None
         if isinstance(d, dict) and d.get("src"):
-            return d["src"]
+            return _canonical_zhimg(d["src"])
     return None
 
 
@@ -380,13 +400,13 @@ def _upload_image_binary(jar, data: bytes):
     upload_token = token_data.get("upload_token") or {}
     if upload_file.get("state") == 1:  # already on Zhihu — just resolve its hash
         object_key = _wait_image_ready(jar, upload_file.get("image_id", ""))
-        return f"https://pic4.zhimg.com/{object_key}" if object_key else None
+        return _canonical_zhimg(f"https://pic4.zhimg.com/{object_key}") if object_key else None
     object_key = upload_file.get("object_key", "")
     if not object_key or not _oss_put(object_key, data, upload_token):
         return None
     if data[:6] in (b"GIF87a", b"GIF89a"):
         object_key += ".gif"
-    return f"https://pic4.zhimg.com/{object_key}"
+    return _canonical_zhimg(f"https://pic4.zhimg.com/{object_key}")
 
 
 def _download_image(src: str):
@@ -400,7 +420,7 @@ def _download_image(src: str):
 def count_images(content: str) -> int:
     srcs = {m.group(2) for m in _IMG_SRC_RE.finditer(content or "")}
     srcs |= {m.group(3) for m in _MD_IMG_RE.finditer(content or "")}
-    return sum(1 for s in srcs if _ZHIMG not in s)
+    return sum(1 for s in srcs if not _on_zhihu_cdn(s))
 
 
 def rehost_images(jar, content: str):
@@ -410,7 +430,7 @@ def rehost_images(jar, content: str):
     stats = {"found": 0, "rehosted": 0, "failed": 0}
 
     def resolve(src: str) -> str:
-        if not src or _ZHIMG in src:
+        if not src or _on_zhihu_cdn(src):
             return src
         if src in cache:
             return cache[src]


### PR DESCRIPTION
## Problem

Follow-up to #472. Zhihu's `uploaded_images` endpoint returns a **draft-scoped, signed** URL:

```
https://pic-private.zhihu.com/v2-<hash>~resize:1440:q75.png?...&expiration=<ts>&auth_key=<sig>&sceneCode=article_draft_web
```

The skill stored that verbatim in the article content. It works for the normal "create draft → publish immediately" flow (Zhihu rewrites it on publish), but the `auth_key`/`expiration` **rot** if a draft sits before publishing, and the signed URL is ugly/fragile to carry around.

Confirmed live: an image uploaded this way is `403` on the bare public URL while draft-scoped, and Zhihu serves it publicly as `pica/picx.zhimg.com/v2-<hash>_1440w.png` only after publish.

## Fix

- `_canonical_zhimg(url)` reduces any Zhihu image URL to the durable public form `https://picx.zhimg.com/v2-<hash>.<ext>` (the identity is the `v2-<hash>`; the signed query + `~resize` transform are dropped). Applied to the return of both `_upload_image_url` and `_upload_image_binary`.
- `_ZHIMG` (single substring) → `_ZHIMG_HOSTS = ("zhimg.com", "pic-private.zhihu.com")` + `_on_zhihu_cdn(src)` which matches on the **parsed hostname** (not a substring), so `pic-private` drafts are treated as already-hosted and re-runs are idempotent.

No behaviour change for the happy path; just stores a stable URL. csdn/bilibili skills already return durable hosts (csdnimg.cn / hdslb.com), so this was zhihu-only.

## Tests

- `py_compile` + `ruff check` clean.
- Unit: `_canonical_zhimg` normalizes pic-private/pic4 → picx, leaves non-zhihu URLs alone; `rehost_images` stores the durable URL (no `auth_key`/`pic-private` leak) and is idempotent on re-run.
- Host edge cases: `my-zhimg.com`, `cdn.acedata.cloud/zhimg.com.png`, `evil.com/?x=pic-private.zhihu.com` all correctly NOT skipped; real `*.zhimg.com` / `pic-private.zhihu.com` skipped.

## 🤖 对抗评审

Reviewer: Codex rate-limited → `general-purpose` subagent (read-only).

- **RISK (fixed):** `_on_zhihu_cdn` used substring matching (`"zhimg.com" in src`), so an external host like `my-zhimg.com` would be wrongly skipped and never re-hosted (image lost). Fixed to parse the hostname (`urllib.parse.urlsplit(src).hostname`) and match exact domain or `.suffix`. (This also hardens the pre-existing substring check inherited from #472.)
- Verified CLEAN otherwise: `_canonical_zhimg` is only ever called on Zhihu-returned URLs (not arbitrary input), regex stops before `?` so query strings aren't absorbed, no backtracking, no crash on no-match (returns input), idempotent re-runs.

Converged in 1 round.
