### PR TITLE
feat(hashnode): publish via cookie-authed editor API (no Pro required)

### DIFF
--- a/skills/hashnode/SKILL.md
+++ b/skills/hashnode/SKILL.md
@@ -1,171 +1,119 @@
 ---
 name: hashnode
-description: Publish, update and read blog posts on Hashnode via its GraphQL API. Use when the user mentions Hashnode, publishing a blog post to Hashnode, cross-posting an article to their Hashnode blog, saving a Hashnode draft, updating a published Hashnode post, or listing their Hashnode publications and posts.
+description: Publish, draft and read blog posts on the user's Hashnode blog using their own login cookies (BYOC) — no Hashnode Pro plan required. Use when the user mentions Hashnode, publishing/cross-posting an article to their Hashnode blog, saving a Hashnode draft, or listing their Hashnode publications.
 when_to_use: |
-  Trigger when the user wants to publish a Markdown article to their
-  Hashnode blog, save it as a draft, update a previously published
-  post, or list / inspect their own Hashnode publications and posts.
-  The connector stores a Hashnode Personal Access Token with full
-  account access — confirm before publishing publicly (you can save a
-  draft first with the createDraft mutation).
+  Trigger when the user wants to publish a Markdown article to their Hashnode
+  blog, save it as a private draft, or list their Hashnode publications. This
+  drives the user's REAL blog, so publishing is gated behind an explicit
+  confirmation (save a draft first if unsure).
 connections: [hashnode]
-allowed_tools: [Bash]
+allowed_tools: [Bash, publish_artifact]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "2.0"
 ---
 
-Call the **Hashnode GraphQL API** with `curl + jq`. The user's Personal Access
-Token is in `$HASHNODE_TOKEN`. Single endpoint: `https://gql-beta.hashnode.com`
-(always `POST` a JSON body `{query, variables}`).
+# hashnode — publish to your Hashnode blog via your own cookies (no Pro)
 
-> The old `https://gql.hashnode.com` host is **deprecated** — it now 301-redirects
-> to a changelog page and returns HTML, not JSON. Always use `gql-beta.hashnode.com`.
+Hashnode moved its **public GraphQL API behind a paid Pro plan** (2026-05-13), so
+a Personal Access Token can no longer publish for free. This skill instead drives
+the **same first-party REST API the Hashnode web editor uses**
+(`https://hashnode.com/api/...`), authenticated by the user's login **session
+cookie** — which is free and needs no Pro plan.
 
-Every request needs these headers:
+The connector injects the cookie jar as `HASHNODE_COOKIES` (a JSON array; the
+session cookie is `hashnode-session`). **Secret — full account access. Never echo
+or print it.**
 
-```
-Authorization: Bearer $HASHNODE_TOKEN
-Content-Type: application/json
-```
+> E2E-verified 2026-07-12 on a real connected blog: list publications, create +
+> save draft (title / subtitle / cover / tags / Markdown), publish, and delete —
+> all via cookie auth, no Pro.
 
-GraphQL always returns HTTP `200`; real failures live in the JSON `errors`
-array — always inspect it and show it verbatim. Two error cases matter:
+## Setup — anchor on our own script
 
