### PR TITLE
docs(acedatacloud): use mcp.acedata.cloud as hosted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Skills provide **knowledge** (when to use, parameters, gotchas). MCP servers pro
 | nano-banana-image | [mcp-nano-banana](https://pypi.org/project/mcp-nano-banana/) | `pip install mcp-nano-banana` | `https://nano-banana.mcp.acedata.cloud/mcp` |
 | short-url | [mcp-shorturl](https://pypi.org/project/mcp-shorturl/) | `pip install mcp-shorturl` | `https://short-url.mcp.acedata.cloud/mcp` |
 | wan-video | [mcp-wan](https://pypi.org/project/mcp-wan/) | `pip install mcp-wan` | `https://wan.mcp.acedata.cloud/mcp` |
-| acedatacloud | [mcp-acedatacloud](https://pypi.org/project/mcp-acedatacloud/) | `pip install mcp-acedatacloud` | `https://acedatacloud.mcp.acedata.cloud/mcp` |
+| acedatacloud | [mcp-acedatacloud](https://pypi.org/project/mcp-acedatacloud/) | `pip install mcp-acedatacloud` | `https://mcp.acedata.cloud/mcp` |
 
 **Using hosted MCP endpoints** (no local install needed):
 

--- a/skills/_shared/mcp-servers.md
+++ b/skills/_shared/mcp-servers.md
@@ -18,7 +18,7 @@ Each AceDataCloud service has a corresponding MCP server that provides tool-use 
 | nano-banana-image | `pip install mcp-nano-banana` | `https://nano-banana.mcp.acedata.cloud/mcp` |
 | short-url | `pip install mcp-shorturl` | `https://short-url.mcp.acedata.cloud/mcp` |
 | wan-video | `pip install mcp-wan` | `https://wan.mcp.acedata.cloud/mcp` |
-| acedatacloud | `pip install mcp-acedatacloud` | `https://acedatacloud.mcp.acedata.cloud/mcp` |
+| acedatacloud | `pip install mcp-acedatacloud` | `https://mcp.acedata.cloud/mcp` |
 
 ## Configuration Example
 


### PR DESCRIPTION
## What

Point the hosted endpoint for the unified `acedatacloud` platform-management MCP at the bare subdomain **https://mcp.acedata.cloud/mcp** (was `acedatacloud.mcp.acedata.cloud`).

Per-service MCPs (`suno.mcp.acedata.cloud`, `serp.mcp.acedata.cloud`, …) keep their per-service prefix — only the unified account/management server moves to the apex `mcp.acedata.cloud`.

## Changes

- `README.md` — MCP pairing table, `acedatacloud` row
- `skills/_shared/mcp-servers.md` — hosted endpoint table, `acedatacloud` row

Docs-only.

## 🤖 对抗评审

VERDICT: CLEAN — two documentation table cells, no behavioral surface.
