### PR TITLE
fix(medium): self-heal script path when SKILL_DIR points at another loaded skill

### DIFF
--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -34,16 +34,20 @@ The connector injects the cookie jar as an env var:
 The skill ships [`scripts/medium.py`](scripts/medium.py) — self-contained, stdlib only.
 
 ```sh
-MED=$SKILL_DIR/scripts/medium.py
-python3 $MED whoami                       # who is logged in
-python3 $MED articles --limit 20          # my posts + clap/response stats
-python3 $MED article <post-id>            # one post's details
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our own
+# script, and re-run this at the top of every Bash block (fresh shell each time).
+MED="$SKILL_DIR/scripts/medium.py"; [ -f "$MED" ] || MED=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/medium.py' 2>/dev/null | head -1)
+[ -f "$MED" ] || { echo "medium script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$MED" whoami                     # who is logged in
+python3 "$MED" articles --limit 20        # my posts + clap/response stats
+python3 "$MED" article <post-id>          # one post's details
 ```
 
 ## Verify the connection first
 
 ```sh
-python3 $MED whoami
+MED="$SKILL_DIR/scripts/medium.py"; [ -f "$MED" ] || MED=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/medium.py' 2>/dev/null | head -1)
+python3 "$MED" whoami
 # → {"user_id": "...", "name": "...", "username": "..."}
 ```
 
@@ -62,9 +66,10 @@ Without a trailing `--confirm` it dry-runs. `--confirm` is honored **only as the
 last argument**. Always show the dry-run, get an explicit "yes", then re-run.
 
 ```sh
-python3 $MED publish --title "Title" --content-file a.md                       # dry-run
-python3 $MED publish --title "Title" --content-file a.md --draft-only --confirm   # private draft
-python3 $MED publish --title "Title" --content-file a.md --confirm                # PUBLIC story
+MED="$SKILL_DIR/scripts/medium.py"; [ -f "$MED" ] || MED=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/medium.py' 2>/dev/null | head -1)
+python3 "$MED" publish --title "Title" --content-file a.md                       # dry-run
+python3 "$MED" publish --title "Title" --content-file a.md --draft-only --confirm   # private draft
+python3 "$MED" publish --title "Title" --content-file a.md --confirm                # PUBLIC story
 ```
 
 Publishing is Medium's multi-step editor flow (new-story → write deltas →


### PR DESCRIPTION
## What & why

Final piece of the skills-wide `$SKILL_DIR` hardening ([#551](https://github.com/AceDataCloud/Skills/pull/551) zhihu, [#553](https://github.com/AceDataCloud/Skills/pull/553) the other 16). `medium` was the one skill **excluded** from #553 because branch `fix/medium-markups-tables-xsrf` ([#525](https://github.com/AceDataCloud/Skills/pull/525)) owned `skills/medium/` at the time and would have conflicted. #525 has since merged, so this applies the identical self-healing resolver to medium.

Same root cause: aichat2 exposes a single `$SKILL_DIR` = the **last** skill loaded in a turn, so `MED=$SKILL_DIR/scripts/medium.py` resolves into the wrong skill's dir when another skill co-loads and `python3 $MED …` fails `No such file or directory`.

## Fix

Per-block resolver + quoted usages, matching medium's publishing-skill siblings (csdn/juejin/substack):

```sh
MED="$SKILL_DIR/scripts/medium.py"; [ -f "$MED" ] || MED=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/medium.py' 2>/dev/null | head -1)
[ -f "$MED" ] || { echo "medium script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
```

## Validation

WSL (simulating the sandbox layout): wrong-dir recovery ✓, empty-`$SKILL_DIR` recovery ✓, happy-path unchanged ✓. Fence parity matches origin/main (unchanged). 1 file, +13/−8, resolver-only (no command/semantic changes).

## 🤖 对抗评审

Mechanical replication of the resolver pattern already reviewed and merged in **#553** (which ran 2 rounds and converged `VERDICT: CLEAN`, with the 4 findings fixed/rebutted there). This is a single-file, resolver-only change identical in shape to csdn/juejin/substack — no new logic. `VERDICT: CLEAN`.
