### PR TITLE
feat(zhihu): add search via Zhihu Developer Platform API

### DIFF
--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -1,35 +1,102 @@
 ---
 name: zhihu
-description: Read and publish on Zhihu (知乎) with the user's own login cookies (BYOC) — list published articles & answers with vote/comment stats, inspect an article/answer/question, publish an article, and answer or edit answers to questions. Use when the user mentions 知乎 / Zhihu, "我的知乎文章/回答", reading their stats (点赞/评论), 发文, or 回答/编辑某个问题的回答.
+description: Search Zhihu & the web, get trending topics, and read/publish on Zhihu (知乎) — search Zhihu content or the entire web via the official Developer Platform API, get hot topics (热榜), list published articles & answers with stats, inspect content, publish articles, and answer questions. Use when the user mentions 知乎 / Zhihu, 搜索知乎, 全网搜索, 热榜, "我的知乎文章/回答", reading stats, 发文, or 回答问题.
 when_to_use: |
-  Trigger for anything on the user's Zhihu (知乎) account driven by their own
-  login cookie: show who they are, list their published articles or answers
-  with vote/comment counts, look at one article / answer / question, publish a
-  new article, post a new answer to a question, or edit an existing answer.
-  This acts as the user's real account, so writes are gated behind an explicit
-  confirmation.
+  Trigger for anything involving Zhihu (知乎):
+  - Searching Zhihu content (站内搜索) or the entire web (全网搜索)
+  - Getting Zhihu trending topics (热榜)
+  - Reading the user's own articles/answers with stats
+  - Publishing articles or answering questions (gated behind confirmation)
+  Search commands use the Zhihu Developer Platform API (Bearer token auth).
+  Read/write commands use the user's login cookies (BYOC).
 connections: [zhihu]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.2"
+  version: "2.0"
 ---
 
-# zhihu — read & publish on Zhihu via your own cookies
+# zhihu — search, read & publish on Zhihu
 
-Drives the user's **real** Zhihu account through the same web APIs the site's
-own editor uses, authenticated by the login cookie they captured with the ACE
-extension. No browser, no third-party deps — just `urllib`.
+Two authentication layers, two scripts:
 
-The connector injects the cookie jar as an env var:
+| Script | Auth | Capabilities |
+|---|---|---|
+| `scripts/search.py` | `ZHIHU_DEVELOPER_TOKEN` (Bearer) | Search Zhihu, search the web, get hot topics |
+| `scripts/blog.py` | `ZHIHU_COOKIES` (login cookie) | Read/write own articles & answers |
 
+No browser, no third-party deps — just `urllib`.
+
+The connector injects credentials as env vars:
+
+- `ZHIHU_DEVELOPER_TOKEN` — Zhihu Developer Platform access secret (Bearer token).
+  Used for search and hot-list queries. **Secret — never echo or print it.**
 - `ZHIHU_COOKIES` — a JSON array of `{name, value, domain, path, ...}` cookies.
-  **Secret — never echo or print it.** The CLI reads it for you.
+  Used for reading/writing the user's own content. **Secret — never echo or print it.**
 
-## CLI
+## Search CLI (search.py)
+
+[`scripts/search.py`](scripts/search.py) — search Zhihu and the web. Requires
+only `ZHIHU_DEVELOPER_TOKEN` (no cookies needed).
+
+```sh
+SEARCH=$SKILL_DIR/scripts/search.py
+
+# Search Zhihu content (站内搜索) — questions, answers, articles
+python3 $SEARCH search "Python 爬虫"
+python3 $SEARCH search "Python 爬虫" --count 5
+
+# Search the entire web (全网搜索) — all indexed sites
+python3 $SEARCH global "AI Agent"
+python3 $SEARCH global "AI Agent" --count 15
+
+# Filter by site or time
+python3 $SEARCH global "React" --filter 'host=="github.com"'
+python3 $SEARCH global "新闻" --filter 'publish_time>=1720000000'
+python3 $SEARCH global "技术" --filter 'host=="github.com" AND publish_time>=1720000000'
+python3 $SEARCH global "实时新闻" --db realtime
+
+# Get Zhihu trending topics (热榜)
+python3 $SEARCH hot
+python3 $SEARCH hot --limit 10
+```
+
+### Search commands
+
+| Goal | Command |
+|---|---|
+| Search Zhihu (max 10 results) | `python3 $SEARCH search "<query>" --count N` |
+| Search entire web (max 20) | `python3 $SEARCH global "<query>" --count N` |
+| Filter by site | `--filter 'host=="example.com"'` |
+| Filter by time | `--filter 'publish_time>=<unix_ts>'` |
+| Search only realtime/static index | `--db realtime` or `--db static` |
+| Zhihu trending topics (max 30) | `python3 $SEARCH hot --limit N` |
+
+### Search result fields
+
+**zhihu_search** returns: title, type (Article/Answer), content_id, url,
+excerpt, vote_up (赞同), comments, author, authority level, edit_time.
+
+**global_search** returns the same fields plus has_more indicator. The `url`
+includes utm tracking params from Zhihu's platform.
+
+**hot_list** returns: rank, title, url, summary, thumbnail.
+
+### global_search Filter syntax
+
+- `host=="example.com"` — filter by domain (note: `host=="zhihu.com"` not
+  supported — use `search` command instead)
+- `publish_time>=1720000000` — filter by publish time (unix seconds)
+- Logical operators: `AND`, `OR` (must be uppercase)
+- Parentheses for grouping: `(host=="a.com" OR host=="b.com") AND publish_time>=T`
+
+---
+
+## Blog CLI (blog.py)
 
 The skill ships [`scripts/blog.py`](scripts/blog.py) — self-contained, stdlib only.
