### PR TITLE
fix(hashnode): gql-beta endpoint + Bearer auth + Pro-plan gating

### DIFF
--- a/skills/hashnode/SKILL.md
+++ b/skills/hashnode/SKILL.md
@@ -16,29 +16,41 @@ metadata:
   version: "1.0"
 ---
 
-Call the **Hashnode Public GraphQL API** with `curl + jq`. The user's Personal
-Access Token is in `$HASHNODE_TOKEN`. Single endpoint: `https://gql.hashnode.com`
+Call the **Hashnode GraphQL API** with `curl + jq`. The user's Personal Access
+Token is in `$HASHNODE_TOKEN`. Single endpoint: `https://gql-beta.hashnode.com`
 (always `POST` a JSON body `{query, variables}`).
+
+> The old `https://gql.hashnode.com` host is **deprecated** — it now 301-redirects
+> to a changelog page and returns HTML, not JSON. Always use `gql-beta.hashnode.com`.
 
 Every request needs these headers:
 
 ```
-Authorization: $HASHNODE_TOKEN      # raw token — NO "Bearer " prefix
+Authorization: Bearer $HASHNODE_TOKEN
 Content-Type: application/json
 ```
 
 GraphQL always returns HTTP `200`; real failures live in the JSON `errors`
-array — always inspect it and show it verbatim. An `errors` entry mentioning
-`Unauthorized` / `not authenticated` means the token is invalid → the user must
-re-connect the Hashnode connector.
+array — always inspect it and show it verbatim. Two error cases matter:
+
+- `Unauthorized` / `not authenticated` → the token is invalid → the user must
+  re-connect the Hashnode connector.
+- `extensions.code == "FORBIDDEN"` with a message like *"Publication does not have
+  an active Pro plan"* → this is **not** a token problem. As of 2026-05-13 Hashnode
+  moved its API behind a paid plan: **every write mutation** (`publishPost`,
+  `createDraft`, `updatePost`) **and publication-scoped reads require the target
+  publication to be on [Hashnode Pro](https://hashnode.com/pro)**. Do NOT tell the
+  user to reconnect and do NOT retry in a loop — tell them the publication owner
+  must upgrade to Hashnode Pro (blog dashboard → Billing → Upgrade to Pro), after
+  which the API works immediately. Public reads (posts/feeds/users/tags) stay free.
 
 Helper — send a query/mutation (`$1` = query string, `$2` = variables JSON):
 
 ```bash
 gql() {
   jq -n --arg q "$1" --argjson v "${2:-null}" '{query:$q, variables:$v}' \
-  | curl -sS -X POST https://gql.hashnode.com \
-      -H "Authorization: $HASHNODE_TOKEN" \
+  | curl -sS -X POST https://gql-beta.hashnode.com \
+      -H "Authorization: Bearer $HASHNODE_TOKEN" \
       -H "Content-Type: application/json" \
       -d @-
 }
@@ -136,7 +148,15 @@ gql 'query GetPost($id: ObjectId!) { post(id: $id) { title url views reactionCou
 
 ## Gotchas
 
-- **No `Bearer` prefix** — the `Authorization` header carries the raw token.
+- **Endpoint is `https://gql-beta.hashnode.com`** — the old `gql.hashnode.com`
+  host is deprecated (301 → HTML changelog page, never valid GraphQL JSON).
+- **`Authorization: Bearer $HASHNODE_TOKEN`** — send the token with the `Bearer`
+  prefix (this is what Hashnode's own official skill uses).
+- **Pro plan required for writes** — since 2026-05-13, `publishPost` / `createDraft`
+  / `updatePost` and publication-scoped reads only work if the target publication
+  has an active **Hashnode Pro** plan; otherwise the call returns a `FORBIDDEN`
+  *"does not have an active Pro plan"* error. That is a billing state on the user's
+  blog, not something the skill or a reconnect can fix — surface it and stop.
 - **`publicationId` is mandatory** for publishing/drafting — never guess it, read
   it from the `me` query.
 - **`tags` is required on `publishPost`** — supply at least one `{name, slug}`;


### PR DESCRIPTION
## Problem

A user asked Studio to publish a marketing article to Hashnode (conversation `66cb30e1-…`). It failed at the very first step (fetching the account / publication id). The agent reported a `403 Forbidden` and told the user to reconnect the Hashnode connector — but the token was fine.

## Root cause (verified live against the real connected `@acedatacloud` account, from the production sandbox)

Two independent upstream changes:

1. **Endpoint deprecated.** The skill posted to `https://gql.hashnode.com`, which Hashnode has **retired** — it now **HTTP 301-redirects** to `hashnode.com/changelog/2026-05-13-graphql-api-paid-access` and returns **HTML, not GraphQL JSON**. Bare requests get Cloudflare `403 (error 1010)` / redirects, which is exactly the garbage the agent saw. The current endpoint is **`https://gql-beta.hashnode.com`** — there the `me` query returns `200` JSON with the account + publication.
2. **API is now paid.** As of **2026-05-13** Hashnode moved its GraphQL API behind **Hashnode Pro**. Every **write** (`publishPost`/`createDraft`/`updatePost`) and publication-scoped read now returns:
   > `{"errors":[{"message":"Publication does not have an active Pro plan. Upgrade in your dashboard to access this via the API.","extensions":{"code":"FORBIDDEN"}}]}`
   The `acedatacloud.hashnode.dev` publication is **not on Pro**, so publishing is blocked upstream regardless of the skill.

Both were cross-checked against Hashnode's **own official skill** (`github.com/Hashnode/gql-skill`), which uses `https://gql-beta.hashnode.com` + `Authorization: Bearer <PAT>` and documents the same Pro-gating.

## Fix (skill can only fix #1; #2 is a billing state on the user's blog)

- Endpoint `gql.hashnode.com` → **`gql-beta.hashnode.com`** (intro + `gql()` helper).
- Auth header → **`Authorization: Bearer $HASHNODE_TOKEN`** (matches the official skill; both raw + Bearer verified working on gql-beta, Bearer is more future-proof).
- Teach the agent to **distinguish the two failure modes**: `Unauthorized` → reconnect the token; `FORBIDDEN` *"no active Pro plan"* → the publication owner must **upgrade to Hashnode Pro** (`hashnode.com/pro`) — **do not reconnect, do not loop-retry**. Public reads stay free.
- Gotchas updated accordingly.

## Verification (live, production sandbox, real token)

| Call | Old `gql.hashnode.com` | New `gql-beta.hashnode.com` |
|---|---|---|
| `me { publications }` | 301 → HTML / CF 403 | **200 JSON** ✅ (`acedatacloud`, publication `6a4a0178…`) |
| `createDraft` (write) | 301 → HTML | **clean `FORBIDDEN` "no active Pro plan"** ✅ |

So the skill now reaches the API correctly and returns an **accurate, actionable** message. Actually publishing (with cover image, links, inline images — as in the user's reference draft) requires the `acedatacloud.hashnode.dev` publication to be on **Hashnode Pro**; until then the API refuses all writes by Hashnode's design.

## 🤖 对抗评审

Read-only adversarial review (Claude general-purpose subagent) against the live findings + Hashnode's official skill:

> No live use of the deprecated host remains (the two `gql.hashnode.com` mentions only describe the deprecation). `gql()` helper endpoint+Bearer consistent; every example mutation/query routes through it (no inline curl, no hardcoded old endpoint/raw-token). Pro-gating guidance accurate (writes + publication-scoped reads gated, public reads free), cites 2026-05-13 + `FORBIDDEN`, and explicitly forbids the original bug (reconnect-on-Pro-error / loop-retry). No `$HASHNODE_TOKEN` leak.
>
> NITs (non-blocking, pre-existing): authenticated `me { posts }` listing may also be Pro-gated; token passed via curl `-H` visible to `ps` (same as before).
>
> **VERDICT: CLEAN**