### PR TITLE
feat(zhihu): answer & edit answers to questions

### DIFF
--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: zhihu
-description: Read and publish on Zhihu (知乎) with the user's own login cookies (BYOC) — list their published articles with vote/comment stats, inspect one article, and publish a new article. Use when the user mentions 知乎 / Zhihu, "我的知乎文章", reading their article stats (点赞/评论), or publishing/发文 to Zhihu.
+description: Read and publish on Zhihu (知乎) with the user's own login cookies (BYOC) — list published articles & answers with vote/comment stats, inspect an article/answer/question, publish an article, and answer or edit answers to questions. Use when the user mentions 知乎 / Zhihu, "我的知乎文章/回答", reading their stats (点赞/评论), 发文, or 回答/编辑某个问题的回答.
 when_to_use: |
   Trigger for anything on the user's Zhihu (知乎) account driven by their own
-  login cookie: show who they are, list their published articles with
-  vote-up / comment counts, look at one article's stats, or publish a new
-  article. This acts as the user's real account, so writes are gated behind
-  an explicit confirmation.
+  login cookie: show who they are, list their published articles or answers
+  with vote/comment counts, look at one article / answer / question, publish a
+  new article, post a new answer to a question, or edit an existing answer.
+  This acts as the user's real account, so writes are gated behind an explicit
+  confirmation.
 connections: [zhihu]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.1"
+  version: "1.2"
 ---
 
 # zhihu — read & publish on Zhihu via your own cookies
@@ -37,6 +38,9 @@ BLOG=$SKILL_DIR/scripts/blog.py
 python3 $BLOG whoami                       # who is logged in
 python3 $BLOG articles --limit 20          # my published articles + stats
 python3 $BLOG article <article-id>         # one article's details + stats