-- `Unauthorized` / `not authenticated` → the token is invalid → the user must
-  re-connect the Hashnode connector.
-- `extensions.code == "FORBIDDEN"` with a message like *"Publication does not have
-  an active Pro plan"* → this is **not** a token problem. As of 2026-05-13 Hashnode
-  moved its API behind a paid plan: **every write mutation** (`publishPost`,
-  `createDraft`, `updatePost`) **and publication-scoped reads require the target
-  publication to be on [Hashnode Pro](https://hashnode.com/pro)**. Do NOT tell the
-  user to reconnect and do NOT retry in a loop — tell them the publication owner
-  must upgrade to Hashnode Pro (blog dashboard → Billing → Upgrade to Pro), after
-  which the API works immediately. Public reads (posts/feeds/users/tags) stay free.
-
-Helper — send a query/mutation (`$1` = query string, `$2` = variables JSON):
-
-```bash
-gql() {
-  jq -n --arg q "$1" --argjson v "${2:-null}" '{query:$q, variables:$v}' \
-  | curl -sS -X POST https://gql-beta.hashnode.com \
-      -H "Authorization: Bearer $HASHNODE_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d @-
-}
+```sh
+# $SKILL_DIR can point at another skill loaded this turn — anchor on our script.
+H="$SKILL_DIR/scripts/hashnode.py"; [ -f "$H" ] || H=$(find /tmp -maxdepth 8 -path '*/skills/*/hashnode/scripts/hashnode.py' 2>/dev/null | head -1)
+[ -f "$H" ] || { echo "hashnode script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$H" publications          # list the user's blogs (verifies the cookie)
 ```
 
-## Always start by confirming the token and finding the publication id
+On an auth error the cookie is expired — have the user reconnect at
+<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
 
-`publishPost` / `createDraft` need a `publicationId`. Fetch the account and its
-publications first (a user can have several blogs):
+## ⚠️ Non-Pro blogs are automoderated — write EDITORIAL, not ads
 
-```bash
-gql 'query { me { id username publications(first: 10) { edges { node { id title url } } } } }' \
-  | jq '{me: .data.me.username, publications: [.data.me.publications.edges[].node | {id, title, url}], errors: .errors}'
+This is the single most important rule. A **non-Pro** publication is subject to
+Hashnode **automoderation**: an overtly promotional post (hypey language,
+"free credits!!", the *same* CTA link repeated 3–4 times) is **auto-removed
+within seconds** — the publish call still returns success, but the live URL then
+404s. (Pro's one benefit here is "protection from automoderation removal".)
+
+To stay live, write a genuinely useful **how-to / guide** that happens to feature
+the product:
+
+- Educational framing and a concrete title (e.g. *"… (Beginner's Guide)"*).
+- At most a couple of **tasteful** links, not the same CTA repeated.
+- No "limited-time!! grab now!!" marketing voice.
+
+`publish` re-fetches the live URL after publishing and returns a `warning` if the
+post was moderated away — if you see that, rewrite it editorially and republish.
+
+## Read
+
+```sh
+python3 "$H" publications        # {publications:[{id,title,url}]}
 ```
 
-Pick the target blog's `id` (that is the `publicationId`). If the user has
-exactly one publication, use it; otherwise ask which blog to post to.
+## Save a private draft (safe, non-public)
 
-## Publish a post
-
-**Confirm with the user before publishing publicly.** If they are not sure, save
-a draft first (see below). `tags` is required — supply 1–5 tags, each as
-`{name, slug}` (slug lowercase, no spaces).
-
-```bash
-PUB_ID="PUBLICATION_ID"          # from the me query above
-TITLE="My title"
-BODY_MD="$(cat article.md)"      # full Markdown body
-
-VARS=$(jq -n --arg p "$PUB_ID" --arg t "$TITLE" --arg b "$BODY_MD" '{
-  input: {
-    publicationId: $p,
-    title: $t,
-    contentMarkdown: $b,
-    tags: [{name:"AI", slug:"ai"}, {name:"Web Development", slug:"web-development"}]
-  }
-}')
-
-gql 'mutation PublishPost($input: PublishPostInput!) {
-  publishPost(input: $input) { post { id slug url title } }
-}' "$VARS" | jq '{post: .data.publishPost.post, errors: .errors}'
+```sh
+python3 "$H" draft \
+  --title "My Title" \
+  --subtitle "Optional subtitle" \
+  --content-file article.md \
+  --cover "https://cdn.example.com/cover.jpg" \
+  --tags ai,apis
+# → {draft_id, editor_url}. Nothing is public yet.
 ```
 
-Useful optional `input` fields:
+- `--content-file` is the Markdown body (use a file for long posts; `--content`
+  for a short inline string). Inline **images** and **links** are just Markdown.
+- `--cover` sets the header/cover image (also used as the OG image).
+- `--tags` are comma-separated slugs (`ai,apis,web-development`); they're resolved
+  to real Hashnode tag ids automatically (up to 5).
+- `--publication <id>` is only needed if the account has more than one blog.
 
-- `subtitle` — post subtitle.
-- `slug` — custom URL slug (otherwise derived from the title).
-- `canonicalUrl` / `originalArticleURL` — when cross-posting, point SEO back to
-  the original source. Set this whenever the same article also lives elsewhere.
-- `coverImageOptions: { coverImageURL: "https://..." }` — cover image.
-- `publishedAt` — ISO-8601 timestamp to backdate; `disableComments` etc. live
-  under `settings`.
+## Publish — GATED (dry-run unless trailing `--confirm`)
 
-## Save a draft (safe, non-public)
-
-Use this when the user has not explicitly approved public publishing:
-
-```bash
-VARS=$(jq -n --arg p "$PUB_ID" --arg t "$TITLE" --arg b "$BODY_MD" '{
-  input: { publicationId: $p, title: $t, contentMarkdown: $b }
-}')
-
-gql 'mutation CreateDraft($input: CreateDraftInput!) {
-  createDraft(input: $input) { draft { id slug title } }
-}' "$VARS" | jq '{draft: .data.createDraft.draft, errors: .errors}'
+```sh
+python3 "$H" publish --title "My Title" --content-file article.md --cover "https://…" --tags ai,apis          # dry-run
+python3 "$H" publish --title "My Title" --content-file article.md --cover "https://…" --tags ai,apis --confirm # LIVE
+# → {ok, url}  (or {ok:false, warning:"…automoderation removed…"} — rewrite editorially)
 ```
 
-## Update a published post
+A confirmed `publish` is **immediately public** on the user's real blog. Always
+show the final title + body, get an explicit "yes", then run with `--confirm` as
+the **last** argument.
 
-`updatePost` needs the post `id` (from `publishPost`, or the list query below):
+## Delete a draft or post — GATED
 
-```bash
-VARS=$(jq -n --arg id "POST_ID" --arg b "$(cat article.md)" '{
-  input: { id: $id, contentMarkdown: $b }
-}')
-
-gql 'mutation UpdatePost($input: UpdatePostInput!) {
-  updatePost(input: $input) { post { id url title } }
-}' "$VARS" | jq '{post: .data.updatePost.post, errors: .errors}'
-```
-
-## List / inspect my posts
-
-```bash
-gql 'query { me { posts(pageSize: 20, page: 1) { nodes { id title slug url views reactionCount responseCount publishedAt } } } }' \
-  | jq '[.data.me.posts.nodes[] | {id, title, url, views, reactions: .reactionCount, responses: .responseCount}]'
-```
-
-Single post with full content + stats:
-
-```bash
-gql 'query GetPost($id: ObjectId!) { post(id: $id) { title url views reactionCount responseCount content { markdown } } }' \
-  "$(jq -n --arg id "POST_ID" '{id:$id}')" | jq '.data.post | {title, url, views, reactions: .reactionCount}'
+```sh
+python3 "$H" delete --id <draftOrPostId>            # dry-run
+python3 "$H" delete --id <draftOrPostId> --confirm  # delete
 ```
 
 ## Gotchas
 
-- **Endpoint is `https://gql-beta.hashnode.com`** — the old `gql.hashnode.com`
-  host is deprecated (301 → HTML changelog page, never valid GraphQL JSON).
-- **`Authorization: Bearer $HASHNODE_TOKEN`** — send the token with the `Bearer`
-  prefix (this is what Hashnode's own official skill uses).
-- **Pro plan required for writes** — since 2026-05-13, `publishPost` / `createDraft`
-  / `updatePost` and publication-scoped reads only work if the target publication
-  has an active **Hashnode Pro** plan; otherwise the call returns a `FORBIDDEN`
-  *"does not have an active Pro plan"* error. That is a billing state on the user's
-  blog, not something the skill or a reconnect can fix — surface it and stop.
-- **`publicationId` is mandatory** for publishing/drafting — never guess it, read
-  it from the `me` query.
-- **`tags` is required on `publishPost`** — supply at least one `{name, slug}`;
-  slug must be lowercase with hyphens (e.g. `machine-learning`).
-- **`errors` on HTTP 200** — GraphQL reports failures in the `errors` array, not
-  via status codes; always surface them.
-- **Idempotency** — re-running `publishPost` creates a *new* post each time; to
-  change an existing one use `updatePost` with its `id`.
-
+- **No Pro, no PAT.** This uses the cookie-authed `hashnode.com/api/*` editor API,
+  not `gql-beta.hashnode.com` (which requires a paid Pro plan).
+- **Automoderation** (above) is the main failure mode on free blogs — keep it
+  editorial.
+- **This is the user's real blog.** Confirm before any publish/delete.
+- **Never print `HASHNODE_COOKIES`** — it is full account access.
+- **First-party internal API** — it can change when Hashnode updates the editor;
+  if a call starts returning HTML/404 unexpectedly, report it as upstream drift.
 
 ## Record the output
 

--- a/skills/hashnode/scripts/hashnode.py
+++ b/skills/hashnode/scripts/hashnode.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+hashnode — read & publish on Hashnode with the user's own login cookies (BYOC).
+Standard-library only (urllib), no third-party deps.
+
+Hashnode moved its **public GraphQL API behind a paid Pro plan** (2026-05-13), so
+this skill does NOT use ``gql-beta.hashnode.com`` / a Personal Access Token.
+Instead it drives the **same first-party REST endpoints the web editor uses**
+(``https://hashnode.com/api/...``), authenticated by the login session cookie —
+which is free and needs no Pro plan.
+
+The connector injects the cookie jar as a JSON env var ``HASHNODE_COOKIES`` (a
+JSON list of cookie dicts; the session cookie is ``hashnode-session``). It is
+full account access — NEVER echo or print it.
+
+⚠️ Non-Pro publications are subject to Hashnode **automoderation**: overtly
+promotional posts (hypey language, repeated identical CTA links, "free credits!!")
+are auto-removed within seconds of publishing, so the post 404s even though the
+publish call returned success. Write **editorial / how-to** content (a helpful
+guide that happens to feature the product, with at most a couple of tasteful
+links) and it stays live. ``publish`` re-fetches the live URL and warns if the
+post was moderated away.
+
+Read commands run directly. ``publish`` / ``delete`` are GATED by a trailing
+``--confirm`` (honored only as the LAST arg). ``draft`` saves a private draft.
+
+Examples:
+  python3 hashnode.py publications
+  python3 hashnode.py draft   --title T --content-file a.md --cover https://x/y.jpg --tags ai,apis
+  python3 hashnode.py publish --title T --content-file a.md --cover https://x/y.jpg --tags ai,apis --confirm
+  python3 hashnode.py delete  --id <draftOrPostId> --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+BASE = "https://hashnode.com"
+
+_RAW = sys.argv[1:]
+# --confirm is honored ONLY as the last token, so body text containing
+# "--confirm" can never silently trigger a write.
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+# State-changing commands — dry-run unless the invocation ends with --confirm.
+GATED = {"publish", "delete"}
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar ──────────────────────────────────────────────────────
+
+def load_cookies() -> list:
+    raw = os.environ.get("HASHNODE_COOKIES")
+    if not raw:
+        die("HASHNODE_COOKIES is not set — connect Hashnode at "
+            "https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"HASHNODE_COOKIES is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"HASHNODE_COOKIES must be a JSON list of cookies, got {type(jar).__name__}")
+    if not any(c.get("name") == "hashnode-session" for c in jar):
+        die("HASHNODE_COOKIES is missing the 'hashnode-session' cookie — re-capture "
+            "on hashnode.com with the ACE extension, then reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            # A domain-less cookie only rides along when at least one scoped
+            # cookie already matched this host (never leak it to a stray host).
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+# ── HTTP ────────────────────────────────────────────────────────────
+
+def request(method, path, jar, *, body=None):
+    url = BASE + path
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "application/json",
+        "Origin": BASE,
+        "Referer": BASE + "/",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host, so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def api(method, path, jar, *, body=None, _retried=False):
+    status, text = request(method, path, jar, body=body)
+    # Hashnode sits behind Cloudflare, which intermittently 403/429s an
+    # otherwise valid session; retry idempotent GETs once. Never replay a
+    # write (POST/PUT/DELETE) — it could duplicate a publish.
+    if status in (403, 429) and method == "GET" and not _retried:
+        time.sleep(1.5)
+        return api(method, path, jar, body=body, _retried=True)
+    if status in (401, 403):
+        die(f"auth failed ({status}) on {path} — cookie likely expired. "
+            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+    # A hashnode.com/api path that 404s with an HTML body means the route/id is
+    # wrong; a JSON {success:false} is a real API error.
+    stripped = text.lstrip()
+    if stripped.startswith("<"):
+        die(f"unexpected non-JSON ({status}) from {path} — the route or id is "
+            f"likely wrong.")
+    try:
+        d = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"non-JSON response ({status}) from {path}: {text[:300]}")
+    if isinstance(d, dict) and d.get("success") is False:
+        die(f"Hashnode API error ({status}) on {path}: {d.get('error')}")
+    return d
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+def resolve_publication(jar, wanted: str | None) -> dict:
+    d = api("GET", "/api/publications", jar)
+    pubs = d.get("publications") or []
+    if not pubs:
+        die("no publications on this account — create a blog on hashnode.com first.")
+    if wanted:
+        for p in pubs:
+            if wanted in (p.get("_id"), p.get("title"), p.get("displayTitle")):
+                return p
+        die(f"publication {wanted!r} not found; have: "
+            + ", ".join(f'{p.get("title")}({p.get("_id")})' for p in pubs))
+    if len(pubs) > 1:
+        die("multiple publications — pass --publication <id>. Have: "
+            + ", ".join(f'{p.get("title")}({p.get("_id")})' for p in pubs))
+    return pubs[0]
+
+
+def resolve_tags(jar, slugs_csv: str | None) -> list:
+    if not slugs_csv:
+        return []
+    tags = []
+    for slug in [s.strip() for s in slugs_csv.split(",") if s.strip()]:
+        d = api("GET", f"/api/tags/search?q={urllib.parse.quote(slug)}", jar)
+        cands = d.get("tags") or []
+        pick = next((t for t in cands if t.get("slug") == slug), None) \
+            or (max(cands, key=lambda t: t.get("numPosts", 0)) if cands else None)
+        if pick:
+            tags.append({"_id": pick["_id"], "name": pick["name"], "slug": pick["slug"]})
+    return tags[:5]
+
+
+def read_content(args) -> str:
+    if args.content_file:
+        if not os.path.isfile(args.content_file):
+            die(f"content file not found: {args.content_file}")
+        with open(args.content_file, encoding="utf-8") as fh:
+            return fh.read()
+    if args.content:
+        return args.content
+    die("provide --content-file or --content")
+
+
+def build_save(args, pub_id, jar) -> dict:
+    body = {
+        "title": (args.title or "").strip(),
+        "contentMarkdown": read_content(args),
+        "publicationId": pub_id,
+    }
+    if not body["title"]:
+        die("provide --title")
+    if args.subtitle:
+        body["subtitle"] = args.subtitle
+    if args.cover:
+        body["coverImage"] = args.cover
+        body["ogImage"] = args.cover
+    if args.slug:
+        body["slug"] = args.slug
+    tags = resolve_tags(jar, args.tags)
+    if tags:
+        body["tags"] = tags
+    return body
+
+
+def create_and_save(args, jar) -> tuple[str, dict]:
+    pub = resolve_publication(jar, args.publication)
+    d = api("POST", "/api/drafts", jar, body={"publicationId": pub["_id"]})
+    did = d.get("draftId")
+    if not did:
+        die(f"draft creation returned no draftId: {d}")
+    save = build_save(args, pub["_id"], jar)
+    api("PUT", f"/api/drafts/{did}", jar, body=save)
+    return did, pub
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def cmd_publications(jar, _args):
+    d = api("GET", "/api/publications", jar)
+    out({"publications": [
+        {"id": p.get("_id"), "title": p.get("title"),
+         "url": p.get("url") or p.get("domain")} for p in d.get("publications") or []]})
+
+
+def cmd_draft(jar, args):
+    did, pub = create_and_save(args, jar)
+    out({"ok": True, "draft_id": did, "publication": pub.get("title"),
+         "editor_url": f"https://hashnode.com/draft/{did}",
+         "note": "Private draft saved. Review it, then run `publish ... --confirm` to go live."})
+
+
+def cmd_publish(jar, args):
+    did, pub = create_and_save(args, jar)
+    d = api("POST", f"/api/drafts/{did}/publish", jar, body={})
+    post = d.get("post") or {}
+    url = post.get("url")
+    result = {"ok": True, "posted": True, "id": post.get("id"),
+              "title": post.get("title"), "url": url, "publication": pub.get("title")}
+    # Verify the post is actually live — non-Pro blogs auto-moderate promo posts.
+    if url:
+        time.sleep(4)
+        try:
+            code = _url_status(url)
+            if code == 404:
+                result["ok"] = False
+                result["warning"] = (
+                    "The publish call succeeded but the live URL returns 404 — "
+                    "Hashnode automoderation removed the post (common for overtly "
+                    "promotional content on a non-Pro blog). Rewrite it in an "
+                    "editorial / how-to style with fewer repeated CTA links and "
+                    "republish.")
+        except Exception:
+            pass
+    out(result)
+
+
+def _url_status(url: str) -> int:
+    req = urllib.request.Request(url, headers={"User-Agent": UA}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return 0
+
+
+def cmd_delete(jar, args):
+    d = api("DELETE", f"/api/drafts/{args.id}", jar)
+    out({"ok": True, "deleted": True, "id": d.get("deletedDraftId") or args.id})
+
+
+COMMANDS = {
+    "publications": cmd_publications,
+    "draft": cmd_draft,
+    "publish": cmd_publish,
+    "delete": cmd_delete,
+}
+
+
+def gated_dry_run(args) -> None:
+    out({"dry_run": True, "command": args.command,
+         "title": getattr(args, "title", None), "id": getattr(args, "id", None),
+         "note": "Re-run with --confirm as the LAST argument to actually run this "
+                 "on the user's REAL Hashnode blog."})
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Hashnode via login cookies (no Pro).")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("publications", help="list my blogs (publications)")
+
+    def add_write_args(sp):
+        sp.add_argument("--title", required=True)
+        sp.add_argument("--subtitle")
+        sp.add_argument("--content-file", dest="content_file", help="path to a Markdown file")
+        sp.add_argument("--content", help="inline Markdown (use --content-file for长文)")
+        sp.add_argument("--cover", help="cover image URL (also used as OG image)")
+        sp.add_argument("--tags", help="comma-separated tag slugs, e.g. ai,apis")
+        sp.add_argument("--slug", help="custom URL slug (optional)")
+        sp.add_argument("--publication", help="publication id (needed only if >1 blog)")
+
+    add_write_args(sub.add_parser("draft", help="save a PRIVATE draft (safe, non-public)"))
+    add_write_args(sub.add_parser("publish", help="publish a post (GATED by trailing --confirm)"))
+
+    sp = sub.add_parser("delete", help="delete a draft or post (GATED by trailing --confirm)")
+    sp.add_argument("--id", required=True)
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args(ARGV)
+    if args.command in GATED and not CONFIRM:
+        gated_dry_run(args)
+        return
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Hashnode moved its **public GraphQL API behind a paid Pro plan** on 2026-05-13, so a Personal Access Token can no longer publish for free — every write returns `FORBIDDEN: Publication does not have an active Pro plan`. (PR #584 fixed the PAT endpoint, but the PAT path itself is now paywalled.)

The **web editor is still free**, so this rewrites the skill to drive the **same first-party REST API the editor uses** — `https://hashnode.com/api/*`, authenticated by the login **session cookie** (`hashnode-session`), which is **not** Pro-gated. Same BYOC-cookie pattern as our Medium / Weibo / X skills (the user's own account + content).

## What

- **New `skills/hashnode/scripts/hashnode.py`** (stdlib only, mirrors `medium.py`):
  - `publications` — list blogs.
  - `draft` — create + save a **private** draft (title, subtitle, cover, tags, Markdown) → returns editor URL.
  - `publish` — create + save + publish, **GATED by a trailing `--confirm`** (dry-run otherwise). Re-fetches the live URL and returns a `warning` if the post was moderated away.
  - `delete` — delete a draft/post, also `--confirm`-gated.
  - Cover image, **tags auto-resolved** via `/api/tags/search`, subtitle, and inline images/links (just Markdown) all supported.
- **Rewritten `SKILL.md`** — documents the cookie API + the **automoderation** rule (below) + write-gating.

## The automoderation gotcha (documented in the skill)

Non-Pro publications run **automoderation**: an overtly promotional post (hypey language, the same CTA link repeated) is **auto-removed within seconds** — the publish call still returns success but the URL then 404s. (Pro's benefit here is literally *"protection from automoderation removal"*.) The skill teaches writing **editorial / how-to** content so posts stay live, and `publish` warns when a post is moderated away.

## Verified E2E (live, real connected blog `acedatacloud.hashnode.dev`, no Pro)

- `publications`, `draft`, `publish` (dry-run + live), `delete` — all succeed via cookie auth.
- Published a real editorial article that **stays live** with cover image + tags + links:
  <https://acedatacloud.hashnode.dev/sora-2-api-generate-cinematic-video-from-text-or-images-beginner-s-guide>
- Confirmed the earlier aggressively-promotional draft got automod-removed (404), while the editorial rewrite stayed up — the mechanism the SKILL now warns about.

## Companion PR

Connector switch (PAT → cookie capture): **AceDataCloud/AuthBackend#<connector-pr>**. Supersedes the PAT path from #584.

## 🤖 对抗评审

Read-only adversarial review (Claude general-purpose subagent) of the script + SKILL + connector against the Medium pattern and the verified API:

> Write-gating fails closed (`--confirm` only as last arg; buried `--confirm` stays dry-run — verified live; dry-run returns before any cookie load/network). `HASHNODE_COOKIES`/session cookie never printed; jar attached only via `add_unredirected_header` (dropped on cross-host 30x); automod re-fetch sends no cookies. Endpoints/bodies/tag+publication resolution match the verified contract; GET-only 403/429 retry never replays a write; `success:false` + HTML-404 guards present. Connector entry well-formed, mirrors `medium/medium`, no dup identifier.
>
> NITs (addressed): added `host_in_scope` guard for domain-less cookies + `with open()` for the content file. Remaining nits advisory only (orphaned section comment pre-existing; automod warn could false-positive on CDN propagation — mitigated by a 4s wait).
>
> **VERDICT: CLEAN**