### PR TITLE
fix(x): raise twikit HTTP timeout so image posts don't ReadTimeout

### DIFF
--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -98,6 +98,7 @@ def current_user_id_from_cookies() -> str | None:
 
 
 def make_client():
+    import httpx
     from twikit import Client
     patch_twikit_transaction_resolver()
     patch_twikit_model_defaults()
@@ -107,7 +108,12 @@ def make_client():
         or os.environ.get("ALL_PROXY") or os.environ.get("all_proxy")
         or None
     )
-    client = Client("en-US", proxy=proxy, user_agent=UA)
+    # twikit builds its httpx.AsyncClient with httpx's 5s default timeout, which
+    # trips a ReadTimeout on media uploads (INIT/APPEND/FINALIZE + status poll)
+    # from datacenter egress — a text-only tweet is one fast call and squeaks
+    # under 5s, but --media does not. Give network ops generous headroom.
+    timeout = httpx.Timeout(60.0, connect=15.0)
+    client = Client("en-US", proxy=proxy, user_agent=UA, timeout=timeout)
     client.set_cookies(load_cookie_dict())
     return client
 
@@ -494,6 +500,14 @@ def main() -> None:
         # twikit scrapes X's non-public API; a bare error here usually means an
         # expired cookie OR that X changed its internal endpoints and twikit
         # needs a compatibility fix.
+        import httpx
+        if isinstance(e, httpx.TimeoutException):
+            die(
+                "X request timed out talking to X (network was slow, not an "
+                "auth problem) — this is transient, retry the same command. "
+                "Timeouts are most common on --media because the image upload "
+                "is the slow leg; if it recurs, try a smaller image."
+            )
         if "Couldn't get KEY_BYTE indices" in str(e):
             die(
                 "X request failed because twikit cannot derive X's current "


### PR DESCRIPTION
## Problem

A user asked Studio to publish a tweet **with an image** (`x post --media <png> --confirm`, conversation `651f231a-…`). It failed with:

> 发布失败：X CLI 在确认发帖时返回 `ReadTimeout` … 建议先重新连接 X

The skill told the user their **cookie expired** — but the cookie was fine. Reconnecting didn't help; the retry hit the same timeout.

## Root cause

`twikit.Client.__init__` does `self.http = AsyncClient(proxy=proxy, **kwargs)`. With no `timeout` kwarg, httpx falls back to its **5-second default**. A text-only tweet is a single fast GraphQL call and squeaks under 5s (which is why plain posts worked), but a `--media` post does **INIT → APPEND (upload the image) → FINALIZE → STATUS poll → create_tweet** — that exceeds 5s from datacenter egress → `httpx.ReadTimeout`. The bare `except Exception` then misclassified it as an expired cookie, sending the user on a pointless reconnect.

Measured: the 1.2 MB image upload takes ~4.2s even over a fast proxy — right on the 5s edge; from the HK sandbox to X's upload endpoint it tips over.

## Fix

- `make_client()`: pass `timeout=httpx.Timeout(60.0, connect=15.0)` to the twikit `Client` (kwarg flows straight through to `httpx.AsyncClient`). Media uploads now have headroom; still well under the model's 120s Bash timeout.
- `main()`: catch `httpx.TimeoutException` explicitly and surface it as a **transient 'retry the same command'** error instead of the misleading 'reconnect your cookie' message.

Only `skills/x/scripts/x.py` changes (the `.agents/` and `.github/` copies are symlinks to `skills/`).

## Verification (real account, real sends)

Reproduced and fixed end-to-end against the live connected account (`@acedatacloud`), then deleted the test tweets:

- **Before:** text-only post ✅; media post ⏱️ ~4.2s upload, ReadTimeout at 5s.
- **After (fixed script):** live `--media` post succeeded **locally** *and* in **both production sandbox pods** (the HK datacenter where it originally failed). Text-only still works. `py_compile` OK.

## 🤖 对抗评审

Read-only adversarial review (Claude general-purpose subagent; Codex not needed for this scope) against twikit's actual source:

> Confirmed `timeout=` is accepted via `**kwargs` and forwarded verbatim to `httpx.AsyncClient` with no keyword collision (`user_agent` is a named param, not swept into kwargs; twikit never sets its own `timeout`). `httpx` is guaranteed importable (hard twikit dep, imported right above). `httpx.Timeout(60.0, connect=15.0)` → read/write/pool=60s, connect=15s. `isinstance(e, httpx.TimeoutException)` correctly precedes the KEY_BYTE / generic-fallback branches and catches Read/Connect/Write/PoolTimeout. `--confirm` gating (dry-run before `make_client`) untouched. No X_COOKIES leak. Timeout genuinely governs the upload legs (verified live on prod pods).
>
> NITs (non-blocking): 60s is per-leg not a total budget; 60s now applies to every command (intentional — the 5s default *was* the bug); duplicate lazy `import httpx` (harmless, matches file style).
>
> **VERDICT: CLEAN**