### PR TITLE
feat(x): 新增 cookie 版 X (Twitter) skill（tweety-ns，发推/图/搜索/时间线/互动/趋势）

### DIFF
--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: x
+description: Read & act on X (Twitter) with the user's own login cookies (BYOC) — post tweets (text / images / video / threads / replies / quotes), search tweets & users, read timelines and single tweets, like / retweet / follow / delete, and see trends. Use when the user mentions X / Twitter, 发推 / 发推特 / 推特, "我的 Twitter", posting to X, searching X, or reading their X timeline.
+when_to_use: |
+  Trigger for anything on the user's X (Twitter) account driven by their own
+  login cookie: post a tweet / thread / reply / quote (optionally with images or
+  a video), search tweets or users, read their home timeline or a user's tweets,
+  look up one tweet, like / retweet / follow / delete, or check trends. This acts
+  as the user's REAL account, so every write is gated behind an explicit
+  confirmation.
+connections: [x]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# x — read & post on X (Twitter) via your own cookies
+
+Drives the user's **real** X account through X's internal web API via
+[`twikit`](https://github.com/d60/twikit), authenticated by the login cookie they
+captured with the ACE extension. No official API key, no cost.
+
+> ⚠️ **Not yet E2E-verified.** Built against twikit's documented API but not run
+> against a live account at build time. The first live run is the verification —
+> if X's internal API drifted it surfaces as a clear error, not silent breakage.
+
+The connector injects the cookie jar as an env var:
+
+- `X_COOKIES` — a JSON array of cookies (needs at least `auth_token` + `ct0`).
+  **Secret — full account access. Never echo or print it.**
+
+## Setup — install twikit once per session
+
+`twikit` may not be preinstalled; bootstrap it (same pattern as the telegram
+skill), then call the shipped CLI:
+
+```sh
+python3 -c "import twikit" 2>/dev/null || pip install --user --quiet twikit 2>/dev/null || true
+X=$SKILL_DIR/scripts/x.py
+python3 $X whoami          # who is logged in
+```
+
+## Read commands (run directly)
+
+```sh
+python3 $X whoami                                            # the logged-in account
+python3 $X search --query "ai agents" --product Latest --limit 20   # Top | Latest | Media
+python3 $X search-users --query "openai" --limit 10
+python3 $X timeline --limit 20                               # my home timeline
+python3 $X user-tweets --user elonmusk --type Tweets --limit 20     # Tweets|Replies|Media|Likes
+python3 $X tweet --id 1234567890123456789                    # single tweet detail
+python3 $X trends --category trending --limit 20             # trending|for-you|news|sports|entertainment
+```
+
+`--user` accepts either an `@screen_name` (the `@` is optional) or a numeric id.
+
+## Verify the connection first
+
+```sh
+python3 $X whoami
+# → {"id": "...", "screen_name": "...", "followers_count": ...}
+```
+
+On an auth error the cookie is expired — have the user reconnect at
+<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+
+## Write commands — GATED (dry-run unless trailing `--confirm`)
+
+Every state-changing command (`post`, `thread`, `like`, `unlike`, `retweet`,
+`unretweet`, `follow`, `unfollow`, `delete`) **dry-runs** without a trailing
+`--confirm`. `--confirm` is honored **only as the last argument**, so a tweet
+body that merely contains "--confirm" can never silently post. Always show the
+dry-run, get an explicit "yes" on the exact text, then re-run with `--confirm`.
+
+```sh
+python3 $X post --text "hello world"                          # dry-run
+python3 $X post --text "hello world" --confirm                # LIVE tweet
+python3 $X post --text "look at this" --media a.jpg,b.png --confirm     # up to 4 images (or 1 video)
+python3 $X post --text "great point" --reply-to 123456 --confirm        # reply
+python3 $X post --text "worth reading" --quote-url https://x.com/u/status/123 --confirm  # quote
+python3 $X thread --text "1/2 first" --text "2/2 second" --confirm       # thread (2+ segments)
+python3 $X like --id 123456 --confirm
+python3 $X retweet --id 123456 --confirm
+python3 $X follow --user elonmusk --confirm
+python3 $X delete --id 123456 --confirm                        # delete one of MY tweets
+```
+
+- **A confirmed `post` / `thread` is immediately PUBLIC** on the user's real
+  account — there is no draft step. Always confirm the exact text first.
+- `--media` takes comma-separated file paths. X allows up to **4 images** OR
+  **1 video/GIF** per tweet; for a thread the media attaches to the **first**
+  segment only.
+
+## Gotchas
+
+- **This is the user's real X account.** Confirm before any write — posts are
+  immediate and public.
+- **Not E2E-verified** (see the warning above) — expect to validate the first run.
+- **twikit is a scraper of X's non-public API.** It can break when X changes its
+  internal endpoints. A `Couldn't get KEY_BYTE indices` / transaction-id error
+  means twikit needs upgrading: `pip install --user -U twikit`. An auth error
+  means the cookie expired → reconnect.
+- **ToS / rate-limit / ban risk.** This acts through the web API, not the
+  official API — high-frequency automation can get the account rate-limited or
+  suspended. Keep volume human-like.
+- **Never print `X_COOKIES`** — it is full account access.
+- **DMs are intentionally not exposed** by this skill.

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+x — read & act on X (Twitter) with the user's own login cookies (BYOC).
+
+Drives X's internal web API through `twikit` (https://github.com/d60/twikit),
+authenticated by the ``auth_token`` + ``ct0`` cookies the user captured with the
+ACE extension. This acts as the user's REAL account, so every state-changing
+command (post / thread / reply / quote / like / retweet / follow / delete) is
+GATED by a trailing ``--confirm`` — without it, the command dry-runs.
+
+The connector injects the cookie jar as a JSON env var ``X_COOKIES`` (a JSON list
+of cookie dicts, each with at least ``name`` and ``value``). It is full account
+access — NEVER echo or print it.
+
+twikit is a scraper of X's non-public API: it can drift when X changes its
+internal endpoints, and high-frequency use risks rate-limiting or account
+suspension under X's ToS. Errors surface as clear messages rather than silent
+breakage.
+
+Examples:
+  python3 x.py whoami
+  python3 x.py search --query "python" --product Latest --limit 20
+  python3 x.py timeline --limit 20
+  python3 x.py user-tweets --user elonmusk --type Tweets --limit 20
+  python3 x.py tweet --id 1234567890
+  python3 x.py trends --category trending
+  python3 x.py post --text "hello world" --confirm
+  python3 x.py post --text "look" --media a.jpg,b.jpg --confirm
+  python3 x.py thread --text "1/2 first" --text "2/2 second" --confirm
+  python3 x.py like --id 1234567890 --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+_RAW = sys.argv[1:]
+# --confirm is honored ONLY as the last token, and only one is stripped, so a
+# tweet body that merely contains "--confirm" can never silently confirm a write.
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+# State-changing commands — dry-run unless the invocation ends with --confirm.
+GATED = {
+    "post", "thread", "like", "unlike", "retweet", "unretweet",
+    "follow", "unfollow", "delete",
+}
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+def load_cookie_dict() -> dict:
+    raw = os.environ.get("X_COOKIES")
+    if not raw:
+        die("X_COOKIES is not set — connect X (Twitter) at "
+            "https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"X_COOKIES is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"X_COOKIES must be a JSON list of cookies, got {type(jar).__name__}")
+    cookies = {}
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if name and value is not None:
+            cookies[name] = value
+    if "auth_token" not in cookies or "ct0" not in cookies:
+        die("X_COOKIES is missing auth_token / ct0 — re-capture the cookie on "
+            "x.com with the ACE extension, then reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    return cookies
+
+
+def make_client():
+    from twikit import Client
+    proxy = (
+        os.environ.get("X_PROXY")
+        or os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+        or os.environ.get("ALL_PROXY") or os.environ.get("all_proxy")
+        or None
+    )
+    client = Client("en-US", proxy=proxy, user_agent=UA)
+    client.set_cookies(load_cookie_dict())
+    return client
+
+
+# ── formatting ──────────────────────────────────────────────────────
+
+def fmt_user(u) -> dict:
+    return {
+        "id": str(getattr(u, "id", "")),
+        "name": getattr(u, "name", None),
+        "screen_name": getattr(u, "screen_name", None),
+        "url": f"https://x.com/{getattr(u, 'screen_name', '')}",
+        "followers_count": getattr(u, "followers_count", None),
+        "following_count": getattr(u, "following_count", None),
+        "statuses_count": getattr(u, "statuses_count", None),
+        "verified": getattr(u, "verified", None) or getattr(u, "is_blue_verified", None),
+        "description": (getattr(u, "description", None) or "")[:200],
+    }
+
+
+def fmt_tweet(t) -> dict:
+    author = getattr(t, "user", None)
+    sn = getattr(author, "screen_name", None) if author else None
+    tid = str(getattr(t, "id", ""))
+    return {
+        "id": tid,
+        "text": (getattr(t, "full_text", None) or getattr(t, "text", None) or "")[:280],
+        "author": sn,
+        "url": f"https://x.com/{sn}/status/{tid}" if sn and tid else None,
+        "created_at": getattr(t, "created_at", None),
+        "favorite_count": getattr(t, "favorite_count", None),
+        "retweet_count": getattr(t, "retweet_count", None),
+        "reply_count": getattr(t, "reply_count", None),
+        "quote_count": getattr(t, "quote_count", None),
+        "view_count": getattr(t, "view_count", None),
+        "lang": getattr(t, "lang", None),
+    }
+
+
+async def resolve_user(client, target: str):
+    t = target.lstrip("@").strip()
+    if t.isdigit():
+        return await client.get_user_by_id(t)
+    return await client.get_user_by_screen_name(t)
+
+
+# ── read commands ───────────────────────────────────────────────────
+
+async def cmd_whoami(client, _args):
+    u = await client.user()
+    out(fmt_user(u))
+
+
+async def cmd_search(client, args):
+    tweets = await client.search_tweet(args.query, args.product, count=args.limit)
+    items = list(tweets)[: args.limit]
+    out({"query": args.query, "product": args.product,
+         "count": len(items), "tweets": [fmt_tweet(t) for t in items]})
+
+
+async def cmd_search_users(client, args):
+    users = await client.search_user(args.query, count=args.limit)
+    items = list(users)[: args.limit]
+    out({"query": args.query, "count": len(items),
+         "users": [fmt_user(u) for u in items]})
+
+
+async def cmd_timeline(client, args):
+    tweets = await client.get_latest_timeline(count=args.limit)
+    items = list(tweets)[: args.limit]
+    out({"count": len(items), "tweets": [fmt_tweet(t) for t in items]})
+
+
+async def cmd_user_tweets(client, args):
+    u = await resolve_user(client, args.user)
+    tweets = await client.get_user_tweets(u.id, args.type, count=args.limit)
+    items = list(tweets)[: args.limit]
+    out({"user": fmt_user(u), "type": args.type,
+         "count": len(items), "tweets": [fmt_tweet(t) for t in items]})
+
+
+async def cmd_tweet(client, args):
+    t = await client.get_tweet_by_id(args.id)
+    out(fmt_tweet(t))
+
+
+async def cmd_trends(client, args):
+    trends = await client.get_trends(args.category, count=args.limit)
+    out({"category": args.category,
+         "trends": [{"name": getattr(x, "name", None),
+                     "tweets_count": getattr(x, "tweets_count", None)}
+                    for x in list(trends)[: args.limit]]})
+
+
+# ── write commands (GATED) ──────────────────────────────────────────
+
+async def _upload_media(client, media_arg: str) -> list:
+    media_ids = []
+    for path in [p.strip() for p in media_arg.split(",") if p.strip()]:
+        if not os.path.isfile(path):
+            die(f"media file not found: {path}")
+        media_ids.append(await client.upload_media(path, wait_for_completion=True))
+    return media_ids
+
+
+def _quote_note(args) -> dict:
+    return {
+        "reply_to": getattr(args, "reply_to", None),
+        "quote_url": getattr(args, "quote_url", None),
+        "media": getattr(args, "media", None),
+    }
+
+
+async def cmd_post(client, args):
+    text = (args.text or "").strip()
+    if not text and not args.media:
+        die("provide --text and/or --media")
+    media_ids = await _upload_media(client, args.media) if args.media else None
+    tweet = await client.create_tweet(
+        text=text, media_ids=media_ids,
+        reply_to=args.reply_to, attachment_url=args.quote_url)
+    out({"ok": True, "posted": True, **fmt_tweet(tweet)})
+
+
+async def cmd_thread(client, args):
+    texts = [t for t in (args.text or []) if t and t.strip()]
+    if len(texts) < 2:
+        die("a thread needs at least two --text segments")
+    media_ids = await _upload_media(client, args.media) if args.media else None
+    posted, reply_to = [], None
+    for i, text in enumerate(texts):
+        tweet = await client.create_tweet(
+            text=text.strip(),
+            media_ids=media_ids if i == 0 else None,
+            reply_to=reply_to)
+        reply_to = tweet.id
+        posted.append(fmt_tweet(tweet))
+    out({"ok": True, "posted": True, "count": len(posted), "tweets": posted})
+
+
+async def cmd_like(client, args):
+    await client.favorite_tweet(args.id)
+    out({"ok": True, "liked": True, "tweet_id": args.id})
+
+
+async def cmd_unlike(client, args):
+    await client.unfavorite_tweet(args.id)
+    out({"ok": True, "unliked": True, "tweet_id": args.id})
+
+
+async def cmd_retweet(client, args):
+    await client.retweet(args.id)
+    out({"ok": True, "retweeted": True, "tweet_id": args.id})
+
+
+async def cmd_unretweet(client, args):
+    await client.delete_retweet(args.id)
+    out({"ok": True, "unretweeted": True, "tweet_id": args.id})
+
+
+async def cmd_follow(client, args):
+    u = await resolve_user(client, args.user)
+    await client.follow_user(u.id)
+    out({"ok": True, "followed": True, "user": u.screen_name, "user_id": str(u.id)})
+
+
+async def cmd_unfollow(client, args):
+    u = await resolve_user(client, args.user)
+    await client.unfollow_user(u.id)
+    out({"ok": True, "unfollowed": True, "user": u.screen_name, "user_id": str(u.id)})
+
+
+async def cmd_delete(client, args):
+    await client.delete_tweet(args.id)
+    out({"ok": True, "deleted": True, "tweet_id": args.id})
+
+
+def gated_dry_run(args) -> None:
+    """Print what a state-changing command WOULD do, without any network call."""
+    cmd = args.command
+    fields: dict = {}
+    if cmd == "post":
+        fields = {"text_preview": (args.text or "")[:280], **_quote_note(args)}
+    elif cmd == "thread":
+        texts = [t for t in (args.text or []) if t and t.strip()]
+        fields = {"segments": len(texts), "preview": [t[:120] for t in texts],
+                  "media_on_first": args.media}
+    elif cmd in ("follow", "unfollow"):
+        fields = {"user": args.user}
+    else:  # like / unlike / retweet / unretweet / delete
+        fields = {"tweet_id": args.id}
+    out({"dry_run": True, "command": cmd, **fields,
+         "note": "Re-run with --confirm as the LAST argument to actually run "
+                 "this. It acts on the user's REAL X account."})
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "search": cmd_search,
+    "search-users": cmd_search_users,
+    "timeline": cmd_timeline,
+    "user-tweets": cmd_user_tweets,
+    "tweet": cmd_tweet,
+    "trends": cmd_trends,
+    "post": cmd_post,
+    "thread": cmd_thread,
+    "like": cmd_like,
+    "unlike": cmd_unlike,
+    "retweet": cmd_retweet,
+    "unretweet": cmd_unretweet,
+    "follow": cmd_follow,
+    "unfollow": cmd_unfollow,
+    "delete": cmd_delete,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="x.py", description="X (Twitter) cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("whoami", help="show the logged-in account")
+
+    sp = sub.add_parser("search", help="search tweets by keyword")
+    sp.add_argument("--query", required=True)
+    sp.add_argument("--product", choices=["Top", "Latest", "Media"], default="Latest")
+    sp.add_argument("--limit", type=int, default=20)
+
+    sp = sub.add_parser("search-users", help="search users by keyword")
+    sp.add_argument("--query", required=True)
+    sp.add_argument("--limit", type=int, default=20)
+
+    sp = sub.add_parser("timeline", help="my home timeline (latest)")
+    sp.add_argument("--limit", type=int, default=20)
+
+    sp = sub.add_parser("user-tweets", help="a user's tweets")
+    sp.add_argument("--user", required=True, help="@screen_name or numeric id")
+    sp.add_argument("--type", choices=["Tweets", "Replies", "Media", "Likes"],
+                    default="Tweets")
+    sp.add_argument("--limit", type=int, default=20)
+
+    sp = sub.add_parser("tweet", help="single tweet detail")
+    sp.add_argument("--id", required=True)
+
+    sp = sub.add_parser("trends", help="trending topics")
+    sp.add_argument("--category",
+                    choices=["trending", "for-you", "news", "sports", "entertainment"],
+                    default="trending")
+    sp.add_argument("--limit", type=int, default=20)
+
+    sp = sub.add_parser("post", help="publish a tweet (GATED by trailing --confirm)")
+    sp.add_argument("--text", default="")
+    sp.add_argument("--media", help="comma-separated image/video file paths")
+    sp.add_argument("--reply-to", dest="reply_to", help="tweet id to reply to")
+    sp.add_argument("--quote-url", dest="quote_url", help="tweet URL to quote")
+
+    sp = sub.add_parser("thread", help="publish a thread (GATED by trailing --confirm)")
+    sp.add_argument("--text", action="append", help="one per tweet; repeat 2+ times")
+    sp.add_argument("--media", help="comma-separated paths, attached to the FIRST tweet")
+
+    for name in ("like", "unlike", "retweet", "unretweet", "delete"):
+        sp = sub.add_parser(name, help=f"{name} a tweet (GATED by trailing --confirm)")
+        sp.add_argument("--id", required=True)
+
+    for name in ("follow", "unfollow"):
+        sp = sub.add_parser(name, help=f"{name} a user (GATED by trailing --confirm)")
+        sp.add_argument("--user", required=True, help="@screen_name or numeric id")
+
+    return p
+
+
+async def run(args) -> None:
+    client = make_client()
+    await COMMANDS[args.command](client, args)
+
+
+def main() -> None:
+    args = build_parser().parse_args(ARGV)
+    # Gated commands dry-run offline (no cookies, no network) unless --confirm.
+    if args.command in GATED and not CONFIRM:
+        gated_dry_run(args)
+        return
+    try:
+        from twikit.errors import (
+            Unauthorized, Forbidden, TooManyRequests, NotFound,
+            TweetNotAvailable, UserNotFound, UserUnavailable,
+            AccountLocked, AccountSuspended, TwitterException,
+        )
+    except Exception as e:  # twikit not importable
+        die(f"twikit is not available: {e}. Install with "
+            f"`pip install --user twikit`.")
+    try:
+        asyncio.run(run(args))
+    except (Unauthorized,) as e:
+        die(f"auth failed — cookie likely expired. Reconnect X at "
+            f"https://auth.acedata.cloud/user/connections. ({e})")
+    except (AccountLocked, AccountSuspended) as e:
+        die(f"account locked/suspended by X: {e}")
+    except TooManyRequests as e:
+        die(f"rate limited by X — wait and retry, or slow down. ({e})")
+    except (NotFound, TweetNotAvailable, UserNotFound, UserUnavailable) as e:
+        die(f"not found / unavailable: {e}")
+    except Forbidden as e:
+        die(f"forbidden by X (content rule, protected account, or ToS): {e}")
+    except TwitterException as e:
+        die(f"X API error: {e}")
+    except Exception as e:
+        # twikit scrapes X's non-public API; a bare error here usually means an
+        # expired cookie OR that X changed its internal endpoints and twikit
+        # needs upgrading (e.g. "Couldn't get KEY_BYTE indices" = transaction-id
+        # bootstrap drift → `pip install --user -U twikit`).
+        die(f"X request failed ({type(e).__name__}: {e}). Likely an expired "
+            f"cookie — reconnect at https://auth.acedata.cloud/user/connections "
+            f"— or twikit drift vs X's internal API (try `pip install --user -U "
+            f"twikit`).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 问题

`auth.acedata.cloud/user/connections` 里的 **X (Twitter)** 连接器是空壳:`connectors.yaml` 用 OAuth 1.0a 密钥式(4 个 password 字段)、**无 `required_skills`**,`skills/` 里也**没有 x/twitter skill** —— 用户填了密钥也无法发推/搜索。密钥式对 C 端发布也不可用(每人自建 X App + 过审 + 自付费,带链接帖 $0.20/条)。

## 改动

新建 **`skills/x/`**,走 cookie 方案(与已上线的 `weibo` / `medium` cookie skill 一致),配套连接器改动在 AuthBackend PR;沙箱预装依赖在 PlatformService PR。

- **`skills/x/scripts/x.py`** —— 用 [`tweety-ns`](https://github.com/mahrtayyab/tweety) 驱动用户**本人**的 X 账号,认证来自 ACE 插件抓取的登录 cookie(`X_COOKIES`:含 `auth_token` + `ct0`),无需官方 key、零成本。
- **`skills/x/SKILL.md`** —— 说明 + gotcha。

### 为什么用 tweety-ns(而非 twikit)

对 X 内部 API 抓取库,**维护活跃度是选型第一要素**。横评后:

| 库 | 维护 | 发帖 | 备注 |
|---|---|---|---|
| **tweety-ns** ✅ 选用 | 🟢 每日提交、"Still Maintained" | ✅ 文/图/thread/回复/引用 | 功能更全(投票/分析/翻译…)|
| twikit | 🟡 最后发版 2025-02 | ✅ | star 多但放缓 |
| twscrape | 🟢 最活跃 | ❌ **只读** | 发布场景不能单用 |
| twitter-api-client | 🔴 弃坑 2 年 | ✅✅ | 对不上现在的 X |

本 PR 初版基于 twikit,评审后按"维护优先"切到 **tweety-ns**(见提交历史)。

### 功能

| 类别 | 命令 |
|---|---|
| 读 | `whoami`、`search`(Top/Latest/Media)、`search-users`、`timeline`、`user-tweets`(Tweets/Replies/Media)、`tweet`、`trends` |
| 写(**全部 `--confirm` 门禁**) | `post`(文/图≤4/视频/回复/引用)、`thread`、`like`/`unlike`、`retweet`/`unretweet`、`follow`/`unfollow`、`delete` |

### 设计要点

- **写操作二次确认**:所有状态变更命令必须以 `--confirm` **作为最后一个参数**才执行,否则**离线 dry-run**(不加载 cookie、不联网)。与 weibo/telegram 门禁语义一致。
- **依赖**:`tweety-ns` 由沙箱预装(PlatformService PR),SKILL 保留 `pip install --user` 兜底(沿用 telegram 的 telethon 引导先例)。
- **密钥安全**:`X_COOKIES` 是完整账号权限,**从不打印**;会话 cookie 写入**临时目录并在 finally 删除**(绝不落到 CWD)。所有错误(cookie 过期 / 限流 / tweety 与 X 内部 API 漂移)返回干净 JSON,不吐 traceback。
- **API 全部对齐 tweety-ns 2.4.1 真实签名**(本地 venv introspect,含 `httpx==0.27.2` 兼容性实测)。

## 已知取舍(写进 SKILL gotcha)

- tweety-ns 是对 X 非公开 API 的抓取:X 改接口时可能失效(报错提示 `pip install --user -U tweety-ns`);高频有**限流/封号**风险,发布做二次确认。
- **尚未真机 E2E**:结构 / dry-run / 错误路径已本地验证;首次真机运行即验证。DM 按需求未开放。

## 验证

- `py_compile` 通过;离线 dry-run(post/thread/like/follow)正确;`--confirm` 非末位 → argparse 拒绝、不发帖;缺/坏 cookie、假 cookie 触发 tweety transaction-id 失败 —— 全部干净 JSON,无 traceback。
- tweety-ns 在 **pinned `httpx==0.27.2`** 下实测可运行(到达 transaction 引导),沙箱 pin 安全。
- `_quote_id` 对 `?s=20`、`/photo/1`、`#frag` 等 URL 变体均正确取到纯 id。

## 🤖 对抗评审

对 twikit→tweety-ns 重写 + 沙箱改动做了只读对抗评审,重点审查写门禁绕过、`X_COOKIES`/会话文件泄漏、tweety API 正确性、错误处理、沙箱依赖冲突:

> 写门禁 fail-closed(9 个写命令全覆盖,尝试的绕过均失败);会话在 `tempfile.mkdtemp` 且 `finally` 清理、绝不落 CWD、cookie 无泄漏路径;tweety 调用与 2.4.1 签名吻合(`me` 作属性不 await、`SearchFilters.Users`、`tweety.exceptions_`);异常阶梯子类先于基类、bare Exception 兜底成干净 JSON;`tweety-ns==2.4.1` 与 `httpx==0.27.2`/`beautifulsoup4~=4.12` 无冲突,smoke-check import 名 `tweety` 正确。

评审提出并**已修复**:
- **RISK** `_quote_id` 之前贪婪拼接 URL 里所有数字(把 `?s=20&t=ab` 的数字混进 id)→ 改为只取 `/status/` 后的首段(去 `?`/`/`/`#`),已单测 4 种 URL 变体全对。
- **NIT** `user-tweets` 未去掉前导 `@` → 已与 follow/unfollow 一致 `lstrip("@")`。