+Requires `ZHIHU_COOKIES` (login cookie).
 
 ```sh
 BLOG=$SKILL_DIR/scripts/blog.py

--- a/skills/zhihu/scripts/search.py
+++ b/skills/zhihu/scripts/search.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+zhihu search — search Zhihu and the web via the Zhihu Developer Platform API.
+Standard-library only (urllib), no third-party deps.
+
+Auth: Bearer token via ``ZHIHU_DEVELOPER_TOKEN`` env var.
+Does NOT require login cookies — independent of blog.py.
+
+Endpoints:
+  zhihu_search  — search Zhihu content (questions/answers/articles)
+  global_search — search the entire web with optional filters
+  hot_list      — current Zhihu trending topics
+
+Quick examples:
+  python3 $SKILL_DIR/scripts/search.py search "Python 爬虫"
+  python3 $SKILL_DIR/scripts/search.py search "Python 爬虫" --count 5
+  python3 $SKILL_DIR/scripts/search.py global "AI Agent" --count 10
+  python3 $SKILL_DIR/scripts/search.py global "React" --filter 'host=="github.com"'
+  python3 $SKILL_DIR/scripts/search.py global "新闻" --db realtime
+  python3 $SKILL_DIR/scripts/search.py hot
+  python3 $SKILL_DIR/scripts/search.py hot --limit 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE_URL = "https://developer.zhihu.com/api/v1/content"
+
+
+def out(obj) -> None:
+    json.dump(obj, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+def die(msg: str, code: int = 1) -> None:
+    sys.stderr.write(f"ERROR: {msg}\n")
+    sys.exit(code)
+
+
+def get_token() -> str:
+    token = os.environ.get("ZHIHU_DEVELOPER_TOKEN", "").strip()
+    if not token:
+        die(
+            "ZHIHU_DEVELOPER_TOKEN not set. "
+            "Set this env var to your Zhihu Developer Platform access secret."
+        )
+    return token
+
+
+def api_get(endpoint: str, params: dict | None = None) -> dict:
+    """GET request to the Zhihu Developer Platform API."""
+    token = get_token()
+    url = f"{BASE_URL}/{endpoint}"
+    if params:
+        # Filter out None values
+        params = {k: v for k, v in params.items() if v is not None}
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Request-Timestamp": str(int(time.time())),
+        "Content-Type": "application/json",
+    }
+
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else ""
+        die(f"HTTP {e.code}: {body[:500]}")
+    except urllib.error.URLError as e:
+        die(f"Network error: {e.reason}")
+    return {}
+
+
+def _fmt_zhihu_item(item: dict) -> dict:
+    """Format a zhihu_search result item for display."""
+    return {
+        "title": item.get("Title", ""),
+        "type": item.get("ContentType", ""),
+        "content_id": item.get("ContentID", ""),
+        "url": item.get("Url", ""),
+        "excerpt": item.get("ContentText", "")[:200],
+        "vote_up": item.get("VoteUpCount", 0),
+        "comments": item.get("CommentCount", 0),
+        "author": item.get("AuthorName", ""),
+        "authority": item.get("AuthorityLevel", ""),
+        "edit_time": item.get("EditTime", 0),
+    }
+
+
+def _fmt_global_item(item: dict) -> dict:
+    """Format a global_search result item for display."""
+    return {
+        "title": item.get("Title", ""),
+        "type": item.get("ContentType", ""),
+        "content_id": item.get("ContentID", ""),
+        "url": item.get("Url", ""),
+        "excerpt": item.get("ContentText", "")[:300],
+        "vote_up": item.get("VoteUpCount", 0),
+        "comments": item.get("CommentCount", 0),
+        "author": item.get("AuthorName", ""),
+        "authority": item.get("AuthorityLevel", ""),
+        "edit_time": item.get("EditTime", 0),
+    }
+
+
+def _fmt_hot_item(item: dict, rank: int) -> dict:
+    """Format a hot_list result item for display."""
+    return {
+        "rank": rank,
+        "title": item.get("Title", ""),
+        "url": item.get("Url", ""),
+        "summary": item.get("Summary", ""),
+        "thumbnail": item.get("ThumbnailUrl", ""),
+    }
+
+
+def cmd_search(args):
+    """Search Zhihu content (站内搜索)."""
+    params = {"Query": args.query, "Count": args.count}
+    resp = api_get("zhihu_search", params)
+
+    if resp.get("Code") != 0:
+        die(f"API error: Code={resp.get('Code')} Message={resp.get('Message')}")
+
+    data = resp.get("Data", {})
+    items = data.get("Items") or []
+
+    result = {
+        "query": args.query,
+        "count": len(items),
+        "results": [_fmt_zhihu_item(it) for it in items],
+    }
+    if data.get("EmptyReason"):
+        result["empty_reason"] = data["EmptyReason"]
+
+    out(result)
+
+
+def cmd_global(args):
+    """Search the entire web (全网搜索)."""
+    params: dict = {"Query": args.query, "Count": args.count}
+    if args.filter:
+        params["Filter"] = args.filter
+    if args.db:
+        params["SearchDB"] = args.db
+
+    resp = api_get("global_search", params)
+
+    if resp.get("Code") != 0:
+        die(f"API error: Code={resp.get('Code')} Message={resp.get('Message')}")
+
+    data = resp.get("Data", {})
+    items = data.get("Items") or []
+
+    result = {
+        "query": args.query,
+        "has_more": data.get("HasMore", False),
+        "count": len(items),
+        "results": [_fmt_global_item(it) for it in items],
+    }
+    out(result)
+
+
+def cmd_hot(args):
+    """Get current Zhihu trending topics (热榜)."""
+    params = {"Limit": args.limit}
+    resp = api_get("hot_list", params)
+
+    if resp.get("Code") != 0:
+        die(f"API error: Code={resp.get('Code')} Message={resp.get('Message')}")
+
+    data = resp.get("Data", {})
+    items = data.get("Items") or []
+
+    result = {
+        "total": data.get("Total", len(items)),
+        "items": [_fmt_hot_item(it, i + 1) for i, it in enumerate(items)],
+    }
+    out(result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="zhihu-search",
+        description="Search Zhihu and the web via the Zhihu Developer Platform API",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # search (zhihu_search)
+    p_search = sub.add_parser("search", help="Search Zhihu content (站内搜索)")
+    p_search.add_argument("query", help="Search query")
+    p_search.add_argument("--count", type=int, default=10, help="Results count (max 10)")
+
+    # global (global_search)
+    p_global = sub.add_parser("global", help="Search the entire web (全网搜索)")
+    p_global.add_argument("query", help="Search query")
+    p_global.add_argument("--count", type=int, default=10, help="Results count (max 20)")
+    p_global.add_argument(
+        "--filter",
+        help='Advanced filter expression, e.g. host=="example.com" AND publish_time>=1700000000',
+    )
+    p_global.add_argument(
+        "--db",
+        choices=["all", "realtime", "static"],
+        help="Index to search: all (default), realtime, static",
+    )
+
+    # hot (hot_list)
+    p_hot = sub.add_parser("hot", help="Get Zhihu trending topics (热榜)")
+    p_hot.add_argument("--limit", type=int, default=30, help="Number of items (max 30)")
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    dispatch = {"search": cmd_search, "global": cmd_global, "hot": cmd_hot}
+    dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `scripts/search.py` to the zhihu skill — a standalone CLI for the **Zhihu Developer Platform** (developer.zhihu.com) official APIs:

| Command | API | Description |
|---|---|---|
| `search <query>` | `zhihu_search` | Search Zhihu content (questions/answers/articles), max 10 |
| `global <query>` | `global_search` | Search the entire web, max 20, with Filter/SearchDB params |
| `hot` | `hot_list` | Current Zhihu trending topics, max 30 |

## Why

The existing `blog.py` handles CRUD for the user's OWN content (via login cookies) but has **no search capability**. The Zhihu Developer Platform provides official, high-quality search APIs that return structured results with rankings, authority levels, vote counts, and highlights.

## Architecture

- **Separate script** (`search.py`) — doesn't require cookies, only `ZHIHU_DEVELOPER_TOKEN` env var
- **Token not committed** — read from environment at runtime
- **stdlib-only** — same zero-dependency approach as `blog.py`
- **Coexists with `blog.py`** — search (Bearer token) + read/write (cookies) are independent auth layers

## Usage

```sh
SEARCH=$SKILL_DIR/scripts/search.py

python3 $SEARCH search "Python 爬虫"
python3 $SEARCH global "AI Agent" --count 15
python3 $SEARCH global "React" --filter 'host=="github.com"'
python3 $SEARCH global "新闻" --db realtime
python3 $SEARCH hot --limit 10
```

## Verified

All three commands tested live against the API — returns structured JSON with titles, URLs, excerpts, vote counts, etc.

## 🤖 对抗评审

Stdlib-only search client, no writes, no secrets in source. Token from env var only. **VERDICT: CLEAN** (1 round).