### PR TITLE
docs(skills): 发布后调 publish_artifact 记录产出（17 skills）

### DIFF
--- a/skills/_shared/artifacts.md
+++ b/skills/_shared/artifacts.md
@@ -1,0 +1,28 @@
+# Recording produced outputs (`publish_artifact`)
+
+Write/publish-capable Skills should record their concrete deliverable so the
+user can later find and aggregate everything the agent produced (in the "My
+Outputs" view at `/chatgpt/artifacts`).
+
+After a publish/send/generate action **succeeds and you have the live result
+URL**, call the built-in `publish_artifact` tool exactly ONCE for that
+deliverable:
+
+```
+publish_artifact(
+  kind="article",          # article | image | video | audio | document | email | message | dataset | link | other
+  channel="<platform>",    # e.g. zhihu, csdn, medium, x, mastodon
+  title="<human title>",
+  url="<the REAL returned URL>",
+  status="delivered"       # delivered | draft | failed
+)
+```
+
+Rules:
+
+- Use the **real URL returned by the publish step** — never fabricate a URL.
+- Call it once per distinct deliverable, right after delivery is confirmed.
+- Do NOT call it for intermediate steps, drafts you didn't submit, or narration.
+- If publishing failed, either skip it or record `status="failed"`.
+
+The tool is non-interactive and works in unattended (scheduled-task) runs.

--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -106,3 +106,17 @@ skips this.
   common `tid` values.
 - **Never print `BILIBILI_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="bilibili", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/blogger/SKILL.md
+++ b/skills/blogger/SKILL.md
@@ -78,3 +78,17 @@ curl -sS -H "Authorization: Bearer $GOOGLE_BLOGGER_TOKEN" \
   or reconnect with the account that has the blog.
 - `content` must be HTML; passing raw Markdown will render literally.
 - Paginate with `&pageToken=$PAGE_TOKEN` from the previous `.nextPageToken`.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="blogger", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/bluesky/SKILL.md
+++ b/skills/bluesky/SKILL.md
@@ -112,3 +112,17 @@ extracts the `rkey`. An empty result / `deleted:true` is success.
   there; all XRPC calls target that host, not `bsky.social`.
 - The CLI creates a fresh short-lived session on **every** invocation, so an
   expiring `accessJwt` is never a concern — just run the command again.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="bluesky", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -91,3 +91,17 @@ image that fails to upload keeps its original URL (never blocks the post).
 - **Never print `CSDN_COOKIES`** — it is full account access.
 - **ToS**: cookie automation acts only on the user's own account with their own
   captured cookie; the user owns that risk.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="csdn", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/devto/SKILL.md
+++ b/skills/devto/SKILL.md
@@ -76,3 +76,17 @@ curl -sS -H "api-key: $DEVTO_API_KEY" -H "Accept: application/vnd.forem.api-v1+j
   bulk publishes or you'll get `429`.
 - `body_markdown` is the source of truth — if you put a `---` front-matter block
   at the top, its fields override the JSON `article` fields.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="devto", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/hashnode/SKILL.md
+++ b/skills/hashnode/SKILL.md
@@ -145,3 +145,17 @@ gql 'query GetPost($id: ObjectId!) { post(id: $id) { title url views reactionCou
   via status codes; always surface them.
 - **Idempotency** — re-running `publishPost` creates a *new* post each time; to
   change an existing one use `updatePost` with its `id`.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="hashnode", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/juejin/SKILL.md
+++ b/skills/juejin/SKILL.md
@@ -73,3 +73,17 @@ python3 $JJ publish --title "标题" --content-file a.md \
 - Publishing without a category + tag is rejected in 审核; prefer `--draft-only`.
 - **Never print `JUEJIN_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="juejin", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/linkedin/SKILL.md
+++ b/skills/linkedin/SKILL.md
@@ -71,3 +71,17 @@ If the versioned endpoint is unavailable for the app, the older
   Page posts need `w_organization_social` + an admin role (not in this connector).
 - The `LinkedIn-Version` header is mandatory for `/rest/*`; a stale value
   returns a version error — bump to the current `YYYYMM`.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="linkedin", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/mastodon/SKILL.md
+++ b/skills/mastodon/SKILL.md
@@ -101,3 +101,17 @@ https://docs.joinmastodon.org/methods/media/
   get `429`.
 - `verify_credentials` returns HTML in fields like `note`; the plaintext source
   lives under the `source` object.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="mastodon", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -93,3 +93,17 @@ to a link paragraph (never blocks the post).
   genuinely expired (reconnect).
 - **Never print `MEDIUM_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="medium", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -120,3 +120,17 @@ curl -sS -X POST "https://api.notion.com/v1/pages" \
 - Most write failures (400/404) come from a property type mismatch —
   e.g. sending `{"select": "Open"}` instead of `{"select": {"name": "Open"}}`.
   Read the database schema once via `GET /v1/databases/<id>` if unsure.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="document", channel="notion", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -77,3 +77,17 @@ curl -sS -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
 - Respect rate limits: read the `X-Ratelimit-Remaining` response header; space
   out bulk submits.
 - Use `r/test` as a safe target when validating that the connection works.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="reddit", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/substack/SKILL.md
+++ b/skills/substack/SKILL.md
@@ -93,3 +93,17 @@ python3 $SUB publish --title "Title" --content-file post.md --send-email --confi
   genuinely expired (reconnect); the CLI never retries a write.
 - **Never print `SUBSTACK_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="substack", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -122,3 +122,17 @@ user verbatim as the confirmation prompt.
   return an error (no shareable link exists).
 - **`edit`/`delete`** generally only apply to the user's own messages (admins can delete others
   in groups they manage).
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="telegram", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/wordpress/SKILL.md
+++ b/skills/wordpress/SKILL.md
@@ -141,3 +141,17 @@ echo "media id=$MEDIA_ID"
 - **Never publish silently.** Even if the user says "post it", prefer creating a
   draft and returning the `wp-admin` edit link unless they explicitly asked to
   go live.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="wordpress", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -107,3 +107,17 @@ python3 $X delete --id 123456 --confirm                        # delete one of M
   suspended. Keep volume human-like.
 - **Never print `X_COOKIES`** — it is full account access.
 - **DMs are intentionally not exposed** by this skill.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="x", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -218,3 +218,17 @@ python3 $BLOG edit-answer --id <answer-id> --content-file ans.html --confirm   #
 - **Scope**: Zhihu only. Other Chinese platforms (掘金 / CSDN / …) ship as their
   own per-platform skills (e.g. `csdn`, `juejin`), each with its own connector —
   not a `--platform` switch here.
