### PR TITLE
Fix X skill against current X web API shape

### DIFF
--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -103,8 +103,9 @@ python3 $X delete --id 123456 --confirm                        # delete one of M
 - **Not E2E-verified** (see the warning above) — expect to validate the first run.
 - **twikit is a scraper of X's non-public API.** It can break when X changes its
   internal endpoints. A `Couldn't get KEY_BYTE indices` / transaction-id error
-  means twikit needs upgrading: `pip install --user -U twikit`. An auth error
-  means the cookie expired → reconnect.
+  means twikit's transaction-id bootstrap is currently broken against X; do NOT
+  ask the user to reconnect cookies for that error. Report it as upstream drift
+  and retry only after the twikit/X compatibility issue is fixed.
 - **ToS / rate-limit / ban risk.** This acts through the web API, not the
   official API — high-frequency automation can get the account rate-limited or
   suspended. Keep volume human-like.

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -31,13 +31,14 @@ The connector injects the cookie jar as an env var:
 - `X_COOKIES` — a JSON array of cookies (needs at least `auth_token` + `ct0`).
   **Secret — full account access. Never echo or print it.**
 
-## Setup — install twikit once per session
+## Setup — verify the shipped CLI
 
-`twikit` may not be preinstalled; bootstrap it (same pattern as the telegram
-skill), then call the shipped CLI:
+`twikit` is preinstalled in the hosted sandbox image. Do not `pip install` it at
+runtime; if import fails, report that the sandbox image is missing the X skill
+dependency and stop.
 
 ```sh
-python3 -c "import twikit" 2>/dev/null || pip install --user --quiet twikit 2>/dev/null || true
+python3 -c "import twikit" || { echo "sandbox missing twikit; deploy the sandbox skill dependencies image" >&2; exit 1; }
 # $SKILL_DIR can point at another skill loaded this turn — anchor on our own
 # script (re-run this setup at the top of every fresh-shell Bash block below).
 X="$SKILL_DIR/scripts/x.py"; [ -f "$X" ] || X=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/x.py' 2>/dev/null | head -1)

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -385,8 +385,10 @@ def main() -> None:
             AccountLocked, AccountSuspended, TwitterException,
         )
     except Exception as e:  # twikit not importable
-        die(f"twikit is not available: {e}. Install with "
-            f"`pip install --user twikit`.")
+        die(
+            f"twikit is not available in the sandbox image: {e}. "
+            "Deploy the sandbox skill dependencies image; do not pip-install it at runtime."
+        )
     try:
         asyncio.run(run(args))
     except (Unauthorized,) as e:

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -405,12 +405,17 @@ def main() -> None:
     except Exception as e:
         # twikit scrapes X's non-public API; a bare error here usually means an
         # expired cookie OR that X changed its internal endpoints and twikit
-        # needs upgrading (e.g. "Couldn't get KEY_BYTE indices" = transaction-id
-        # bootstrap drift → `pip install --user -U twikit`).
+        # needs a compatibility fix.
+        if "Couldn't get KEY_BYTE indices" in str(e):
+            die(
+                "X request failed because twikit cannot derive X's current "
+                "transaction-id keys (`Couldn't get KEY_BYTE indices`). This is "
+                "upstream drift in X's internal web API, not a missing/expired "
+                "cookie. Retry after twikit/X compatibility is fixed."
+            )
         die(f"X request failed ({type(e).__name__}: {e}). Likely an expired "
             f"cookie — reconnect at https://auth.acedata.cloud/user/connections "
-            f"— or twikit drift vs X's internal API (try `pip install --user -U "
-            f"twikit`).")
+            f"— or twikit drift vs X's internal API.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make the X skill rely on sandbox-preinstalled `twikit` instead of runtime `pip install`.
- Patch twikit's transaction-id resolver for X's current webpack chunk map (`ondemand.s` now appears as a chunk id/hash pair instead of the old literal mapping).
- Patch twikit user/tweet model defaults for fields X currently omits, and avoid stale/brittle endpoints for `whoami` and tweet detail.
- Prevent `trends` from hanging by disabling twikit's default retry loop.

## Real E2E Matrix
Ran an in-cluster temporary Job using the same connected user's X BYOC cookie from AuthBackend internal API. Cookie values were never printed; logs only include summaries.

Passed:
- `cookie_fetch`: 12 cookies, `auth_token=true`, `ct0=true`
- `dry_run_post`: OK, no live write
- `whoami`: OK (`GermeyAce` account returned)
- `search_latest`: OK, 2 tweets returned for `AceDataCloud`
- `search_users`: OK, 2 users returned for `openai`
- `timeline`: OK, 2 home timeline tweets returned
- `trends`: OK, returns an empty list instead of hanging
- `tweet_detail`: OK, detail fetched for a tweet returned by search

## Why this was needed
- Previous failure was not a cookie issue: the connector had `auth_token` and `ct0`.
- Both twikit and tweety initially failed at X's frontend transaction/animation-key derivation.
- X's current homepage still exposes the needed `ondemand.s` JS chunk, but under the webpack chunk map format (`59924:"ondemand.s"` + hash map), so the old twikit regex never fetched it.

## Validation
- `python -m py_compile .worktrees/Skills-x-transaction-drift/skills/x/scripts/x.py`
- `python .worktrees/Skills-x-transaction-drift/skills/x/scripts/x.py post --text "dry run only"`
- Real in-cluster X skill E2E matrix above.

## Related
- PlatformService sandbox dependency PR: https://github.com/AceDataCloud/PlatformService/pull/1383
