### PR TITLE
feat(skills): add Instagram + Threads publishing skills (BYOC)

### DIFF
--- a/skills/instagram/SKILL.md
+++ b/skills/instagram/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: instagram
+description: Publish images, videos, Reels or carousels to your Instagram professional account via the Instagram Content Publishing API, and read your own recent media. Use when the user wants to post to Instagram (photo / video / reel / carousel), cross-post a visual, or review their own Instagram posts. Instagram is image/video-only (no text-only posts). Auth uses an access token (BYOC). 支持 Instagram 图片 / 视频 / Reels / 轮播发布。
+when_to_use: |
+  Trigger when the user wants to publish a photo, video, reel or carousel to
+  their Instagram professional (Business/Creator) account, or review their own
+  recent posts. Instagram only publishes image/video — there are no text-only
+  posts. Publishing posts as their real account — confirm caption + media first.
+connections: [instagram]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **Instagram Graph API** (`graph.facebook.com`) with `curl + jq`. The
+connector injects `$INSTAGRAM_ACCESS_TOKEN` (a token with
+`instagram_content_publish` + `pages_read_engagement`; a Facebook Page token or
+an Instagram-Login user token) and optionally `$INSTAGRAM_IG_USER_ID`. Never echo them.
+
+Instagram publishes only **images / videos / reels** to a **professional**
+(Business or Creator) account linked to a Facebook Page. There are no text-only posts.
+
+### Resolve the Instagram account id
+
+If `$INSTAGRAM_IG_USER_ID` is set, use it. Otherwise derive it from the linked Page:
+
+```bash
+if [ -n "$INSTAGRAM_IG_USER_ID" ]; then
+  IGID="$INSTAGRAM_IG_USER_ID"
+else
+  PAGE=$(curl -sS "https://graph.facebook.com/v21.0/me/accounts?access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.data[0].id')
+  IGID=$(curl -sS "https://graph.facebook.com/v21.0/$PAGE?fields=instagram_business_account&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.instagram_business_account.id')
+fi
+echo "ig_user_id=$IGID"
+```
+
+Errors are JSON with `error.message` / `error.code` — show them verbatim.
+`401` / `OAuthException` → token expired or missing scope; a null `IGID` → the
+token isn't linked to a professional IG account / Page (see Gotchas). Reconnect if needed.
+
+## Publish a single image (two-step: create container → publish)
+
+**Confirm the caption + image with the user first.** The `image_url` must be a
+**public JPEG** URL (Instagram server-side cURLs it):
+
+```bash
+CID=$(curl -sS -X POST "https://graph.facebook.com/v21.0/$IGID/media" \
+  -d "image_url=https://cdn.acedata.cloud/xxxx.jpg" \
+  --data-urlencode "caption=One endpoint → posters, cards, mockups. #AI #API" \
+  -d "access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r .id)
+echo "container=$CID"
+
+curl -sS -X POST "https://graph.facebook.com/v21.0/$IGID/media_publish" \
+  -d "creation_id=$CID" -d "access_token=$INSTAGRAM_ACCESS_TOKEN" | jq .
+# → {"id":"<IG_MEDIA_ID>"}
+```
+
+Get the permalink to hand back to the user:
+
+```bash
+curl -sS "https://graph.facebook.com/v21.0/<IG_MEDIA_ID>?fields=permalink&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r .permalink
+```
+
+## Reels / video
+
+Create with `media_type=REELS` + a public `video_url`, then **poll the container
+status until FINISHED** before publishing (video processing takes time):
+
+```bash
+CID=$(curl -sS -X POST "https://graph.facebook.com/v21.0/$IGID/media" \
+  -d "media_type=REELS" -d "video_url=https://cdn.acedata.cloud/xxxx.mp4" \
+  --data-urlencode "caption=..." -d "access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r .id)
+
+# poll until the video finishes processing (up to ~5 min) BEFORE publishing —
+# publishing an IN_PROGRESS container is rejected:
+for i in $(seq 1 60); do
+  ST=$(curl -sS "https://graph.facebook.com/v21.0/$CID?fields=status_code&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r .status_code)
+  echo "status=$ST"; [ "$ST" = "FINISHED" ] && break
+  [ "$ST" = "ERROR" ] || [ "$ST" = "EXPIRED" ] && { echo "container failed: $ST"; break; }
+  sleep 5
+done
+
+curl -sS -X POST "https://graph.facebook.com/v21.0/$IGID/media_publish" \
+  -d "creation_id=$CID" -d "access_token=$INSTAGRAM_ACCESS_TOKEN" | jq .
+```
+
+## Carousel (2–10 items)
+
+Create each child with `is_carousel_item=true`, then a `media_type=CAROUSEL`
+container with `children=<ID1>,<ID2>,...` + `caption`, then publish the carousel id.
+
+## Gotchas
+
+- **No text-only posts** — Instagram requires an image or video. Use a public
+  **JPEG** for images (PNG/other formats are rejected; extended JPEG like MPO/JPS too).
+- **Professional account required** — a Business/Creator IG account linked to a
+  Facebook Page. If `instagram_business_account` is null, the account isn't a
+  professional account or isn't linked; the user must fix that in IG / Page settings.
+- **Media must be a public URL** on a server Instagram can reach; local files
+  won't work. Host on cdn.acedata.cloud first.
+- **Rate limit:** 100 API-published posts per 24h (a carousel counts as 1). Check
+  via `GET /$IGID/content_publishing_limit`.
+- **Page Publishing Authorization (PPA):** some Pages must complete PPA before API
+  publishing works — surface the API error verbatim if it mentions PPA.
+- API version: keep the `vXX.0` path current if you hit a version/deprecation error.
+
+## Record the output
+
+After you successfully publish and obtain the live permalink, call the built-in
+`publish_artifact` tool ONCE so the user can track it in **My Outputs**:
+
+```
+publish_artifact(kind="image", channel="instagram", title="<title>", url="<the REAL permalink>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.

--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: threads
+description: Publish text, image, video or carousel posts to your Threads (@threads) account via the official Threads API, and read your own recent posts. Use when the user wants to post to Threads, cross-post a short update / thread, attach an image or link, or review their own Threads posts. Auth uses a Threads access token (BYOC). 支持 Threads 文本 / 图片 / 视频 / 轮播发布与自有贴文读取。
+when_to_use: |
+  Trigger when the user wants to publish a post to their Threads account or
+  review their own recent Threads posts. Threads is Meta's text-first social
+  app; the connector stores a Threads access token with threads_content_publish.
+  Posting publishes as their real account — confirm the text with the user first.
+connections: [threads]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Call the **Threads API** (`graph.threads.net`) with `curl + jq`. The connector
+injects one credential: `$THREADS_ACCESS_TOKEN` (a long-lived Threads access
+token with the `threads_basic` + `threads_content_publish` scopes). Never echo it.
+
+Resolve the caller's Threads user id once (every publish needs it):
+
+```bash
+ME=$(curl -sS "https://graph.threads.net/v1.0/me?fields=id,username&access_token=$THREADS_ACCESS_TOKEN")
+TID=$(echo "$ME" | jq -r .id)
+echo "$ME"     # {"id":"<THREADS_USER_ID>","username":"..."}
+```
+
+Errors are JSON with `error.message` / `error.code` — show them verbatim.
+`401` / `OAuthException` → the token expired or lacks scope; reconnect the
+Threads connector.
+
+## Publish a post (two-step: create container → publish)
+
+**Confirm the text with the user first** (it publishes as their real account).
+Text ≤ **500 characters** (emoji counted as UTF-8 bytes).
+
+Step 1 — create a media container. Text-only (guard the 500-byte limit first):
+
+```bash
+TEXT="Shipping one API for AI images → posters, cards, mockups. https://platform.acedata.cloud #AI #API"
+[ "$(printf %s "$TEXT" | wc -c)" -le 500 ] || { echo "text exceeds Threads 500-byte limit — shorten it"; }
+CID=$(curl -sS -X POST "https://graph.threads.net/v1.0/$TID/threads" \
+  --data-urlencode "media_type=TEXT" \
+  --data-urlencode "text=$TEXT" \
+  -d "access_token=$THREADS_ACCESS_TOKEN" | jq -r .id)
+echo "container=$CID"
+```
+
+Image post — add `media_type=IMAGE` + a **public** `image_url` (Threads cURLs it
+server-side, so it must be on a public server); video uses `media_type=VIDEO` + `video_url`:
+
+```bash
+CID=$(curl -sS -X POST "https://graph.threads.net/v1.0/$TID/threads" \
+  --data-urlencode "media_type=IMAGE" \
+  -d "image_url=https://cdn.acedata.cloud/xxxx.jpg" \
+  --data-urlencode "text=caption here" \
+  -d "access_token=$THREADS_ACCESS_TOKEN" | jq -r .id)
+```
+
+Step 2 — publish the container. **Text posts publish immediately; for IMAGE /
+VIDEO / carousel containers you MUST wait ≥30s first** so Threads can
+fetch/process the upload — publishing too early fails or returns no id:
+
+```bash
+sleep 30   # REQUIRED for IMAGE / VIDEO / carousel; skip for TEXT-only posts
+curl -sS -X POST "https://graph.threads.net/v1.0/$TID/threads_publish" \
+  -d "creation_id=$CID" -d "access_token=$THREADS_ACCESS_TOKEN" | jq .
+# → {"id":"<THREADS_MEDIA_ID>"}
+```
+
+If `threads_publish` returns no id, the container isn't ready yet — poll
+`GET /v1.0/<CID>?fields=status&access_token=$THREADS_ACCESS_TOKEN` until
+`status=FINISHED`, then retry publish.
+
+Get the public URL of the published post and hand it to the user:
+
+```bash
+curl -sS "https://graph.threads.net/v1.0/<THREADS_MEDIA_ID>?fields=id,permalink&access_token=$THREADS_ACCESS_TOKEN" | jq -r .permalink
+```
+
+## Carousel (2–20 items)
+
+Create each child with `is_carousel_item=true`, then a `media_type=CAROUSEL`
+container with `children=<ID1>,<ID2>,...`, then publish the carousel id. Links:
+add `link_attachment=<URL>` (text-only posts, ≤5 links). Topic tag: `topic_tag=<TAG>`.
+
+## List my recent posts
+
+```bash
+curl -sS "https://graph.threads.net/v1.0/$TID/threads?fields=id,text,permalink,timestamp&limit=20&access_token=$THREADS_ACCESS_TOKEN" | jq '.data'
+```
+
+## Gotchas
+
+- **500-char limit**; emoji count as their UTF-8 byte length.
+- **Media must be a public URL** — Threads server-side cURLs `image_url`/`video_url`;
+  local files won't work. Upload to a public host / cdn.acedata.cloud first.
+- **Wait ~30s before publishing media** containers (text publishes instantly); if
+  `threads_publish` doesn't return an id, poll `GET /<container-id>?fields=status`.
+- **Rate limit:** 250 published posts per 24h per profile (a carousel counts as 1).
+- Threads tokens differ from Facebook/Instagram tokens — they come from the
+  Threads OAuth flow on `graph.threads.net`, not `graph.facebook.com`.
+
+## Record the output
+
+After you successfully publish and obtain the live permalink, call the built-in
+`publish_artifact` tool ONCE so the user can track it in **My Outputs**:
+
+```
+publish_artifact(kind="message", channel="threads", title="<title>", url="<the REAL permalink>", status="delivered")
+```
+
+Use the real returned URL — never fabricate one. Call it once per published item,
+only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+See `_shared/artifacts.md`.


### PR DESCRIPTION
## What
Add two publishing skills — **Instagram** and **Threads** — thin `curl + jq` wrappers over the official Meta Graph APIs, matching house style (linkedin/bluesky).

- `skills/instagram/SKILL.md` — Instagram Content Publishing API (`graph.facebook.com`): resolve the professional IG account id from the linked Page, then 2-step create-container (`/media`) → publish (`/media_publish`) for image / video / Reels / carousel. Image/video only (no text posts); public media URL + Business/Creator account required; 100 posts/24h.
- `skills/threads/SKILL.md` — Threads API (`graph.threads.net/v1.0`): 2-step create-container (`/threads`) → publish (`/threads_publish`) for text / image / video / carousel; 500-char limit; media needs a public URL + ~30s processing wait.

Both read their BYOC-injected token (`$INSTAGRAM_ACCESS_TOKEN` / `$THREADS_ACCESS_TOKEN`), gate every publish on user confirmation, never echo the token, surface API errors verbatim, and record the live result via `publish_artifact` (per `_shared/artifacts.md`).

## Why
Wave B of the connector-directory marketing expansion (`plans/connector-directory/06-marketing-distribution.md`) — the Meta-family visual/text social gaps. Pairs with the `instagram/instagram` + `threads/threads` BYOC connector rows (AuthBackend PR). **Merge this Skills PR first** so `required_skills` auto-install resolves.

## Validation
- Frontmatter parses; `name` == dir; `description` ≤ 1024; `connections` / `allowed_tools` correct (mirrors CI `validate.yml`).
- BYOC env-var names verified against the worker projection `<NAMESPACE>_<KEY>`.
- API endpoints/params verified against the official Instagram Content Publishing + Threads Posts docs.

## 🤖 对抗评审
Reviewer: Claude general-purpose subagent (Codex not installed on this host). One round, converged.

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | Threads media publish: 30s wait was commented out → an LLM might publish too early | **Fixed** — `sleep 30` now explicit + a "poll status until FINISHED" fallback |
| 2 | Instagram Reels: status check shown as a single call, not a loop | **Fixed** — real `for` poll loop until `FINISHED` / `ERROR` |
| 3 | Threads 500-char limit documented but not guarded | **Fixed** — added a `wc -c` byte guard before create-container |
| 4 | `required_skills` won't resolve until skills merge | **Process** — merge this Skills PR before the AuthBackend connector PR; missing-skill is logged + skipped, so no break |
| — | env vars, namespaces (single-token), frontmatter, YAML, API endpoints | **CLEAN** |
