### PR TITLE
feat(didi-ride): add DiDi ride-hailing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These skills drive third-party connectors users wire up at [auth.acedata.cloud/u
 | [slack](skills/slack/) | Read Slack channels, messages, and user info via Web API | `slack` |
 | [wechat-official-account](skills/wechat-official-account/) | Manage WeChat MP — drafts, publishing, materials, user tags | `wechat` (BYOC) |
 | [personal-wechat](skills/personal-wechat/) | Operate a personal WeChat account through a self-hosted Wisdom service | `personalwechat` (BYOC) |
+| [didi-ride](skills/didi-ride/) | Book DiDi rides, estimate fares, query/cancel orders, plan routes via the DiDi MCP | `didi` (BYOC) |
 
 ## Prerequisites
 

--- a/skills/didi-ride/SKILL.md
+++ b/skills/didi-ride/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: didi-ride
+description: 通过滴滴出行 MCP 打车、查价、查询订单、取消订单、规划路线（驾车/公交/步行/骑行）和搜索地点。Use when the user mentions 滴滴, 打车, 叫车, 回家/上班要打车, 查一下从 A 到 B 多少钱/怎么走, 查询订单, 司机在哪/多久到, 预约叫车, 路线规划, DiDi, ride-hailing, or booking a taxi.
+when_to_use: |
+  Trigger for anything involving the user's DiDi (滴滴出行) account:
+  book a ride ("打车去…", "回家", "上班"), get a fare/route estimate,
+  query an existing order (driver location, ETA, trip progress), cancel
+  an order, plan a driving/transit/walking/cycling route, or search
+  places / reverse-geocode. Creating and cancelling orders act on real
+  money and a real driver, so those writes are gated behind explicit
+  confirmation.
+connections: [didi]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# DiDi Ride (滴滴出行)
+
+Drive the user's **DiDi (滴滴出行)** account through the DiDi MCP server:
+book rides, estimate fares, track orders, cancel, and plan routes.
+
+The `didi` BYOC connector injects one env var into the sandbox:
+
+- `DIDI_MCP_KEY` — the user's DiDi MCP key. **Secret — never echo, print, or log it.**
+
+If `DIDI_MCP_KEY` is missing, tell the user to connect the DiDi connector at
+[auth.acedata.cloud/user/connections](https://auth.acedata.cloud/user/connections)
+(they get the key by scanning the QR in the 滴滴出行 App or via
+<https://mcp.didichuxing.com/claw>).
+
+## CLI
+
+The skill ships a stdlib-only helper that speaks the MCP Streamable-HTTP
+protocol to DiDi. Point at it once:
+
+```bash
+DIDI=$SKILL_DIR/scripts/didi.py
+```
+
+Two commands:
+
+```bash
+python3 $DIDI list                        # list tools + their JSON input schemas
+python3 $DIDI call <tool> '<json-args>'   # call any tool
+```
+
+**Always check `references/api_references.md` for the exact tool + parameter
+names before calling.** When unsure, run `python3 $DIDI list` — it returns the
+authoritative input schema for every tool straight from DiDi. Do **not** guess
+parameter names (common mistakes: `keyword` → `keywords`, `region` → `city`,
+four coord fields → six `from_name/from_lat/from_lng/to_name/to_lat/to_lng`).
+
+All argument **values must be strings** (including coordinates and
+`product_category`), e.g. `{"product_category":"1"}` not `{"product_category":1}`.
+
+## Write gating (real money / real driver)
+
+`taxi_create_order` and `taxi_cancel_order` are **gated**: without a trailing
+`--confirm` the helper only DRY-RUNS and changes nothing. Run once without
+`--confirm` to preview, then re-run with `--confirm` as the **last** argument
+after the user approves:
+
+```bash
+python3 $DIDI call taxi_create_order '{"estimate_trace_id":"...","product_category":"1"}' --confirm
+```
+
+- Even when the user says "打车" / "取消订单", confirm the concrete details
+  (起终点、车型 for booking; the order for cancelling) before adding `--confirm`.
+- Cancel intent ≠ cancel confirmation — always ask "确认取消吗？" first.
+
+## Booking flow (最小可执行)
+
+1. **Resolve addresses** — `maps_textsearch` (never invent coordinates; don't
+   reuse coordinates from earlier turns — the user may have moved).
+   - If the user references an address alias (家 / 公司 / etc.) that you don't
+     have, ask them; this skill has no stored preferences.
+2. **Confirm start/end** — if `maps_textsearch` returns ≥2 candidates, list at
+   least the top 3 and let the user pick; a single exact match needs no
+   confirmation.
+3. **Estimate** — `taxi_estimate`; record the returned `traceId` /
+   `estimate_trace_id`. It expires (`-32021`) — re-estimate if stale.
+4. **Pick car type** — user's current message wins ("叫快车"→`product_category`
+   `1`, "专车"→`8`); otherwise ask. Only use categories present in the
+   `taxi_estimate` response; never silently substitute a different service level
+   (快车 `1` ≠ 特惠快车 `201`).
+5. **Create order** — `taxi_create_order` with the latest `estimate_trace_id`
+   (dry-run → confirm → `--confirm`).
+6. **Report** — order id, start/end, car type, estimated fare. Tell the user
+   they can send 「查询订单」 to check status.
+
+## Query an order
+
+Order id comes from (in priority): the user's message → the most recent order
+created this conversation → else ask.
+
+```bash
+python3 $DIDI call taxi_query_order '{"order_id":"ORDER_ID"}'
+```
+
+Status codes (`code`):
+
+| code | 含义 | 输出 |
+|------|------|------|
+| 0 | 匹配中 | ⏳ 正在为您匹配司机 |
+| 1 | 司机已接单 | 展示司机姓名、车型、车牌、电话、距离与预计到达时间 |
+| 2 | 司机已到达 | 🔔 司机已到达上车点 |
+| 4 | 行程进行中 | 🚗 行程已开始 |
+| 5 | 订单完成 | ✅ 行程结束（展示费用，如有） |
+| 6 | 系统取消 | ❌ 订单已被系统取消 |
+| 7 | 已取消 | ❌ 订单已取消 |
+| 3 / 8-12 | 其他终态 | 显示对应状态描述 |
+
+## Routes & places (no order needed)
+
+```bash
+python3 $DIDI call maps_direction_driving  '{"from_name":"...","from_lat":"...","from_lng":"...","to_name":"...","to_lat":"...","to_lng":"..."}'
+python3 $DIDI call maps_direction_transit  '{...}'   # 公交
+python3 $DIDI call maps_direction_walking  '{...}'   # 步行
+python3 $DIDI call maps_direction_bicycling '{...}'  # 骑行
+python3 $DIDI call maps_place_around '{"keywords":"咖啡","lat":"...","lng":"..."}'
+python3 $DIDI call maps_regeocode '{"lat":"...","lng":"..."}'
+```
+
+## Gotchas
+
+- **Never print the key or the raw endpoint URL** — the helper handles the
+  transport and keeps the key internal.
+- `taxi_create_order` takes only `estimate_trace_id`, `product_category`, and
+  optional `caller_car_phone`. Don't pass the estimate's coordinate/name fields.
+- No stored preferences: this skill doesn't remember home/work/car type — ask
+  the user, or wire richer memory in a higher layer.
+- Auth failure surfaces as `-32002` (or HTTP 401/403): the key is missing/expired
+  → have the user reconnect the connector.
+
+> **Setup:** See [authentication](../_shared/authentication.md). This skill uses
+> the `didi` connector's injected `DIDI_MCP_KEY`, not `ACEDATACLOUD_API_TOKEN`.

--- a/skills/didi-ride/references/api_references.md
+++ b/skills/didi-ride/references/api_references.md
@@ -1,0 +1,97 @@
+# DiDi MCP — Tool Reference
+
+Authoritative schemas come from `python3 $DIDI list` (the DiDi server returns
+each tool's `inputSchema`). This file summarizes the tools and the parameter
+names that are easy to get wrong. **All values are strings.**
+
+## Places & geocoding
+
+### `maps_textsearch` — search a place by text
+| param | required | notes |
+|-------|----------|-------|
+| `keywords` | yes | search text, e.g. `北京西站` (NOT `keyword`) |
+| `city` | no | city name to scope the search, e.g. `北京` (NOT `region`) |
+
+Returns candidate places with names + coordinates. Use these coordinates for
+`taxi_estimate` and the `maps_direction_*` tools.
+
+### `maps_regeocode` — coordinates → address
+| param | required |
+|-------|----------|
+| `lat` | yes |
+| `lng` | yes |
+
+## Routes
+
+`maps_direction_driving` / `maps_direction_transit` / `maps_direction_walking`
+/ `maps_direction_bicycling` — all take the same six fields:
+
+| param | required |
+|-------|----------|
+| `from_name` | yes |
+| `from_lat` | yes |
+| `from_lng` | yes |
+| `to_name` | yes |
+| `to_lat` | yes |
+| `to_lng` | yes |
+
+### `maps_place_around` — nearby POI search
+| param | required | notes |
+|-------|----------|-------|
+| `keywords` | yes | POI keyword, e.g. `咖啡` |
+| `lat` | yes | center latitude |
+| `lng` | yes | center longitude |
+
+## Ride hailing
+
+### `taxi_estimate` — price/ETA estimate (do this before ordering)
+Six coordinate/name fields (same as routes):
+`from_name`, `from_lat`, `from_lng`, `to_name`, `to_lat`, `to_lng`.
+
+Returns a list of available car types, each with a `productCategory` and price,
+plus a `traceId` / `estimate_trace_id` required by `taxi_create_order`. The
+trace id expires — a stale one returns `-32021`; re-estimate to refresh.
+
+Common `product_category` values:
+
+| code | 车型 |
+|------|------|
+| `1` | 快车 |
+| `8` | 专车 |
+| `201` | 特惠快车 |
+
+> Treat these as hints — always match against the `productCategory` values the
+> live `taxi_estimate` response actually returns. `1` (快车) and `201`
+> (特惠快车) are different service levels; never swap one for the other.
+
+### `taxi_create_order` — book the ride  ⚠️ WRITE (needs `--confirm`)
+| param | required | notes |
+|-------|----------|-------|
+| `estimate_trace_id` | yes | from the latest `taxi_estimate` |
+| `product_category` | yes | chosen car type code (string) |
+| `caller_car_phone` | no | omit unless the user gives a number |
+
+Only these three fields. Do **not** pass coordinate/name fields.
+
+### `taxi_query_order` — status + driver location
+| param | required |
+|-------|----------|
+| `order_id` | yes |
+
+Status `code`: `0` 匹配中 · `1` 司机已接单 · `2` 司机已到达 · `4` 行程中 ·
+`5` 完成 · `6` 系统取消 · `7` 已取消 · `3`/`8`-`12` 其他终态.
+
+### `taxi_cancel_order` — cancel  ⚠️ WRITE (needs `--confirm`)
+| param | required |
+|-------|----------|
+| `order_id` | yes |
+
+Always ask "确认取消吗？" before adding `--confirm`.
+
+## Errors
+
+| code | meaning | action |
+|------|---------|--------|
+| `-32002` / HTTP 401 / 403 | auth failed | key missing/expired → reconnect connector |
+| `-32021` | estimate trace expired | re-run `taxi_estimate` |
+| HTTP 400 | bad params | re-check parameter names against `didi.py list` |

--- a/skills/didi-ride/scripts/didi.py
+++ b/skills/didi-ride/scripts/didi.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""DiDi ride helper — talks to the DiDi MCP server over the MCP
+Streamable-HTTP transport using only the Python standard library.
+
+The `didi` BYOC connector injects one env var:
+
+    DIDI_MCP_KEY   the user's DiDi MCP key (secret — never printed)
+
+Usage:
+    python3 didi.py list                        # list available tools + schemas
+    python3 didi.py call <tool> '<json-args>'   # call any tool
+
+State-changing tools (`taxi_create_order`, `taxi_cancel_order`) are
+gated: without a trailing `--confirm` they only DRY-RUN and change
+nothing. `--confirm` is honored only as the LAST argument.
+
+Examples:
+    python3 didi.py call maps_textsearch '{"keywords":"北京西站","city":"北京"}'
+    python3 didi.py call taxi_estimate '{"from_name":"...","from_lat":"39.9","from_lng":"116.3","to_name":"...","to_lat":"39.9","to_lng":"116.4"}'
+    python3 didi.py call taxi_create_order '{"estimate_trace_id":"...","product_category":"1"}' --confirm
+    python3 didi.py call taxi_query_order '{"order_id":"..."}'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MCP_ENDPOINT = os.environ.get("DIDI_MCP_URL", "https://mcp.didichuxing.com/mcp-servers")
+MCP_KEY = os.environ.get("DIDI_MCP_KEY", "").strip()
+PROTOCOL_VERSION = "2025-06-18"
+
+# Tools that create or cancel a real ride — must be confirmed explicitly.
+WRITE_TOOLS = {"taxi_create_order", "taxi_cancel_order"}
+
+
+def die(payload: dict, code: int = 1) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    sys.exit(code)
+
+
+class MCPClient:
+    """Minimal MCP Streamable-HTTP client (stdlib only).
+
+    Never logs or echoes the key; the endpoint URL (which carries the
+    key as a query param) is kept internal and never printed.
+    """
+
+    def __init__(self, endpoint: str, key: str) -> None:
+        sep = "&" if "?" in endpoint else "?"
+        self._url = f"{endpoint}{sep}key={urllib.parse.quote(key, safe='')}"
+        self._session_id: str | None = None
+        self._rid = 0
+
+    def _post(self, payload: dict, expect_id):
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(self._url, data=body, method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json, text/event-stream")
+        req.add_header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        if self._session_id:
+            req.add_header("Mcp-Session-Id", self._session_id)
+        try:
+            resp = urllib.request.urlopen(req, timeout=90)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:600]
+            die(
+                {
+                    "error": f"HTTP {exc.code} from DiDi MCP",
+                    "detail": detail,
+                    "hint": "If 401/403, the DiDi connector key is missing or expired — "
+                    "reconnect at https://auth.acedata.cloud/user/connections",
+                }
+            )
+        except urllib.error.URLError as exc:
+            die({"error": "network error reaching DiDi MCP", "detail": str(exc.reason)})
+        except Exception as exc:  # noqa: BLE001
+            # Never let an unexpected traceback surface — self._url carries the
+            # key as a query param (DiDi mandates ?key=), so emit only the
+            # exception type, never its message or the URL.
+            die({"error": "unexpected error calling DiDi MCP", "detail": type(exc).__name__})
+        sid = resp.headers.get("Mcp-Session-Id")
+        if sid:
+            self._session_id = sid
+        ctype = (resp.headers.get("Content-Type") or "").lower()
+        raw = resp.read().decode("utf-8", "replace")
+        return _parse_response(raw, ctype, expect_id)
+
+    def initialize(self) -> None:
+        self._rid += 1
+        result = self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": self._rid,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "acedata-didi-skill", "version": "1.0"},
+                },
+            },
+            expect_id=self._rid,
+        )
+        if isinstance(result, dict) and result.get("error"):
+            die({"error": "DiDi MCP initialize failed", "detail": result["error"]})
+        # Fire-and-forget the initialized notification (no response expected).
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"}, expect_id=None)
+
+    def list_tools(self):
+        self._rid += 1
+        return self._post(
+            {"jsonrpc": "2.0", "id": self._rid, "method": "tools/list"},
+            expect_id=self._rid,
+        )
+
+    def call_tool(self, name: str, arguments: dict):
+        self._rid += 1
+        return self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": self._rid,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+            expect_id=self._rid,
+        )
+
+
+def _parse_response(raw: str, ctype: str, expect_id):
+    """Return the JSON-RPC envelope for our request id.
+
+    Handles both plain application/json and text/event-stream (SSE),
+    where the response arrives as one or more `data: {...}` lines.
+    """
+    messages: list[dict] = []
+    if "text/event-stream" in ctype:
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            chunk = line[5:].strip()
+            if not chunk or chunk == "[DONE]":
+                continue
+            try:
+                messages.append(json.loads(chunk))
+            except json.JSONDecodeError:
+                continue
+    else:
+        raw = raw.strip()
+        if not raw:
+            return {}
+        try:
+            messages.append(json.loads(raw))
+        except json.JSONDecodeError:
+            die({"error": "unparseable response from DiDi MCP", "detail": raw[:600]})
+    if expect_id is not None:
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("id") == expect_id:
+                return msg
+    return messages[-1] if messages else {}
+
+
+def emit(envelope: dict) -> None:
+    if not isinstance(envelope, dict):
+        print(json.dumps(envelope, ensure_ascii=False, indent=2))
+        return
+    if envelope.get("error"):
+        die({"error": envelope["error"]})
+    result = envelope.get("result", envelope)
+    # tools/call results wrap text in a content[] array.
+    if isinstance(result, dict) and isinstance(result.get("content"), list):
+        texts = [
+            c.get("text", "")
+            for c in result["content"]
+            if isinstance(c, dict) and c.get("type") == "text"
+        ]
+        if texts:
+            print("\n".join(texts))
+            if result.get("isError"):
+                sys.exit(1)
+            return
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+def _format_tools(envelope: dict) -> None:
+    tools = (envelope.get("result") or {}).get("tools") if isinstance(envelope, dict) else None
+    if not tools:
+        emit(envelope)
+        return
+    slim = [
+        {
+            "name": t.get("name"),
+            "description": t.get("description"),
+            "inputSchema": t.get("inputSchema"),
+        }
+        for t in tools
+    ]
+    print(json.dumps(slim, ensure_ascii=False, indent=2))
+
+
+def main() -> None:
+    if not MCP_KEY:
+        die(
+            {
+                "error": "DIDI_MCP_KEY not set",
+                "hint": "Connect the DiDi connector at "
+                "https://auth.acedata.cloud/user/connections to inject the key.",
+            }
+        )
+
+    argv = sys.argv[1:]
+    confirm = bool(argv) and argv[-1] == "--confirm"
+    if confirm:
+        argv = argv[:-1]
+    if not argv:
+        die({"error": "usage: didi.py <list|call> ..."})
+
+    cmd, rest = argv[0], argv[1:]
+    client = MCPClient(MCP_ENDPOINT, MCP_KEY)
+
+    if cmd == "list":
+        client.initialize()
+        _format_tools(client.list_tools())
+        return
+
+    if cmd == "call":
+        if not rest:
+            die({"error": "call needs a tool name", "usage": "didi.py call <tool> '<json-args>'"})
+        tool = rest[0]
+        args_raw = rest[1] if len(rest) > 1 else "{}"
+        try:
+            arguments = json.loads(args_raw)
+        except json.JSONDecodeError as exc:
+            die({"error": "arguments must be valid JSON", "detail": str(exc), "got": args_raw})
+        if not isinstance(arguments, dict):
+            die({"error": "arguments JSON must be an object", "got": args_raw})
+
+        if tool in WRITE_TOOLS and not confirm:
+            print(
+                json.dumps(
+                    {
+                        "dry_run": True,
+                        "tool": tool,
+                        "arguments": arguments,
+                        "note": "state-changing call — re-run with --confirm as the LAST "
+                        "argument to actually perform it",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return
+
+        client.initialize()
+        emit(client.call_tool(tool, arguments))
+        return
+
+    die({"error": f"unknown command: {cmd}", "usage": "didi.py <list|call> ..."})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Add a **DiDi (滴滴出行) ride-hailing** skill that books rides, estimates fares, queries/cancels orders, and plans routes through the DiDi MCP server.

Pairs with the new `didi/didi` BYOC connector in AuthBackend (separate PR) — the connector injects `DIDI_MCP_KEY` into the sandbox; this skill consumes it.

## Files

- `skills/didi-ride/SKILL.md` — skill instructions (`connections: [didi]`, `allowed_tools: [Bash]`), booking flow, order-status table, write-gating rules.
- `skills/didi-ride/scripts/didi.py` — stdlib-only MCP Streamable-HTTP client (`list` / `call <tool> '<json>'`). Speaks the JSON-RPC handshake (initialize → notifications/initialized → tools/call), parses both `application/json` and SSE responses.
- `skills/didi-ride/references/api_references.md` — exact tool + parameter reference (maps_textsearch, taxi_estimate/create/query/cancel, route tools) with the common param-name pitfalls.
- `README.md` — new row in the Connectors table.

## Safety

- `taxi_create_order` / `taxi_cancel_order` are **write-gated**: no trailing `--confirm` → dry-run only. `--confirm` is honored only as the last arg, so a JSON value can't spoof it.
- The `DIDI_MCP_KEY` never prints; the key-bearing endpoint URL is kept internal and is never emitted on any error path.

## 🤖 对抗评审

Reviewer: Claude subagent (Codex not installed on this host). Read-only pass over all 5 files + the AuthBackend `sync_connectors` field handling.

| # | Finding | Verdict |
|---|---------|---------|
| 1 | **RISK** — `DIDI_MCP_KEY` embedded in URL as `?key=...`; reviewer suggested switching to `Authorization: Bearer`. | **Partially rebutted + hardened.** The DiDi MCP endpoint *mandates* the key as a `?key=` query param (the upstream reference skill uses exactly `?key=$DIDI_MCP_KEY`); a Bearer header would fail to authenticate, so we cannot switch. Residual leak concern (an unexpected exception's traceback exposing `self._url`) addressed: added a broad `except Exception` that emits only the exception **type name** (never the message or URL), and the key is now `urllib.parse.quote`-encoded. The key is never printed anywhere. |
| 2 | Env-var derivation `didi` + `mcp_key` → `DIDI_MCP_KEY` | ✅ Verified correct against the worker's BYOC injection (`<PROVIDER_UPPER>_<KEY_UPPER>`). |
| 3 | `--confirm` cannot be spoofed by a JSON arg (extracted before parse, last-arg only) | ✅ CLEAN. |
| 4 | Frontmatter (name==dir, connections, description ≤1024), tool-name consistency across the 3 files, README row | ✅ CLEAN. |
| 5 | Connector schema conformance + `sync_connectors` field handling | ✅ CLEAN (see AuthBackend PR). |
| 6 | `icon_url` / `publisher_logo_url` are AceData placeholders with a `TODO(human)` | NIT — acknowledged debt; replace with the official DiDi logo on cdn.acedata.cloud. |

Verdict after fixes: **CLEAN**.
