### PR TITLE
docs(seedance-video): sync skill to Seedance 2.0 (multimodal reference, 4k, dur 2-15)

### DIFF
--- a/skills/seedance-video/SKILL.md
+++ b/skills/seedance-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seedance-video
-description: Generate AI dance and motion videos with Seedance (ByteDance) via AceDataCloud API. Use when creating videos from text prompts or animating images into motion videos. Supports multiple models with configurable resolution, aspect ratio, duration, and optional audio generation.
+description: Generate AI videos with Seedance (ByteDance) via AceDataCloud API. Use when creating videos from text prompts, animating images into motion videos, or driving Seedance 2.0 multimodal generation with real-person / character image references, reference audio, and reference video. Supports multiple models with configurable resolution (up to 4k), aspect ratio, duration, and optional audio generation.
 license: Apache-2.0
 metadata:
   author: acedatacloud
@@ -20,7 +20,7 @@ Generate AI dance and motion videos through AceDataCloud's Seedance (ByteDance) 
 curl -X POST https://api.acedata.cloud/seedance/videos \
   -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"model": "doubao-seedance-1-0-pro-250528", "content": [{"type": "text", "text": "a dancer performing contemporary ballet in a misty forest"}], "callback_url": "https://api.acedata.cloud/health"}'
+  -d '{"model": "doubao-seedance-2-0-260128", "content": [{"type": "text", "text": "a dancer performing contemporary ballet in a misty forest"}], "callback_url": "https://api.acedata.cloud/health"}'
 ```
 
 > **Async:** See [async task polling](../_shared/async-tasks.md). Poll via `POST /seedance/tasks` with `{"id": "..."}`.
@@ -35,11 +35,23 @@ curl -X POST https://api.acedata.cloud/seedance/tasks \
 
 ## Models
 
+### Seedance 2.0 (current generation — multimodal reference)
+
+The 2.0 series adds multimodal reference inputs: real-person / character **image** references, reference **audio**, and reference **video** (see the workflows below).
+
+| Model | Best For | Max resolution |
+|-------|----------|----------------|
+| `doubao-seedance-2-0-260128` | Highest quality, real-person/character reference, 4k output | `4k` |
+| `doubao-seedance-2-0-fast-260128` | Faster 2.0 generation | `720p` |
+| `doubao-seedance-2-0-mini-260615` | Lightweight / most cost-effective 2.0 | `720p` |
+
+### Seedance 1.x
+
 | Model | Type | Best For |
 |-------|------|----------|
+| `doubao-seedance-1-5-pro-251215` | Text+Image-to-Video | 1.5 flagship, audio support |
 | `doubao-seedance-1-0-pro-250528` | Text+Image-to-Video | General-purpose, reliable quality |
 | `doubao-seedance-1-0-pro-fast-251015` | Text+Image-to-Video | Faster Pro generation |
-| `doubao-seedance-1-5-pro-251215` | Text+Image-to-Video | Latest model, highest quality, audio support |
 | `doubao-seedance-1-0-lite-t2v-250428` | Text-to-Video only | Lightweight text-to-video |
 | `doubao-seedance-1-0-lite-i2v-250428` | Image-to-Video only | Lightweight image-to-video |
 
@@ -86,7 +98,11 @@ POST /seedance/videos
 Image roles:
 - `first_frame` — image is used as the opening frame
 - `last_frame` — image is used as the closing frame
-- `reference_image` — image is used as a style/content reference
+- `reference_image` — image is used as a style / subject / real-person reference (Seedance 2.0 keeps the referenced person or character consistent)
+
+Reference media (Seedance 2.0 only):
+- `audio_url` — reference audio for voice timbre / background music (no `role`)
+- `video_url` — reference video for subject, camera movement, motion or overall style (no `role`)
 
 ### 3. First-frame + Last-frame
 
@@ -95,7 +111,7 @@ Provide both a start and end frame image:
 ```json
 POST /seedance/videos
 {
-  "model": "doubao-seedance-1-0-pro-250528",
+  "model": "doubao-seedance-2-0-260128",
   "content": [
     {"type": "text", "text": "smooth transition between two scenes"},
     {"type": "image_url", "role": "first_frame", "image_url": {"url": "https://example.com/start.jpg"}},
@@ -104,18 +120,53 @@ POST /seedance/videos
 }
 ```
 
+### 4. Real-person / character reference (Seedance 2.0)
+
+Seedance 2.0 models (`doubao-seedance-2-0-260128`, `doubao-seedance-2-0-fast-260128`, `doubao-seedance-2-0-mini-260615`) can keep a **specific person or character** consistent across a brand-new scene. Pass one or more photos as `image_url` items with `role: "reference_image"` — the model preserves that subject's appearance. Up to 9 reference images are accepted.
+
+```json
+POST /seedance/videos
+{
+  "model": "doubao-seedance-2-0-260128",
+  "content": [
+    {"type": "text", "text": "the same person walking through a neon-lit night market, cinematic"},
+    {"type": "image_url", "role": "reference_image", "image_url": {"url": "https://example.com/person.jpg"}}
+  ],
+  "resolution": "1080p",
+  "duration": 8
+}
+```
+
+### 5. Reference audio / video (Seedance 2.0)
+
+2.0 models also accept reference **audio** (voice timbre, background music) and reference **video** (subject content, camera movement, motion, overall style). Add `audio_url` and/or `video_url` content items. Limits: up to 3 audio and 3 video references per request.
+
+```json
+POST /seedance/videos
+{
+  "model": "doubao-seedance-2-0-260128",
+  "content": [
+    {"type": "text", "text": "a singer performing on stage, matching the reference voice and motion"},
+    {"type": "image_url", "role": "reference_image", "image_url": {"url": "https://example.com/person.jpg"}},
+    {"type": "audio_url", "audio_url": {"url": "https://example.com/voice.mp3"}},
+    {"type": "video_url", "video_url": {"url": "https://example.com/motion.mp4"}}
+  ],
+  "generate_audio": true
+}
+```
+
 ## Parameters
 
 | Parameter | Values | Description |
 |-----------|--------|-------------|
 | `model` | see Models table | Model to use (required) |
-| `content` | array | Input items: text and/or image_url objects (required) |
-| `resolution` | `"480p"`, `"720p"`, `"1080p"` | Output resolution (default: 720p for pro, 480p for lite) |
+| `content` | array | Input items: `text`, `image_url`, `audio_url` (2.0), `video_url` (2.0) (required) |
+| `resolution` | `"480p"`, `"720p"`, `"1080p"`, `"4k"` | Output resolution. `4k` is `doubao-seedance-2-0-260128` (standard) only; `2-0-fast` / `2-0-mini` max out at `720p` (default: 720p for pro/2.0, 480p for lite) |
 | `ratio` | `"16:9"`, `"4:3"`, `"1:1"`, `"3:4"`, `"9:16"`, `"21:9"`, `"adaptive"` | Aspect ratio (default: 16:9) |
-| `duration` | `2` – `12` | Duration in seconds |
-| `frames` | 29–289 (must satisfy 25+4n) | Frame count — mutually exclusive with `duration` |
+| `duration` | `2` – `15` | Duration in seconds (Seedance 2.0 supports 4–15) |
+| `frames` | 29–361 (must satisfy 25+4n) | Frame count — mutually exclusive with `duration` |
 | `seed` | -1 to 4294967295 | Seed for reproducible results (-1 = random) |
-| `generate_audio` | `true` / `false` | Generate audio (only supported by `doubao-seedance-1-5-pro-251215`) |
+| `generate_audio` | `true` / `false` | Generate audio (supported by `doubao-seedance-1-5-pro-251215` and the `doubao-seedance-2-0` series; other models ignore it) |
 | `camerafixed` | `true` / `false` | Fix the camera position during generation |
 | `watermark` | `true` / `false` | Add a watermark to the generated video |
 | `return_last_frame` | `true` / `false` | Return the last frame of the generated video |
@@ -137,12 +188,13 @@ Supported inline params: `--rs` (resolution), `--rt` (ratio), `--dur` (duration)
 - Model names use the `doubao-*` convention (e.g. `doubao-seedance-1-0-pro-250528`) — old short names like `seedance-1.0` are not valid
 - The `content` array replaces the old `prompt` + `image_url` fields; always use `content`
 - Image and text scenarios are mutually exclusive per content item — each item has either `text` or `image_url`, not both
-- `first_frame`, `last_frame`, and `reference_image` roles are mutually exclusive scenarios — pick one pattern per request
-- `generate_audio: true` is only supported by `doubao-seedance-1-5-pro-251215`; other models ignore this field
+- `first_frame` and `last_frame` may be combined in one request, but `reference_image` is mutually exclusive with `first_frame` / `last_frame` — do not mix a reference image with first/last frames
+- `generate_audio: true` is supported by `doubao-seedance-1-5-pro-251215` and the `doubao-seedance-2-0` series; other models ignore this field
 - Lite models are split: `*-lite-t2v-*` only accepts text, `*-lite-i2v-*` only accepts image-to-video
-- Resolution options are `480p`, `720p`, `1080p` — there is no 360p or 540p
+- `audio_url` and `video_url` reference items are used by the **Seedance 2.0 series only**
+- Resolution options are `480p`, `720p`, `1080p`, and `4k` (`4k` is `doubao-seedance-2-0-260128` only; `2-0-fast` / `2-0-mini` max out at `720p`) — there is no 360p or 540p
 - `service_tier` values are `"default"` and `"flex"` (not "standard"/"premium")
-- Duration range is **2–12 seconds** — values outside this range will fail
+- Duration range is **2–15 seconds** (Seedance 2.0 supports 4–15) — values outside this range will fail
 - Task states use `"succeeded"` (not "completed") — check for this value when polling
 
 > **MCP:** `pip install mcp-seedance` | Hosted: `https://seedance.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)


### PR DESCRIPTION
Sync the `seedance-video` skill to the live **Seedance 2.0** capability (the skill was stuck on the 1.x spec while `origin/main` of PlatformBackend, its OpenAPI and the CLI had already moved to 2.0).

## What changed
- **Models**: added the Seedance 2.0 series — `doubao-seedance-2-0-260128` (4k), `doubao-seedance-2-0-fast-260128`, `doubao-seedance-2-0-mini-260615` (1.x kept, matching the OpenAPI model enum on main).
- **Multimodal reference (2.0)**: new `audio_url` (reference audio) and `video_url` (reference video) content types; documented real-person / character `reference_image` workflow.
- **Resolution**: added `4k` (with the model caveat: `4k` is `2-0-260128`-only; `2-0-fast`/`2-0-mini` cap at `720p`).
- **Duration**: `2`–`12` → `2`–`15`; **frames** `29–289` → `29–361`.
- **generate_audio**: now noted as supported by `1-5-pro` **and** the `2-0` series.
- Quick-start example bumped to a live `2-0` model.

No code, only the skill markdown.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). One round.

- RISK: duration "4–15" contradicts "2–15". → **Rebut**: accurate — the API accepts 2–15; Seedance 2.0 prefers 4–15 (the worker validates 2–15 and lets upstream reject sub-4s). Text reads "2–15 (Seedance 2.0 supports 4–15)".
- RISK: ` ```json ` blocks contain a leading `POST /seedance/videos` line → not valid JSON. → **Rebut**: pre-existing illustrative convention used by every example in the file; converting all is out of scope for this sync.
- RISK: roles described as all-mutually-exclusive but file shows first+last together. → **Fixed**: clarified `first_frame`+`last_frame` may combine; `reference_image` is exclusive with first/last.
- RISK: "1.x models ignore audio/video" asserts ignore-vs-reject behavior. → **Fixed**: softened to "used by the Seedance 2.0 series only".
- RISK: "real-person photos are registered as assets transparently by the API" is an internal, flag-gated implementation detail. → **Fixed**: removed the claim.

VERDICT after fixes: CLEAN.