+python3 $BLOG answers --limit 20           # my published answers + stats
+python3 $BLOG answer <answer-id>           # one answer's details + stats
+python3 $BLOG question <question-id>       # a question's info + whether I answered it
 ```
 
 ## Verify the connection first
@@ -56,11 +60,21 @@ extension). Do **not** retry in a loop.
 |---|---|
 | Who am I | `python3 $BLOG whoami` |
 | My latest articles + vote/comment counts | `python3 $BLOG articles --limit 20` |
-| Next page | `python3 $BLOG articles --limit 20 --offset 20` |
+| My latest answers + like/favorite/comment counts | `python3 $BLOG answers --limit 20` |
+| Next page (any list) | add `--offset 20` |
 | One article's stats | `python3 $BLOG article <id>` |
+| One answer's stats (incl. 赞同 voteup) | `python3 $BLOG answer <id>` |
+| A question's info + my answer id (if any) | `python3 $BLOG question <id>` |
 
-Stats come straight from Zhihu: `voteup_count` (赞同), `comment_count` (评论).
-Zhihu does not expose per-article read counts on these endpoints.
+Article stats: `voteup_count` (赞同), `comment_count` (评论). Zhihu does not
+expose per-article read counts on these endpoints.
+
+**Answer stat caveat:** the `answers` *list* endpoint does **not** return
+`voteup_count` (赞同) — it only exposes `like_count` (喜欢), `favorite_count`
+(收藏) and `comment_count`. For the authoritative 赞同 count of an answer, call
+`answer <id>` (the single-answer endpoint returns `voteup_count`). `question <id>`
+reports `already_answered` + `my_answer_id` so you know whether to use
+`answer-question` (new) or `edit-answer` (update).
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 
@@ -88,10 +102,46 @@ python3 $BLOG publish --title "标题" --content-file article.html --confirm    
   reports `images_found`. Pass `--no-images` to skip this. So you can hand the
   CLI HTML/Markdown with normal public image URLs and the pictures survive.
 
+## Answering questions — GATED (dry-run unless trailing `--confirm`)
+
+Two write commands cover the question/answer side. Both gate exactly like
+`publish`: no trailing `--confirm` → **dry-run**; `--confirm` is honored **only
+as the last argument**. Always show the dry-run, get an explicit "yes", then
+re-run with `--confirm` last.
+
+```sh
+# Content is HTML (same as articles). For Markdown, convert to HTML first.
+
+# Post a NEW answer to a question
+python3 $BLOG answer-question --question <qid> --content-file ans.html                       # dry-run
+python3 $BLOG answer-question --question <qid> --content-file ans.html --draft-only --confirm  # PRIVATE draft (safe)
+python3 $BLOG answer-question --question <qid> --content-file ans.html --confirm               # PUBLIC, goes live
+
+# Edit an EXISTING answer (replaces its live, public content)
+python3 $BLOG edit-answer --id <answer-id> --content-file ans.html             # dry-run
+python3 $BLOG edit-answer --id <answer-id> --content-file ans.html --confirm   # overwrites live answer
+```
+
+- **One answer per question.** Zhihu allows a single answer per user per
+  question. If the user already answered, `answer-question --confirm` returns a
+  clear error telling you to use `edit-answer` instead — find the existing answer
+  id with `answers` or `question <qid>` (which reports `my_answer_id`).
+- **`--draft-only` is the safe path for new answers** — it saves a *private*
+  draft on the question (nothing public). The user reviews it on Zhihu, then you
+  re-run without `--draft-only` (with `--confirm`) to publish. Prefer this unless
+  the user clearly asked to go live immediately.
+- **`edit-answer` has no private mode** — the answer is already public, so any
+  `--confirm` edit is live immediately. It preserves the answer's current repost
+  setting unless you override with `--repost allowed|disallowed`.
+- **转载授权** (`--repost allowed|disallowed`): new answers default to
+  `disallowed` (don't grant repost rights); editing keeps the current setting.
+- **Images are auto-hosted** for answers too — same behavior and `--no-images`
+  flag as `publish`.
+
 ## Gotchas — surface before the user is surprised
 
-- **This is the user's real Zhihu account.** Confirm before any publish; reading
-  exposes their own private drafts.
+- **This is the user's real Zhihu account.** Confirm before any publish / answer /
+  edit; reading exposes their own private drafts.
 - **Cookie expiry**: Zhihu cookies are short-lived. A `401`/`403` means
   reconnect at auth.acedata.cloud/user/connections — never loop-retry.
 - **ToS**: cookie automation is against most platforms' terms. This only ever

--- a/skills/zhihu/scripts/blog.py
+++ b/skills/zhihu/scripts/blog.py
@@ -165,6 +165,12 @@ ZH = {
     "articles": "https://www.zhihu.com/api/v4/members/{token}/articles",
     "article": "https://www.zhihu.com/api/v4/articles/{id}",
     "create_draft": "https://zhuanlan.zhihu.com/api/articles/drafts",
+    # Answers (回答) — the question/answer side of Zhihu, distinct from articles.
+    "member_answers": "https://www.zhihu.com/api/v4/members/{token}/answers",
+    "answer": "https://www.zhihu.com/api/v4/answers/{id}",
+    "question": "https://www.zhihu.com/api/v4/questions/{id}",
+    "question_answers": "https://www.zhihu.com/api/v4/questions/{id}/answers",
+    "question_draft": "https://www.zhihu.com/api/v4/questions/{id}/draft",
 }
 ZH_FETCH = {"x-requested-with": "fetch"}
 
@@ -243,6 +249,141 @@ def cmd_article(jar, args):
     res = _fmt_article(a)
     res["content_excerpt"] = (a.get("excerpt") or "")[:200]
     out(res)
+
+
+# ── Answers (回答) ───────────────────────────────────────────────────
+#
+# Answers are Zhihu's question/answer side, separate from articles. A user has
+# at most ONE answer per question (a second POST returns RepeatedActionException
+# 103003 — surface that and point at edit-answer). Writes go through the same
+# cookie-only web APIs as articles; no x-zse signature is required.
+
+ZH_ANSWER_LIST_INCLUDE = (
+    "data[*].comment_count,created_time,updated_time,question"
+)
+
+
+def _fmt_answer(a: dict) -> dict:
+    aid = a.get("id")
+    q = a.get("question") or {}
+    qid = q.get("id")
+    # The member/answers endpoint never returns voteup_count (赞同); it only
+    # exposes like_count / favorites under reaction.statistics. The authoritative
+    # 赞同 count lives on the single-answer detail endpoint (`answer <id>`).
+    react = (a.get("reaction") or {}).get("statistics") or {}
+    return {
+        "answer_id": str(aid) if aid is not None else None,
+        "question_id": str(qid) if qid is not None else None,
+        "question_title": q.get("title"),
+        "url": (f"https://www.zhihu.com/question/{qid}/answer/{aid}" if (qid and aid) else None),
+        "voteup_count": a.get("voteup_count"),
+        "like_count": react.get("like_count"),
+        "favorite_count": react.get("favorites"),
+        "comment_count": a.get("comment_count"),
+        "created_time": a.get("created_time"),
+        "updated_time": a.get("updated_time"),
+    }
+
+
+def cmd_answers(jar, args):
+    me = zh_me(jar)
+    token = me.get("url_token")
+    if not token:
+        die("Zhihu profile has no url_token; cannot list answers.")
+    url = ZH["member_answers"].format(token=token)
+    q = urllib.parse.urlencode({
+        "include": ZH_ANSWER_LIST_INCLUDE,
+        "limit": args.limit,
+        "offset": args.offset,
+    })
+    _, data = get_json(f"{url}?{q}", jar, headers=ZH_FETCH)
+    items = data.get("data", []) if isinstance(data, dict) else []
+    out({
+        "total": (data.get("paging") or {}).get("totals") if isinstance(data, dict) else None,
+        "count": len(items),
+        "answers": [_fmt_answer(a) for a in items],
+    })
+
+
+def cmd_answer(jar, args):
+    base = ZH["answer"].format(id=args.id)
+    q = urllib.parse.urlencode({
+        "include": "content,voteup_count,comment_count,created_time,updated_time,question",
+    })
+    _, a = get_json(f"{base}?{q}", jar, headers=ZH_FETCH)
+    if not isinstance(a, dict) or not a.get("id"):
+        die(f"answer {args.id} not found or not accessible: {str(a)[:300]}")
+    res = _fmt_answer(a)
+    res["content_excerpt"] = (a.get("excerpt") or "")[:200]
+    out(res)
+
+
+def cmd_question(jar, args):
+    base = ZH["question"].format(id=args.id)
+    q = urllib.parse.urlencode({
+        "include": "answer_count,follower_count,visit_count,comment_count,detail",
+    })
+    _, qd = get_json(f"{base}?{q}", jar, headers=ZH_FETCH)
+    if not isinstance(qd, dict) or not (qd.get("id") or qd.get("title")):
+        die(f"question {args.id} not found or not accessible: {str(qd)[:300]}")
+    # Detect whether the logged-in user already answered this question so the
+    # caller knows to use `edit-answer` instead of `answer-question`.
+    mine = _my_answer_for_question(jar, args.id)
+    out({
+        "question_id": str(qd.get("id") or args.id),
+        "title": qd.get("title"),
+        "url": f"https://www.zhihu.com/question/{args.id}",
+        "answer_count": qd.get("answer_count"),
+        "follower_count": qd.get("follower_count"),
+        "visit_count": qd.get("visit_count"),
+        "detail_excerpt": _strip_tags(qd.get("detail") or "")[:300],
+        "my_answer_id": mine,
+        "already_answered": bool(mine),
+    })
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(html: str) -> str:
+    return _TAG_RE.sub("", html or "").strip()
+
+
+def _my_answer_for_question(jar, question_id: str):
+    """Return the logged-in user's answer id for a question, or None.
+
+    Scans the *user's own* answers (bounded by their answer count) and matches
+    on question id. This is reliable even for popular questions — unlike walking
+    the question's own answer list, which may have thousands of entries. For an
+    account with more answers than the scan cap this is best-effort.
+    """
+    me = zh_me(jar)
+    token = me.get("url_token")
+    if not token:
+        return None
+    url = ZH["member_answers"].format(token=token)
+    qid = str(question_id)
+    offset = 0
+    for _ in range(15):  # up to 300 of the user's own answers
+        q = urllib.parse.urlencode({
+            "include": "data[*].question",
+            "limit": 20,
+            "offset": offset,
+        })
+        status, data = request("GET", f"{url}?{q}", jar, headers=ZH_FETCH)
+        try:
+            data = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+        items = data.get("data", []) if isinstance(data, dict) else []
+        for a in items:
+            if str((a.get("question") or {}).get("id")) == qid:
+                return str(a.get("id"))
+        if (data.get("paging") or {}).get("is_end", True) or not items:
+            return None
+        offset += 20
+    return None
+
 
 
 # ── Image re-hosting ────────────────────────────────────────
@@ -539,11 +680,187 @@ def cmd_publish(jar, args):
     })
 
 
+def _read_content(args) -> str:
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    if content is None:
+        die("provide --content-file <path> or --content <html>")
+    return content
+
+
+def _reshipment(value):
+    # Zhihu accepts "allowed" / "disallowed" for 转载授权 (repost permission).
+    return value if value in ("allowed", "disallowed") else None
+
+
+def cmd_answer_question(jar, args):
+    """Post a NEW answer to a question (GATED). --draft-only saves a private draft."""
+    qid = args.question
+    if not qid:
+        die("--question <question-id> is required")
+    content = _read_content(args)
+    # Fetch the question title so the dry-run shows what is being answered.
+    title = None
+    try:
+        _, qd = get_json(
+            f"{ZH['question'].format(id=qid)}?{urllib.parse.urlencode({'include': 'title'})}",
+            jar, headers=ZH_FETCH,
+        )
+        title = qd.get("title") if isinstance(qd, dict) else None
+    except SystemExit:
+        raise
+    except Exception:
+        pass
+
+    reship = _reshipment(args.repost) or "disallowed"
+
+    if not CONFIRM:
+        out({
+            "dry_run": True,
+            "command": "answer-question",
+            "platform": "zhihu",
+            "question_id": str(qid),
+            "question_title": title,
+            "draft_only": args.draft_only,
+            "reshipment_settings": reship,
+            "content_bytes": len(content),
+            "images_found": count_images(content),
+            "note": "re-run with --confirm as the LAST argument to actually write. "
+                    "Without --draft-only this publishes a PUBLIC answer on the user's real "
+                    "account. One answer per question — if you already answered, use edit-answer.",
+        })
+        return
+
+    image_stats = {"found": 0, "rehosted": 0, "failed": 0}
+    if not args.no_images:
+        content, image_stats = rehost_images(jar, content)
+
+    if args.draft_only:
+        # Private autosave draft on the question — nothing goes public.
+        status, text = request(
+            "PUT", ZH["question_draft"].format(id=qid), jar,
+            headers=ZH_FETCH, body={"content": content, "delta_time": 5},
+        )
+        if status >= 400:
+            die(f"save-draft failed ({status}) for question {qid}: {text[:300]}")
+        out({
+            "ok": True,
+            "draft_only": True,
+            "question_id": str(qid),
+            "images": image_stats,
+            "review_url": f"https://www.zhihu.com/question/{qid}",
+            "note": "Private draft saved. Open the question to review, then re-run "
+                    "without --draft-only (and --confirm) to publish.",
+        })
+        return
+
+    status, text = request(
+        "POST", ZH["question_answers"].format(id=qid), jar,
+        headers=ZH_FETCH, body={"content": content, "reshipment_settings": reship},
+    )
+    try:
+        res = json.loads(text)
+    except json.JSONDecodeError:
+        res = {}
+    if status >= 400:
+        # Zhihu's `error` is usually a dict {code, name, message} but can be a
+        # bare string; guard both. `code` may arrive as int or str.
+        err = res.get("error") if isinstance(res, dict) and isinstance(res.get("error"), dict) else {}
+        if str(err.get("code")) == "103003":
+            die(
+                f"you already answered question {qid}; Zhihu allows one answer per "
+                f"question. Find your answer id with `answers` and use "
+                f"`edit-answer --id <answer-id>` instead."
+            )
+        die(f"publish answer failed ({status}) for question {qid}: {text[:300]}")
+    aid = res.get("id") if isinstance(res, dict) else None
+    if not aid:
+        die(f"publish answer returned no id ({status}): {text[:300]}")
+    out({
+        "ok": True,
+        "published": True,
+        "question_id": str(qid),
+        "answer_id": str(aid),
+        "images": image_stats,
+        "url": f"https://www.zhihu.com/question/{qid}/answer/{aid}",
+    })
+
+
+def cmd_edit_answer(jar, args):
+    """Edit an EXISTING answer's content (GATED). The answer stays public."""
+    aid = args.id
+    if not aid:
+        die("--id <answer-id> is required")
+    content = _read_content(args)
+    # Read the current answer to preserve its repost setting and show context.
+    cur = {}
+    try:
+        _, cur = get_json(
+            f"{ZH['answer'].format(id=aid)}?{urllib.parse.urlencode({'include': 'reshipment_settings,question'})}",
+            jar, headers=ZH_FETCH,
+        )
+    except SystemExit:
+        raise
+    except Exception:
+        cur = {}
+    if not isinstance(cur, dict):
+        cur = {}
+    # Keep the answer's current repost setting; if it couldn't be read and the
+    # user gave no override, fall back to the conservative "disallowed" rather
+    # than silently granting repost rights.
+    reship = _reshipment(args.repost) or cur.get("reshipment_settings") or "disallowed"
+    q = cur.get("question") or {}
+
+    if not CONFIRM:
+        out({
+            "dry_run": True,
+            "command": "edit-answer",
+            "platform": "zhihu",
+            "answer_id": str(aid),
+            "question_title": q.get("title"),
+            "reshipment_settings": reship,
+            "content_bytes": len(content),
+            "images_found": count_images(content),
+            "note": "re-run with --confirm as the LAST argument to actually overwrite. "
+                    "This replaces the live, public answer's content on the user's real account.",
+        })
+        return
+
+    image_stats = {"found": 0, "rehosted": 0, "failed": 0}
+    if not args.no_images:
+        content, image_stats = rehost_images(jar, content)
+
+    status, text = request(
+        "PUT", ZH["answer"].format(id=aid), jar,
+        headers=ZH_FETCH, body={"content": content, "reshipment_settings": reship},
+    )
+    if status >= 400:
+        die(f"edit answer failed ({status}) for {aid}: {text[:300]}")
+    qid = q.get("id")
+    out({
+        "ok": True,
+        "edited": True,
+        "answer_id": str(aid),
+        "images": image_stats,
+        "url": (f"https://www.zhihu.com/question/{qid}/answer/{aid}" if qid else None),
+    })
+
+
 COMMANDS = {
     "whoami": cmd_whoami,
     "articles": cmd_articles,
     "article": cmd_article,
     "publish": cmd_publish,
+    "answers": cmd_answers,
+    "answer": cmd_answer,
+    "question": cmd_question,
+    "answer-question": cmd_answer_question,
+    "edit-answer": cmd_edit_answer,
 }
 
 
@@ -568,6 +885,38 @@ def main() -> None:
     sp.add_argument("--content-file", help="path to an HTML file")
     sp.add_argument("--draft-only", action="store_true",
                     help="create a draft only; do NOT go public")
+    sp.add_argument("--no-images", action="store_true",
+                    help="skip re-hosting external images to Zhihu's CDN")
+
+    sp = sub.add_parser("answers", help="list the user's published answers + stats")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.add_argument("--offset", type=int, default=0)
+
+    sp = sub.add_parser("answer", help="one answer's details + stats")
+    sp.add_argument("id")
+
+    sp = sub.add_parser("question", help="a question's info + whether you already answered it")
+    sp.add_argument("id")
+
+    sp = sub.add_parser("answer-question",
+                        help="post a NEW answer to a question (GATED by trailing --confirm)")
+    sp.add_argument("--question", help="question id to answer")
+    sp.add_argument("--content", help="HTML content inline")
+    sp.add_argument("--content-file", help="path to an HTML file")
+    sp.add_argument("--draft-only", action="store_true",
+                    help="save a private draft on the question; do NOT go public")
+    sp.add_argument("--repost", choices=["allowed", "disallowed"],
+                    help="转载授权: allow or disallow reposting (default disallowed)")
+    sp.add_argument("--no-images", action="store_true",
+                    help="skip re-hosting external images to Zhihu's CDN")
+
+    sp = sub.add_parser("edit-answer",
+                        help="overwrite an existing answer's content (GATED by trailing --confirm)")
+    sp.add_argument("--id", help="answer id to edit")
+    sp.add_argument("--content", help="HTML content inline")
+    sp.add_argument("--content-file", help="path to an HTML file")
+    sp.add_argument("--repost", choices=["allowed", "disallowed"],
+                    help="转载授权: override repost permission (default keeps current)")
     sp.add_argument("--no-images", action="store_true",
                     help="skip re-hosting external images to Zhihu's CDN")
 


### PR DESCRIPTION
## What

Extend the `zhihu` skill beyond articles to the **question/answer** side, so the agent can read, **answer**, and **edit answers** to questions on the user's own account (BYOC cookies).

### New commands (`scripts/blog.py`)

| Command | Purpose |
|---|---|
| `answers --limit N` | List my published answers + `like_count` / `favorite_count` / `comment_count` |
| `answer <id>` | One answer's detail incl. authoritative 赞同 `voteup_count` |
| `question <id>` | Question info + `already_answered` / `my_answer_id` detection |
| `answer-question --question <qid> --content-file f.html` | Post a **new** answer (GATED). `--draft-only` saves a private draft; otherwise publishes publicly |
| `edit-answer --id <aid> --content-file f.html` | Overwrite an existing answer's content (GATED) |

All write paths use the **same cookie-only web APIs as articles — no `x-zse-96` signature needed** (verified live, see below):

```
POST           /api/v4/questions/{qid}/answers     # new answer  {content, reshipment_settings}
PUT            /api/v4/answers/{aid}                # edit answer {content, reshipment_settings}
PUT/GET/DELETE /api/v4/questions/{qid}/draft        # private safe draft
```

- **One answer per question** (Zhihu error `103003`): handled gracefully — `answer-question` returns a clear message pointing at `edit-answer`.
- **Images** are auto re-hosted to Zhihu's CDN, reusing the existing `rehost_images` machinery (Zhihu strips foreign `<img>` in answers too).
- **Gating** reuses the existing trailing-`--confirm` pattern (honored only as the last argv token); secret handling and dry-run UX match `publish`.
- `SKILL.md` bumped to `1.2` with answer reading/answering recipes and the answer-stat caveat (the list endpoint omits 赞同 — use `answer <id>`).

## Research

Open-source survey (WechatSync, `toff314/zhihu-creator-cli`, `openweb-org/openweb`, `jackwener/OpenCLI`, `littlepai/Unofficial-Zhihu-API`) confirmed: most projects are **read-only** and note that answer **writes** "need dynamic signatures `x-zse-96`". The new-answer endpoint + body shape (`content` + `reshipment_settings`) came from `OpenCLI/clis/zhihu/answer.js` (which dodges signing by running in a browser).

## Live testing (operator's own connected account — Germey)

Probed the real endpoints from inside the cluster (cookies never left the pod). All **non-destructively** verified:

- New-answer write path works **cookie-only** — proved via the duplicate-answer business error `400 {"code":103003,"name":"RepeatedActionException"}` (auth gate passed, **nothing created**) rather than a `403` signature error.
- Edit path: idempotent re-save of an existing answer → `200` (no visible change).
- Private draft: `PUT`/`GET`/`DELETE /questions/{qid}/draft` → `200` / `{"success":true}` (cleaned up).
- Reads (`whoami`/`answers`/`answer`/`question`) and `already_answered` detection verified through the actual CLI; test draft + temp files cleaned up.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (read-only), focused on gating bypass, secret leakage, and write-path correctness.

- **RISK** — `cmd_answer_question` could `AttributeError` if Zhihu returns `{"error": "<string>"}` (not a dict), or miss `103003` sent as a string. **Fixed:** guard `error` is a dict and compare `str(err.get("code")) == "103003"`.
- **RISK** — `cmd_edit_answer` defaulted `reshipment_settings` to the *more-permissive* `"allowed"` when the current answer couldn't be read, silently granting repost rights. **Fixed:** fall back to the conservative `"disallowed"` (matches the new-answer default).
- Reviewer confirmed gating is sound (a `--confirm` inside content/values can't confirm; both write commands short-circuit to dry-run before any POST/PUT and before image rehosting), cookies are never printed, `_reshipment` can't emit an invalid value, and `_my_answer_for_question` is bounded.

Re-verified live after the fixes: the duplicate-answer guard still fires correctly. `ruff` + `py_compile` clean; SKILL.md passes the repo's frontmatter validation (description 331 chars, 154 lines).
