### PR TITLE
fix(skills): self-heal script path across 16 skills when SKILL_DIR is clobbered

### DIFF
--- a/skills/acedatacloud/SKILL.md
+++ b/skills/acedatacloud/SKILL.md
@@ -62,7 +62,10 @@ The skill ships [`scripts/acedatacloud.py`](scripts/acedatacloud.py) — a self-
 CLI (stdlib only) for the most common operations.
 
 ```bash
-ADC=$SKILL_DIR/scripts/acedatacloud.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+ADC="$SKILL_DIR/scripts/acedatacloud.py"; [ -f "$ADC" ] || ADC=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/acedatacloud.py' 2>/dev/null | head -1)
+[ -f "$ADC" ] || { echo "acedatacloud script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 # Read
 python3 $ADC balance                         # remaining credits per subscription

--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -34,11 +34,14 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/bilibili.py`](scripts/bilibili.py) — self-contained, stdlib only.
 
 ```sh
-BILI=$SKILL_DIR/scripts/bilibili.py
-python3 $BILI whoami                       # who is logged in (mid, name)
-python3 $BILI articles --limit 20          # my 专栏 articles + stats
-python3 $BILI article <cvid>               # one article's stats (cv id)
-python3 $BILI drafts --limit 50            # list saved drafts (aid + title)
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bilibili.py' 2>/dev/null | head -1)
+[ -f "$BILI" ] || { echo "bilibili script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$BILI" whoami                     # who is logged in (mid, name)
+python3 "$BILI" articles --limit 20        # my 专栏 articles + stats
+python3 "$BILI" article <cvid>             # one article's stats (cv id)
+python3 "$BILI" drafts --limit 50          # list saved drafts (aid + title)
 ```
 
 Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (评论),
