### PR TITLE
fix(instagram): resolve IG user id from both Page and User access tokens

### DIFF
--- a/skills/instagram/SKILL.md
+++ b/skills/instagram/SKILL.md
@@ -24,14 +24,22 @@ Instagram publishes only **images / videos / reels** to a **professional**
 
 ### Resolve the Instagram account id
 
-If `$INSTAGRAM_IG_USER_ID` is set, use it. Otherwise derive it from the linked Page:
+If `$INSTAGRAM_IG_USER_ID` is set, use it. Otherwise derive it from the token —
+try the **Page-token** path first (`/me` is the Page), then fall back to the
+**user-token** path (`/me/accounts` → linked Page → IG account), so either token
+type the connector accepts resolves cleanly:
 
 ```bash
 if [ -n "$INSTAGRAM_IG_USER_ID" ]; then
   IGID="$INSTAGRAM_IG_USER_ID"
 else
-  PAGE=$(curl -sS "https://graph.facebook.com/v21.0/me/accounts?access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.data[0].id')
-  IGID=$(curl -sS "https://graph.facebook.com/v21.0/$PAGE?fields=instagram_business_account&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.instagram_business_account.id')
+  # Page access token: /me IS the Page, read its linked IG account directly
+  IGID=$(curl -sS "https://graph.facebook.com/v21.0/me?fields=instagram_business_account&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.instagram_business_account.id // empty')
+  if [ -z "$IGID" ]; then
+    # User access token: list the managed Page, then its linked IG account
+    PAGE=$(curl -sS "https://graph.facebook.com/v21.0/me/accounts?access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.data[0].id // empty')
+    IGID=$(curl -sS "https://graph.facebook.com/v21.0/$PAGE?fields=instagram_business_account&access_token=$INSTAGRAM_ACCESS_TOKEN" | jq -r '.instagram_business_account.id // empty')
+  fi
 fi
 echo "ig_user_id=$IGID"
 ```


### PR DESCRIPTION
## What
Instagram skill now resolves the IG user id from **both** access-token types the connector accepts, instead of only the user-token path.

## Why (found during end-to-end verification)
The connector help offers either a **Page access token** or a **User access token**. The old discovery only did the user-token path (GET /me/accounts → Page → `instagram_business_account`), which returns empty for a **Page** token — so a user who pasted a Page token (and left the optional IG id blank) would get a null `IGID` and every publish would fail.

## Fix
Try the Page-token path first (`GET /me?fields=instagram_business_account` — `/me` *is* the Page for a Page token), then fall back to the user-token path. Both use `// empty` so a miss cleanly falls through.

## Verification
All Graph endpoints hit with a fake token return `code 190 OAuthException` (structurally valid, not 404/param error): `/me`, `/me/accounts`, `/me?fields=instagram_business_account`, `/{id}/media`, `/{id}/media_publish`. Skill frontmatter + code-fence balance re-validated.

## 🤖 对抗评审
Follow-up robustness fix to the already-reviewed #547 (merged). Change is additive (adds a first-choice discovery branch + `// empty` guards); no new inputs, no auth/billing surface. VERDICT: CLEAN.