### PR TITLE
docs(ai-chat): add Claude Fable 5 to skill examples

### DIFF
--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -58,7 +58,7 @@ models include:
 |--------|------------------|
 | OpenAI / reasoning | `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o3`, `o4-mini` |
 | OpenAI free-tier chat-completions | `gpt-5.5:free`, `gpt-5:free`, `gpt-4.1:free`, `gpt-4o:free`, `gpt-4o-mini:free`, `gpt-oss:free` |
-| Claude | `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
+| Claude | `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
 | Gemini | `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
 | Grok | `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
 | DeepSeek | `deepseek-r1`, `deepseek-r1-0528`, `deepseek-v3`, `deepseek-v3-250324`, `deepseek-v3.2-exp`, `deepseek-v4-flash` |


### PR DESCRIPTION
## Summary

Align the `ai-chat` skill with the newly launched Claude lineup by adding:

- `claude-fable-5`
- `claude-sonnet-5`

to the representative Claude model examples in `skills/ai-chat/SKILL.md`.

This follows the live platform rollout that already:

- published the platform announcement `新增支持 Claude Fable 5`
- routed and billed `claude-fable-5` in production

## Validation

- diff-only validation on `skills/ai-chat/SKILL.md` (single-line change)
- live announcement confirmed as newest published item via `/announcements/`

## 🤖 对抗评审

Reviewer: Claude `Explore` subagent (read-only), with live context that `claude-fable-5` is already routable and billed in production.

- One useful style note was raised about ordering the two new Claude 5.x entries.
- Applied: `claude-fable-5` now appears before `claude-sonnet-5`.
- Rebutted: requests to enumerate preview/legacy siblings were not adopted because this section is explicitly a representative examples list, not an exhaustive catalog.

Result: `VERDICT: CLEAN` for this documentation-only change.