+
+
+## Record the output
+
+After you successfully publish and obtain the live result URL, call the built-in
+`publish_artifact` tool ONCE so the user can track this deliverable in **My Outputs**:
+
+```
+publish_artifact(kind="article", channel="zhihu", title="<title>", url="<the REAL returned URL>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.


### PR DESCRIPTION
## 背景

实现 [AICHAT2-ARTIFACTS 计划](https://github.com/AceDataCloud/Index/blob/main/plans/aichat-and-nexior/AICHAT2-ARTIFACTS.md) PR7：让发布类 skill 在发布成功后调 `publish_artifact` 记录产出，用户即可在「我的产出」(`/chatgpt/artifacts`) 汇总查看所发文章/内容。

## 改动

- **`skills/_shared/artifacts.md`（新）** — 记录产出的规范文档（何时调、字段、绝不编造 URL）。
- 给 **17 个发布类 skill** 的 SKILL.md 追加一节「Record the output」：发布成功拿到真实 URL 后调 `publish_artifact(kind, channel, title, url, status)`：
  - article：zhihu / csdn / bilibili / juejin / medium / devto / hashnode / blogger / linkedin / wordpress / substack
  - document：notion
  - message：x / mastodon / bluesky / reddit / telegram
- 幂等：已含 `publish_artifact` 的 skill 跳过；纯 markdown 文档改动，不动脚本。

## 依赖

`publish_artifact` 内置工具由 PlatformService#1320 提供（aichat2 worker）。skill 同步经 AuthBackend skill-catalog-sync CronJob 生效。

## 🤖 对抗评审

纯文档/约定改动（追加 SKILL.md 指导段 + 新增 _shared 参考），无脚本/代码路径变更，风险面为零 —— 按对抗评审策略即时收敛。VERDICT: CLEAN。
