### PR TITLE
Clarify X connector transaction-id drift

### DIFF
--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -103,8 +103,9 @@ python3 $X delete --id 123456 --confirm                        # delete one of M
 - **Not E2E-verified** (see the warning above) — expect to validate the first run.
 - **twikit is a scraper of X's non-public API.** It can break when X changes its
   internal endpoints. A `Couldn't get KEY_BYTE indices` / transaction-id error
-  means twikit needs upgrading: `pip install --user -U twikit`. An auth error
-  means the cookie expired → reconnect.
+  means twikit's transaction-id bootstrap is currently broken against X; do NOT
+  ask the user to reconnect cookies for that error. Report it as upstream drift
+  and retry only after the twikit/X compatibility issue is fixed.
 - **ToS / rate-limit / ban risk.** This acts through the web API, not the
   official API — high-frequency automation can get the account rate-limited or
   suspended. Keep volume human-like.

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -405,12 +405,17 @@ def main() -> None:
     except Exception as e:
         # twikit scrapes X's non-public API; a bare error here usually means an
         # expired cookie OR that X changed its internal endpoints and twikit
-        # needs upgrading (e.g. "Couldn't get KEY_BYTE indices" = transaction-id
-        # bootstrap drift → `pip install --user -U twikit`).
+        # needs a compatibility fix.
+        if "Couldn't get KEY_BYTE indices" in str(e):
+            die(
+                "X request failed because twikit cannot derive X's current "
+                "transaction-id keys (`Couldn't get KEY_BYTE indices`). This is "
+                "upstream drift in X's internal web API, not a missing/expired "
+                "cookie. Retry after twikit/X compatibility is fixed."
+            )
         die(f"X request failed ({type(e).__name__}: {e}). Likely an expired "
             f"cookie — reconnect at https://auth.acedata.cloud/user/connections "
-            f"— or twikit drift vs X's internal API (try `pip install --user -U "
-            f"twikit`).")
+            f"— or twikit drift vs X's internal API.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Clarify the verified X connector failure mode: `Couldn't get KEY_BYTE indices` is twikit/X transaction-id drift, not a missing or expired X cookie.
- Remove misleading remediation that `pip install -U twikit` or reconnecting cookies fixes this specific error.

## Root Cause Evidence
- Reported conversation `f892ad8b-e332-4ee5-a2c9-cddd3501cc09` completed with tools `load_skill` + `Bash`; no 5xx.
- `chat: engine ready` for that conversation included `X_COOKIES`, so the connector was connected and credentials were injected.
- Temporary in-cluster E2E Job fetched the same user's X BYOC connection and confirmed: `cookie_count=12`, `has_auth_token=true`, `has_ct0=true`.
- The E2E failed at `await client.user()` with `Exception: Couldn't get KEY_BYTE indices`.
- Re-running the same E2E with twikit GitHub `main` produced the same `Couldn't get KEY_BYTE indices`, so `pip install -U twikit` is not currently a fix.

## Validation
- `python -m py_compile .worktrees/Skills-x-transaction-drift/skills/x/scripts/x.py`
- `python .worktrees/Skills-x-transaction-drift/skills/x/scripts/x.py post --text "dry run only"`
- VS Code diagnostics: no errors in `skills/x/SKILL.md` or `skills/x/scripts/x.py`

## 🤖 对抗评审
- Explore read-only adversarial review: VERDICT: CLEAN.
- It checked wording, exception ordering, false-positive risk, and scope. No blocking issues found.