### PR TITLE
feat(apple-notes): declare surfaces: [mac] (macOS-desktop-only)

### DIFF
--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -10,6 +10,7 @@ when_to_use: |
   notes, so create / append / move / delete are GATED behind an explicit
   confirmation.
 allowed_tools: [Bash]
+surfaces: [mac]
 license: Apache-2.0
 compatibility: macOS-only. No API token, no connector — Apple Notes has no cloud API. Drives the local Notes.app via AppleScript (osascript); zero external dependencies (Python 3 standard library only). Requires granting Automation access to Notes.app on first run. Does not call api.acedata.cloud.
 metadata:
@@ -22,8 +23,15 @@ metadata:
 Drives the user's **real** Apple Notes through `Notes.app` on macOS. Apple never
 shipped a cloud API for Notes, so there is nothing to OAuth into and no token to
 inject — this skill runs **on the user's own Mac** and talks to Notes.app with
-AppleScript (`osascript`). It works when Claude Code runs on macOS directly, or
-remotely through a CodingBridge node running on the user's Mac.
+AppleScript (`osascript`). It works wherever an agent runs on macOS: the
+**AceDataCloud desktop app** (which executes local tools / local MCP on the
+user's Mac), Claude Code on macOS, or a CodingBridge node on the user's Mac.
+
+> **`surfaces: [mac]`** in the frontmatter marks this skill as **macOS-desktop
+> only** — it cannot run on the web / iOS / Android / Windows surfaces (there is
+> no local `Notes.app` there). The skill/connector directory UI reads this to
+> badge the card ("macOS desktop") and steer users to install it from the macOS
+> desktop app. Absent `surfaces`, a skill is assumed available everywhere.
 
 The skill ships [`scripts/notes.py`](scripts/notes.py) — self-contained, Python
 **standard library only** (it shells out to `osascript`; no `pip install`, no


### PR DESCRIPTION
## What

Declares `surfaces: [mac]` in the **apple-notes** skill frontmatter — marking it as runnable **only on the macOS desktop surface** (the AceDataCloud desktop app now executes local tools / local MCP on the user's Mac; there is no local `Notes.app` on web / iOS / Android / Windows).

## `surfaces` convention

- **Value space:** `web`, `desktop`, `mac`, `windows`, `ios`, `android`. `mac` / `windows` imply the desktop (Electron) surface on that OS.
- **Semantics:** an **allowlist** of where the skill can run/install. **Absent `surfaces` = available everywhere** (backward-compatible — no other skill changes).
- **apple-notes** → `[mac]`.

## Why no backend change is needed

`AuthBackend` already stores the **entire** SKILL.md frontmatter in `Skill.frontmatter` (`services/skills.py` `update_or_create(..., defaults={... "frontmatter": fm ...})`) and `SkillSerializer` exposes it; the AuthFrontend `ISkillCatalogItem` already carries `frontmatter`. So `surfaces` reaches the browse/install UI client-side with **no model/migration change** — a follow-up frontend PR reads `frontmatter.surfaces` to badge the card ("macOS desktop") and label install.

## Scope

Frontmatter field + inline doc note only. The directory UI badge/annotation lands in a separate AuthFrontend PR.

## 🤖 对抗评审

Trivial change (one frontmatter key + a doc paragraph). Self-review:

- **OK — CI:** Skills `validate.yml` only checks `name`/`description` + marketplace refs; an extra `surfaces` key is inert. YAML validated locally (`surfaces == ['mac']`).
- **OK — parser safety:** `parse_skill_content` / `_parse_lenient` store the full `fm` dict and ignore unknown keys; `surfaces` does not collide with `connections`/`allowed_tools` validation.
- **OK — backward compat:** absent `surfaces` = unrestricted; no existing skill is affected.
- **OK — accuracy:** value space + semantics documented; matches Nexior surface vocabulary (`web`/`desktop`/`ios`/`android`) + OS qualifier (`mac`/`windows`).

VERDICT: **CLEAN**.