@@ -47,7 +50,8 @@ Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (�
 ## Verify the connection first
 
 ```sh
-python3 $BILI whoami
+BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bilibili.py' 2>/dev/null | head -1)
+python3 "$BILI" whoami
 # → {"mid": 91207595, "name": "...", "level": 4}
 ```
 
@@ -61,9 +65,10 @@ trailing `--confirm` it dry-runs. `--confirm` is honored **only as the last
 argument**. Always show the dry-run, get an explicit "yes", then re-run.
 
 ```sh
-python3 $BILI publish --title "标题" --content-file a.html                       # dry-run
-python3 $BILI publish --title "标题" --content-file a.html --draft-only --confirm   # save a draft
-python3 $BILI publish --title "标题" --content-file a.html --confirm                # save draft + submit (publish)
+BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bilibili.py' 2>/dev/null | head -1)
+python3 "$BILI" publish --title "标题" --content-file a.html                       # dry-run
+python3 "$BILI" publish --title "标题" --content-file a.html --draft-only --confirm   # save a draft
+python3 "$BILI" publish --title "标题" --content-file a.html --confirm                # save draft + submit (publish)
 ```
 
 - `--draft-only` saves a draft (no submit) — safe; finish/publish in the editor.
@@ -77,9 +82,10 @@ Bilibili caps 专栏 drafts at **999**; once full, saving a new draft fails with
 `code 37106 草稿数已达最大上限`. List drafts and delete the ones you don't need:
 
 ```sh
-python3 $BILI drafts --limit 50                       # list (aid + title)
-python3 $BILI delete-draft <aid> <aid2> ...           # dry-run (shows what would delete)
-python3 $BILI delete-draft <aid> <aid2> ... --confirm # PERMANENTLY delete those drafts
+BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bilibili.py' 2>/dev/null | head -1)
+python3 "$BILI" drafts --limit 50                       # list (aid + title)
+python3 "$BILI" delete-draft <aid> <aid2> ...           # dry-run (shows what would delete)
+python3 "$BILI" delete-draft <aid> <aid2> ... --confirm # PERMANENTLY delete those drafts
 ```
 
 - `delete-draft` is **GATED** (dry-run unless trailing `--confirm`) and deletion

--- a/skills/bluesky/SKILL.md
+++ b/skills/bluesky/SKILL.md
@@ -31,7 +31,10 @@ Three connector credentials are injected: `$BLUESKY_HANDLE`
 them from the env — never echo them.
 
 ```sh
-BSKY="$SKILL_DIR/scripts/bluesky.py"
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block below).
+BSKY="$SKILL_DIR/scripts/bluesky.py"; [ -f "$BSKY" ] || BSKY=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bluesky.py' 2>/dev/null | head -1)
+[ -f "$BSKY" ] || { echo "bluesky script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 python3 "$BSKY" whoami          # verify the session → {did, handle, service}
 ```
 

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -36,10 +36,13 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/csdn.py`](scripts/csdn.py) — self-contained, stdlib only.
 
 ```sh
-CSDN=$SKILL_DIR/scripts/csdn.py
-python3 $CSDN whoami                       # who is logged in (+ total article count)
-python3 $CSDN articles --limit 20          # my published articles + stats
-python3 $CSDN article <article-id>         # one article's stats
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+CSDN="$SKILL_DIR/scripts/csdn.py"; [ -f "$CSDN" ] || CSDN=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/csdn.py' 2>/dev/null | head -1)
+[ -f "$CSDN" ] || { echo "csdn script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$CSDN" whoami                     # who is logged in (+ total article count)
+python3 "$CSDN" articles --limit 20        # my published articles + stats
+python3 "$CSDN" article <article-id>       # one article's stats
 ```
 
 Stats come straight from CSDN: `view_count` (阅读), `digg_count` (点赞),
@@ -48,7 +51,8 @@ Stats come straight from CSDN: `view_count` (阅读), `digg_count` (点赞),
 ## Verify the connection first
 
 ```sh
-python3 $CSDN whoami
+CSDN="$SKILL_DIR/scripts/csdn.py"; [ -f "$CSDN" ] || CSDN=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/csdn.py' 2>/dev/null | head -1)
+python3 "$CSDN" whoami
 # → {"username": "...", "nickname": "...", "articles_total": 1597}
 ```
 
@@ -63,9 +67,10 @@ argument**. Always show the dry-run, get an explicit "yes", then re-run with
 `--confirm` last.
 
 ```sh
-python3 $CSDN publish --title "标题" --content-file a.md                      # dry-run
-python3 $CSDN publish --title "标题" --content-file a.md --draft-only --confirm  # private draft (status=2)
-python3 $CSDN publish --title "标题" --content-file a.md --tags "AI,Python" --confirm  # PUBLIC, goes live
+CSDN="$SKILL_DIR/scripts/csdn.py"; [ -f "$CSDN" ] || CSDN=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/csdn.py' 2>/dev/null | head -1)
+python3 "$CSDN" publish --title "标题" --content-file a.md                      # dry-run
+python3 "$CSDN" publish --title "标题" --content-file a.md --draft-only --confirm  # private draft (status=2)
+python3 "$CSDN" publish --title "标题" --content-file a.md --tags "AI,Python" --confirm  # PUBLIC, goes live
 ```
 
 - `--draft-only` saves a private draft (CSDN `status=2`) — safe, nothing public.

--- a/skills/didi-ride/SKILL.md
+++ b/skills/didi-ride/SKILL.md
@@ -34,10 +34,13 @@ If `DIDI_MCP_KEY` is missing, tell the user to connect the DiDi connector at
 ## CLI
 
 The skill ships a stdlib-only helper that speaks the MCP Streamable-HTTP
-protocol to DiDi. Point at it once:
+protocol to DiDi. **Run this resolver at the top of every Bash block below** —
+each Bash call is a fresh shell, and `$SKILL_DIR` points at the LAST skill loaded
+this turn, so anchor on our own script:
 
 ```bash
-DIDI=$SKILL_DIR/scripts/didi.py
+DIDI="$SKILL_DIR/scripts/didi.py"; [ -f "$DIDI" ] || DIDI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/didi.py' 2>/dev/null | head -1)
+[ -f "$DIDI" ] || { echo "didi-ride script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 ```
 
 Two commands:

--- a/skills/juejin/SKILL.md
+++ b/skills/juejin/SKILL.md
@@ -30,10 +30,13 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/juejin.py`](scripts/juejin.py) — self-contained, stdlib only.
 
 ```sh
-JJ=$SKILL_DIR/scripts/juejin.py
-python3 $JJ whoami                       # who is logged in (+ totals)
-python3 $JJ articles --limit 20          # my published articles + stats
-python3 $JJ article <article-id>         # one article's stats
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+JJ="$SKILL_DIR/scripts/juejin.py"; [ -f "$JJ" ] || JJ=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/juejin.py' 2>/dev/null | head -1)
+[ -f "$JJ" ] || { echo "juejin script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$JJ" whoami                     # who is logged in (+ totals)
+python3 "$JJ" articles --limit 20        # my published articles + stats
+python3 "$JJ" article <article-id>       # one article's stats
 ```
 
 Stats come straight from 掘金: `view_count` (阅读), `digg_count` (点赞),
@@ -42,7 +45,8 @@ Stats come straight from 掘金: `view_count` (阅读), `digg_count` (点赞),
 ## Verify the connection first
 
 ```sh
-python3 $JJ whoami
+JJ="$SKILL_DIR/scripts/juejin.py"; [ -f "$JJ" ] || JJ=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/juejin.py' 2>/dev/null | head -1)
+python3 "$JJ" whoami
 # → {"user_id": "...", "name": "...", "post_article_count": 336}
 ```
 
@@ -56,9 +60,10 @@ trailing `--confirm` it dry-runs. `--confirm` is honored **only as the last
 argument**. Always show the dry-run, get an explicit "yes", then re-run.
 
 ```sh
-python3 $JJ publish --title "标题" --content-file a.md                       # dry-run
-python3 $JJ publish --title "标题" --content-file a.md --draft-only --confirm   # private draft
-python3 $JJ publish --title "标题" --content-file a.md \
+JJ="$SKILL_DIR/scripts/juejin.py"; [ -f "$JJ" ] || JJ=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/juejin.py' 2>/dev/null | head -1)
+python3 "$JJ" publish --title "标题" --content-file a.md                       # dry-run
+python3 "$JJ" publish --title "标题" --content-file a.md --draft-only --confirm   # private draft
+python3 "$JJ" publish --title "标题" --content-file a.md \
     --category-id 6809637769959178254 --tag-ids 6809640407484334093 --confirm # PUBLIC
 ```
 

--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -37,10 +37,13 @@ after the user explicitly approves the exact target and content.
 
 ## CLI
 
-The skill ships a stdlib-only helper:
+The skill ships a stdlib-only helper. **Run this resolver at the top of every
+Bash block below** — each Bash call is a fresh shell, and `$SKILL_DIR` points at
+the LAST skill loaded this turn, so anchor on our own script:
 
 ```bash
-WX=$SKILL_DIR/scripts/personal_wechat.py
+WX="$SKILL_DIR/scripts/personal_wechat.py"; [ -f "$WX" ] || WX=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/personal_wechat.py' 2>/dev/null | head -1)
+[ -f "$WX" ] || { echo "personal-wechat script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 ```
 
 ## Verify Connection First

--- a/skills/substack/SKILL.md
+++ b/skills/substack/SKILL.md
@@ -34,15 +34,19 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/substack.py`](scripts/substack.py) — self-contained, stdlib only.
 
 ```sh
-SUB=$SKILL_DIR/scripts/substack.py
-python3 $SUB whoami                       # who is logged in + primary publication
-python3 $SUB articles --limit 20          # my published posts + stats
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+SUB="$SKILL_DIR/scripts/substack.py"; [ -f "$SUB" ] || SUB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/substack.py' 2>/dev/null | head -1)
+[ -f "$SUB" ] || { echo "substack script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$SUB" whoami                     # who is logged in + primary publication
+python3 "$SUB" articles --limit 20        # my published posts + stats
 ```
 
 ## Verify the connection first
 
 ```sh
-python3 $SUB whoami
+SUB="$SKILL_DIR/scripts/substack.py"; [ -f "$SUB" ] || SUB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/substack.py' 2>/dev/null | head -1)
+python3 "$SUB" whoami
 # → {"user_id": ..., "name": "...", "handle": "...", "publication": "...", "publication_url": "https://<sub>.substack.com"}
 ```
 
@@ -61,17 +65,18 @@ Without a trailing `--confirm` it dry-runs. `--confirm` is honored **only as the
 last argument**. Always show the dry-run, get an explicit "yes", then re-run.
 
 ```sh
+SUB="$SKILL_DIR/scripts/substack.py"; [ -f "$SUB" ] || SUB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/substack.py' 2>/dev/null | head -1)
 # dry-run (shows the plan, writes nothing)
-python3 $SUB publish --title "Title" --content-file post.md
+python3 "$SUB" publish --title "Title" --content-file post.md
 
 # private draft (visible only in the user's dashboard)
-python3 $SUB publish --title "Title" --content-file post.md --draft-only --confirm
+python3 "$SUB" publish --title "Title" --content-file post.md --draft-only --confirm
 
 # go LIVE on the web (does NOT email subscribers)
-python3 $SUB publish --title "Title" --content-file post.md --confirm
+python3 "$SUB" publish --title "Title" --content-file post.md --confirm
 
 # go LIVE and email subscribers (use only when the user explicitly asks)
-python3 $SUB publish --title "Title" --content-file post.md --send-email --confirm
+python3 "$SUB" publish --title "Title" --content-file post.md --send-email --confirm
 ```
 
 - `--draft-only` stops at a draft — **default to this** unless the user asked to

--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -34,7 +34,10 @@ The skill ships [`scripts/tg.py`](scripts/tg.py) — self-contained (the only th
 to re-create per turn, so a multi-step flow (dry-run → confirm) can't lose the helper between calls:
 
 ```sh
-TG="$SKILL_DIR/scripts/tg.py"
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block below).
+TG="$SKILL_DIR/scripts/tg.py"; [ -f "$TG" ] || TG=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/tg.py' 2>/dev/null | head -1)
+[ -f "$TG" ] || { echo "telegram script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 python3 "$TG" whoami
 ```
 

--- a/skills/tencentcloud-cls-alarm/SKILL.md
+++ b/skills/tencentcloud-cls-alarm/SKILL.md
@@ -27,23 +27,26 @@ CRUD on CLS alarm policies, notice groups, mute shields, and the alarm execution
 The skill ships [`scripts/cls_alarm.py`](scripts/cls_alarm.py) — wraps every alarm / notice / shield operation as a subcommand.
 
 ```bash
-A=$SKILL_DIR/scripts/cls_alarm.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+CLSA="$SKILL_DIR/scripts/cls_alarm.py"; [ -f "$CLSA" ] || CLSA=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/cls_alarm.py' 2>/dev/null | head -1)
+[ -f "$CLSA" ] || { echo "tencentcloud-cls-alarm script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
-python3 $A alarms                              # list policies
-python3 $A alarm <alarm-id>                    # full detail
-python3 $A alarm-disable <alarm-id>            # quick mute (Status=false)
-python3 $A alarm-enable  <alarm-id>
-python3 $A alarm-create --json /tmp/alarm.json --dry-run
-python3 $A alarm-modify <alarm-id> --condition '$1.cnt > 20'
-python3 $A alarm-delete <alarm-id> --yes       # destructive
+python3 "$CLSA" alarms                          # list policies
+python3 "$CLSA" alarm <alarm-id>                # full detail
+python3 "$CLSA" alarm-disable <alarm-id>        # quick mute (Status=false)
+python3 "$CLSA" alarm-enable  <alarm-id>
+python3 "$CLSA" alarm-create --json /tmp/alarm.json --dry-run
+python3 "$CLSA" alarm-modify <alarm-id> --condition '$1.cnt > 20'
+python3 "$CLSA" alarm-delete <alarm-id> --yes   # destructive
 
-python3 $A notices                             # notice groups
-python3 $A notice <notice-id>
+python3 "$CLSA" notices                         # notice groups
+python3 "$CLSA" notice <notice-id>
 
-python3 $A shields                             # mute rules
-python3 $A shield-create --notice-id <notice-id> --start $(date +%s) --end $(date -v+2H +%s) --type 1 --reason "deploy"
+python3 "$CLSA" shields                         # mute rules
+python3 "$CLSA" shield-create --notice-id <notice-id> --start $(date +%s) --end $(date -v+2H +%s) --type 1 --reason "deploy"
 
-python3 $A alarm-log --time 6h                 # firing history
+python3 "$CLSA" alarm-log --time 6h             # firing history
 ```
 
 For the rare schema field the CLI doesn't surface, fall through to the raw SDK examples below.

--- a/skills/tencentcloud-cls/SKILL.md
+++ b/skills/tencentcloud-cls/SKILL.md
@@ -26,7 +26,10 @@ Search and run CQL / SQL analytics over Tencent Cloud CLS log topics.
 The skill ships [`scripts/cls.py`](scripts/cls.py) — a self-contained CLI for the most common operations.
 
 ```bash
-CLS=$SKILL_DIR/scripts/cls.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+CLS="$SKILL_DIR/scripts/cls.py"; [ -f "$CLS" ] || CLS=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/cls.py' 2>/dev/null | head -1)
+[ -f "$CLS" ] || { echo "tencentcloud-cls script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 $CLS topics                                              # list topics
 python3 $CLS search --topic <topic-id> --query 'level:ERROR' --time 1h

--- a/skills/tencentcloud-cos/SKILL.md
+++ b/skills/tencentcloud-cos/SKILL.md
@@ -24,7 +24,10 @@ Manage Tencent Cloud COS buckets and objects via the official `cos-python-sdk-v5
 The skill ships [`scripts/cos.py`](scripts/cos.py) — a self-contained CLI that wraps every COS operation below. **Prefer this over hand-rolled SDK calls** when the user's request maps cleanly onto one of its subcommands; it's what the maintained code paths exercise.
 
 ```bash
-COS=$SKILL_DIR/scripts/cos.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+COS="$SKILL_DIR/scripts/cos.py"; [ -f "$COS" ] || COS=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/cos.py' 2>/dev/null | head -1)
+[ -f "$COS" ] || { echo "tencentcloud-cos script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 $COS buckets                                  # list all buckets
 python3 $COS ls mydata-1250000000 --prefix images/    # list objects

--- a/skills/tencentcloud-dns/SKILL.md
+++ b/skills/tencentcloud-dns/SKILL.md
@@ -26,7 +26,10 @@ Manage DNS records via the DNSPod API.
 The skill ships [`scripts/dns.py`](scripts/dns.py) — wraps every common DNSPod v3 operation.
 
 ```bash
-DNS=$SKILL_DIR/scripts/dns.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+DNS="$SKILL_DIR/scripts/dns.py"; [ -f "$DNS" ] || DNS=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/dns.py' 2>/dev/null | head -1)
+[ -f "$DNS" ] || { echo "tencentcloud-dns script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 $DNS domains                                       # list domains
 python3 $DNS list example.com                              # records on one domain

--- a/skills/tencentcloud-edgeone/SKILL.md
+++ b/skills/tencentcloud-edgeone/SKILL.md
@@ -25,7 +25,10 @@ Manage EdgeOne zones — purge cache, prefetch URLs, manage DNS records on the z
 The skill ships [`scripts/edgeone.py`](scripts/edgeone.py) — wraps zone discovery, purge / prefetch, task tracking, EdgeOne DNS records, and WAF inspection.
 
 ```bash
-EO=$SKILL_DIR/scripts/edgeone.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+EO="$SKILL_DIR/scripts/edgeone.py"; [ -f "$EO" ] || EO=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/edgeone.py' 2>/dev/null | head -1)
+[ -f "$EO" ] || { echo "tencentcloud-edgeone script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 $EO zones                                                  # list zones
 python3 $EO zone zone-xxxxxxxx                                     # one zone's details

--- a/skills/tencentcloud-tke/SKILL.md
+++ b/skills/tencentcloud-tke/SKILL.md
@@ -25,7 +25,10 @@ Manage TKE clusters and the workloads inside them.
 The skill ships [`scripts/tke.py`](scripts/tke.py) — wraps cluster discovery, kubeconfig retrieval, and the most common in-cluster operations.
 
 ```bash
-TKE=$SKILL_DIR/scripts/tke.py
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this at the top of every fresh-shell Bash block).
+TKE="$SKILL_DIR/scripts/tke.py"; [ -f "$TKE" ] || TKE=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/tke.py' 2>/dev/null | head -1)
+[ -f "$TKE" ] || { echo "tencentcloud-tke script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 $TKE clusters                                              # list clusters
 python3 $TKE cluster cls-xxxxxxxx                                  # one cluster's details

--- a/skills/weibo/SKILL.md
+++ b/skills/weibo/SKILL.md
@@ -37,9 +37,12 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/weibo.py`](scripts/weibo.py) — self-contained, stdlib only.
 
 ```sh
-WB=$SKILL_DIR/scripts/weibo.py
-python3 $WB whoami                       # who is logged in (+ counts)
-python3 $WB posts --limit 20             # my recent 微博 + engagement
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+WB="$SKILL_DIR/scripts/weibo.py"; [ -f "$WB" ] || WB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/weibo.py' 2>/dev/null | head -1)
+[ -f "$WB" ] || { echo "weibo script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$WB" whoami                     # who is logged in (+ counts)
+python3 "$WB" posts --limit 20           # my recent 微博 + engagement
 ```
 
 Engagement comes straight from 微博: `reposts_count` (转发), `comments_count`
@@ -48,7 +51,8 @@ Engagement comes straight from 微博: `reposts_count` (转发), `comments_count
 ## Verify the connection first
 
 ```sh
-python3 $WB whoami
+WB="$SKILL_DIR/scripts/weibo.py"; [ -f "$WB" ] || WB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/weibo.py' 2>/dev/null | head -1)
+python3 "$WB" whoami
 # → {"uid": "...", "name": "...", "statuses_count": ...}
 ```
 
@@ -62,8 +66,9 @@ Without a trailing `--confirm` it dry-runs. `--confirm` is honored **only as the
 last argument**. Always show the dry-run, get an explicit "yes", then re-run.
 
 ```sh
-python3 $WB post --content "你好，这是一条微博"            # dry-run
-python3 $WB post --content "你好，这是一条微博" --confirm   # PUBLIC 微博 (immediate)
+WB="$SKILL_DIR/scripts/weibo.py"; [ -f "$WB" ] || WB=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/weibo.py' 2>/dev/null | head -1)
+python3 "$WB" post --content "你好，这是一条微博"            # dry-run
+python3 "$WB" post --content "你好，这是一条微博" --confirm   # PUBLIC 微博 (immediate)
 ```
 
 - There is **no draft and no private mode** on 微博 — a confirmed post is

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -38,8 +38,11 @@ skill), then call the shipped CLI:
 
 ```sh
 python3 -c "import twikit" 2>/dev/null || pip install --user --quiet twikit 2>/dev/null || true
-X=$SKILL_DIR/scripts/x.py
-python3 $X whoami          # who is logged in
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script (re-run this setup at the top of every fresh-shell Bash block below).
+X="$SKILL_DIR/scripts/x.py"; [ -f "$X" ] || X=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/x.py' 2>/dev/null | head -1)
+[ -f "$X" ] || { echo "x script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$X" whoami          # who is logged in
 ```
 
 ## Read commands (run directly)


### PR DESCRIPTION
## What & why

Follow-up to the zhihu fix ([#551](https://github.com/AceDataCloud/Skills/pull/551)). Same root cause, applied uniformly to the **16 other skills** that shared the fragile pattern.

The aichat2 sandbox exposes a single `$SKILL_DIR` env var = the **last** skill loaded in a turn. Every skill documented `VAR=$SKILL_DIR/scripts/<x>.py`, so when two skills load together in one turn, `$SKILL_DIR` points at the wrong skill and `python3 $VAR …` fails `No such file or directory` (the exact failure traced in studio conv `ad9ce5de`). Any two co-loaded skills could trigger it — e.g. a "publish to Zhihu + CSDN + Juejin" request.

## Fix — self-healing resolver, anchored on each skill's own unique script

```sh
VAR="$SKILL_DIR/scripts/<x>.py"; [ -f "$VAR" ] || VAR=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/<x>.py' 2>/dev/null | head -1)
[ -f "$VAR" ] || { echo "<skill> script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
```

Applied to: **acedatacloud, bilibili, bluesky, csdn, didi-ride, juejin, personal-wechat, substack, telegram, weibo, x**, and **tencentcloud-{cls, cls-alarm, cos, dns, edgeone, tke}**.

**Placement follows each skill's structure** (the invariant — no raw `$SKILL_DIR` resolution — is uniform):
- **Publishing skills with a few functional blocks** (bilibili, csdn, juejin, weibo, substack) → resolver repeated at the top of each `sh` block so every block is self-contained; `$VAR` usages quoted.
- **Skills with one big block or many command blocks / tables** (acedatacloud, telegram, didi-ride, personal-wechat, bluesky, x, all tencentcloud-*) → the setup line is hardened + an explicit "re-run at the top of every Bash block" instruction; the block that defines the var is self-contained.

`tencentcloud-cls-alarm`'s single-letter var `A` was renamed to `CLSA`.

**`medium` is intentionally excluded** — another branch (`fix/medium-markups-tables-xsrf`) owns `skills/medium/` and would conflict; it should get the same one-line change there.

## Validation (WSL, simulating the sandbox layout)

- **28/28** resolver lines recover to the correct skill when `$SKILL_DIR` points at a *wrong* skill or is empty, and reject a non-skill `scripts/x.py` decoy under `/tmp`.
- **18/18** guard lines parse (`bash -n`).
- All markdown fences balanced; anchors cross-checked against the real `scripts/<x>.py` in every skill; no command/semantic changes (only path resolution + quoting).

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex not installed on this host).

**Round 1 — `VERDICT: CHANGES SUGGESTED`** (anchors all verified correct, no collisions, no markdown breakage, medium confirmed untouched):
1. **HIGH — quoting inconsistency** (utility skills use unquoted `python3 $VAR`). **Partially fixed + rebutted.** Publishing skills (and cls-alarm, rewritten for the rename) quote. For the remaining single-block utility skills I rebut full quoting: the var is *defined* quoted, it is assigned and used within the **same** Bash block (same shell), and aichat2 sandbox skill paths (`/tmp/sessions/<uuid>/skills/<slug>/scripts/`) never contain spaces — so `python3 $VAR` cannot word-split. Quoting ~100 in-block usages is disproportionate for zero runtime effect.
2. **MED — "re-run every block" note not visually reinforced.** **Rebutted.** The block that defines the var is self-contained (resolver + guard), and downstream blocks are preceded by an explicit "re-run at the top of every Bash block" instruction (the standard CLI-doc idiom). Per-block prepend across a 13-block skill (personal-wechat) and table-based skills (telegram) is disproportionate; few-block publishing skills already got per-block resolvers.
3. **MED — generic var `A` in cls-alarm.** **Fixed** → renamed to `CLSA`.
4. **LOW — `exit 1` if a block were sourced.** **Rebutted.** aichat2 runs each Bash tool call in a fresh, non-sourced subshell, so `exit 1` ends only that command.

No open defects remain (findings are either fixed or rebutted with a concrete reason); converged.
