### PR TITLE
feat(reddit): support cookie-authenticated operations

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -117,8 +117,24 @@ jobs:
 
           echo "marketplace.json validated successfully"
 
-      - name: Test Reddit skill helper
-        run: python3 -m unittest discover -s skills/reddit/tests -p 'test_*.py'
+      - name: Run Python skill tests
+        shell: bash
+        run: |
+          test_list=$(mktemp)
+          trap 'rm -f "$test_list"' EXIT
+          if ! find skills -type f -path '*/tests/*' -name 'test_*.py' -print0 > "$test_list"; then
+            echo "::error::Failed to discover Python skill tests"
+            exit 1
+          fi
+          sort -z -o "$test_list" "$test_list"
+
+          if [ ! -s "$test_list" ]; then
+            echo "No Python skill tests found"
+            exit 0
+          fi
+
+          python3 -m pip install --disable-pip-version-check 'pytest>=8,<10'
+          xargs -0 python3 -m pytest -v --import-mode=importlib < "$test_list"
 
       - name: Check for orphaned skills
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -117,6 +117,9 @@ jobs:
 
           echo "marketplace.json validated successfully"
 
+      - name: Test Reddit skill helper
+        run: python3 -m unittest discover -s skills/reddit/tests -p 'test_*.py'
+
       - name: Check for orphaned skills
         run: |
           # Find skills not referenced in marketplace.json

--- a/PUBLISHER_CONNECTORS.md
+++ b/PUBLISHER_CONNECTORS.md
@@ -1,20 +1,17 @@
 # Publisher Connectors — Go-Live Steps (what YOU need to do)
 
-These connectors + skills are code-complete. To make them **work on production**,
-a human has to register OAuth apps / enable APIs and set secrets, then run the
-sync commands. Per-platform steps below. Order: do the setup, set the env, then
-`python manage.py sync_connectors` (AuthBackend) — the skills sync automatically
-via the Skills catalog.
+These connectors + skills are code-complete. Some need an OAuth app or API
+enablement; Reddit works through ACE Cookie capture while its commercial OAuth
+application is under review. After any platform setup, run
+`python manage.py sync_connectors` (AuthBackend). Skills sync automatically via
+the Skills catalog.
 
-Common OAuth callback (Reddit & LinkedIn) — register **the same redirect base
-the existing Google/GitHub connectors use**, with the provider path appended:
+Common OAuth callback (Reddit & LinkedIn) — register the provider path below:
 
 ```
-https://auth.acedata.cloud/api/v1/connections/callback/reddit
-https://auth.acedata.cloud/api/v1/connections/callback/linkedin
+https://auth.acedata.cloud/oauth/callback/reddit
+https://auth.acedata.cloud/oauth/callback/linkedin
 ```
-(If your Google/GitHub apps use a different callback base, mirror it — the path
-segment is the provider id `reddit` / `linkedin`.)
 
 ---
 
@@ -30,9 +27,18 @@ No new OAuth app (reuses your Google client, same as Drive/Gmail/YouTube):
    (It's a sensitive scope → may need Google verification, like youtube.upload.)
 3. No new env var needed.
 
-## 3. Reddit — register an OAuth app
+## 3. Reddit — Cookie now; OAuth after Reddit approval
+
+The recommended method is Cookie capture: log in to Reddit, then connect with
+the ACE extension. No platform secret is required. The connector injects the
+encrypted cookie jar as `REDDIT_COOKIES`; the skill can read identity / the
+user's own submissions and submit confirmed text or link posts.
+
+Official OAuth remains available as a second auth method, but Reddit now requires
+explicit Data API approval before app registration. After written approval:
+
 1. https://www.reddit.com/prefs/apps → **create app** → type **"web app"**.
-2. **redirect uri** = the Reddit callback above.
+2. **redirect uri** = `https://auth.acedata.cloud/oauth/callback/reddit`.
 3. Copy the client id (under the app name) + secret.
 4. Set K8s secret env on AuthBackend:
    - `REDDIT_OAUTH_CLIENT_ID=...`
@@ -59,11 +65,14 @@ are pulled into the Skill catalog by the normal skills sync; each connector's
 
 ## Verify it works (online)
 1. Open **auth.acedata.cloud → Browse connectors** → the 4 new cards appear.
-2. Click **Connect** on Dev.to (paste a key) and on Blogger/Reddit/LinkedIn (OAuth).
+2. Connect Dev.to with an API key, Blogger/LinkedIn with OAuth, and Reddit with
+   **Browser extension Cookie capture**. Reddit OAuth remains unavailable until
+   Reddit grants written approval and production credentials are configured.
 3. In Studio chat: "把这段发到我的 dev.to / Blogger / Reddit r/test / LinkedIn" →
-   the matching skill runs with the injected token and posts.
+   the matching skill runs with the injected credential and asks for explicit
+   confirmation before posting.
 
 ## Cost note
-Dev.to, Blogger, Reddit, LinkedIn — all free APIs. (We deliberately skipped X,
-which is now pay-per-use $0.01/post, and Facebook, which needs app review +
-Page-token complexity.)
+Dev.to, Blogger and LinkedIn currently expose free API access for these flows.
+Reddit commercial access is pending review and may require a separate agreement
+or fees. X is pay-per-use, while Facebook needs app review and Page-token setup.

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reddit
-description: Submit posts (link or text) to subreddits and read your Reddit identity / content via the Reddit API. Use when the user mentions Reddit, posting to a subreddit, submitting a link or self-post, or checking their Reddit profile / submissions.
+description: Submit posts (link or text) to subreddits and read your Reddit identity / submissions using either official OAuth or your own Reddit login cookies. Use when the user mentions Reddit, posting to a subreddit, submitting a link or self-post, or checking their Reddit profile / submissions.
 when_to_use: |
   Trigger when the user wants to submit a post to a subreddit (link or
   self/text post), or read their own Reddit identity and submissions.
@@ -8,75 +8,88 @@ when_to_use: |
   / karma requirements — confirm the target subreddit, title and body
   before submitting.
 connections: [reddit]
-allowed_tools: [Bash]
+allowed_tools: [Bash, publish_artifact]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "2.0"
 ---
 
-Call the **Reddit API** (OAuth endpoints) with `curl + jq`. The user's bearer
-token is in `$REDDIT_TOKEN`. **Every call MUST send a `User-Agent` header** or
-Reddit returns `429`. Use the OAuth host `https://oauth.reddit.com`.
+# Reddit — OAuth or login-cookie access
 
-```bash
-UA="web:cloud.acedata.connectors:v1.0 (by /u/acedatacloud)"
+The connector injects exactly one of these credentials:
+
+- `REDDIT_COOKIES`: JSON cookie array captured by the ACE browser extension.
+  It includes `reddit_session` and grants full account access. **Secret — never
+  echo, print, log or return it.**
+- `REDDIT_TOKEN`: official OAuth bearer token (`identity read submit`).
+
+The helper automatically prefers Cookie when present and otherwise uses OAuth.
+It sends Reddit's required descriptive User-Agent and never forwards cookies
+outside `reddit.com`.
+
+## Script resolution
+
+Bash calls do not share shell variables. Resolve the helper inside **every**
+fenced Bash invocation before using it:
+
+```sh
+R="${SKILL_DIR:-}/scripts/reddit.py"; [ -f "$R" ] || R=$(find /tmp -maxdepth 8 -path '*/skills/*/reddit/scripts/reddit.py' -print -quit 2>/dev/null)
+[ -f "$R" ] || { echo "reddit script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$R" whoami
 ```
 
-Errors are JSON; a submit returns `{"json":{"errors":[...], "data":{...}}}` —
-if `errors` is non-empty, show them verbatim. `401` → token expired, re-connect.
+If authentication fails, ask the user to reconnect at
+<https://auth.acedata.cloud/user/connections>. Do not loop-retry a blocked or
+expired session.
 
-**Always start by confirming identity:**
+## Read
 
-```bash
-curl -sS -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
-  "https://oauth.reddit.com/api/v1/me" | jq '{name, total_karma, link_karma}'
+```sh
+R="${SKILL_DIR:-}/scripts/reddit.py"; [ -f "$R" ] || R=$(find /tmp -maxdepth 8 -path '*/skills/*/reddit/scripts/reddit.py' -print -quit 2>/dev/null)
+[ -f "$R" ] || { echo "reddit script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+python3 "$R" whoami
+python3 "$R" submissions --limit 10
 ```
 
-## Submit a post
+## Submit a post — GATED
 
-**Confirm the subreddit + title + body with the user first.** `sr` is the
-subreddit name WITHOUT the `r/` prefix.
+Posting is public. **Always show the subreddit, final title and final body/URL,
+then obtain explicit confirmation.** Without a trailing `--confirm`, both write
+commands are dry-runs and make no network request.
 
-```bash
-# Self (text) post: kind=self + text. Link post: kind=link + url.
-curl -sS -X POST "https://oauth.reddit.com/api/submit" \
-  -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
-  --data-urlencode "sr=test" \
-  --data-urlencode "kind=self" \
-  --data-urlencode "title=My title" \
-  --data-urlencode "text=My self-post body in markdown" \
-  --data-urlencode "api_type=json" \
-  | jq '.json | {errors, url: .data.url, id: .data.id}'
+```sh
+R="${SKILL_DIR:-}/scripts/reddit.py"; [ -f "$R" ] || R=$(find /tmp -maxdepth 8 -path '*/skills/*/reddit/scripts/reddit.py' -print -quit 2>/dev/null)
+[ -f "$R" ] || { echo "reddit script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
+
+# Text post: use a file for long Markdown.
+python3 "$R" submit-text --subreddit test --title "My title" --text-file post.md
+python3 "$R" submit-text --subreddit test --title "My title" --text-file post.md --confirm
+
+# Link post.
+python3 "$R" submit-link --subreddit test --title "My title" --url "https://example.com"
+python3 "$R" submit-link --subreddit test --title "My title" --url "https://example.com" --confirm
 ```
 
-For a link post:
+`--confirm` is honored only when it is the final argument. A title or body that
+contains the text `--confirm` can never trigger a write.
 
-```bash
-curl -sS -X POST "https://oauth.reddit.com/api/submit" \
-  -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
-  --data-urlencode "sr=test" --data-urlencode "kind=link" \
-  --data-urlencode "title=My title" --data-urlencode "url=https://example.com" \
-  --data-urlencode "api_type=json" | jq '.json'
-```
+## Safety and failure handling
 
-## Read my submissions
-
-```bash
-curl -sS -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: $UA" \
-  "https://oauth.reddit.com/user/USERNAME/submitted?limit=10" \
-  | jq '.data.children[] | .data | {title, subreddit, ups, num_comments, permalink}'
-```
-
-## Gotchas
-
-- **User-Agent is mandatory** on every request — omitting it → `429`.
-- Many subreddits gate posting on **account age / karma / flair**; a submit can
-  return `errors` like `[["SUBREDDIT_NOTALLOWED", ...]]` — surface it and try
-  `r/test` to validate the flow.
-- Respect rate limits: read the `X-Ratelimit-Remaining` response header; space
-  out bulk submits.
-- Use `r/test` as a safe target when validating that the connection works.
+- Never print `REDDIT_COOKIES`, `REDDIT_TOKEN`, `reddit_session` or the modhash.
+- Do not vote, send private messages, evade bans, automate engagement, or
+  cross-post identical content. This skill intentionally exposes none of those
+  operations.
+- Follow each subreddit's rules. Account age, karma and flair requirements can
+  reject a post; report the rejection without exposing Reddit's raw authenticated
+  response, which may contain reflected credential material.
+- Do not retry a write automatically. A timeout may occur after Reddit accepted
+  it, and replaying could create a duplicate.
+- Respect rate limits and never bulk-submit. Use `r/test` only for a deliberate
+  end-to-end validation.
+- Cookie mode drives Reddit's first-party web JSON endpoints and may drift when
+  Reddit changes its site. Report unexpected HTML or route errors as upstream
+  drift instead of guessing another private endpoint.
 
 
 ## Record the output

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Read and submit Reddit posts with OAuth or the user's login cookies.
+
+Cookie mode uses Reddit's first-party web JSON endpoints and the ``modhash``
+returned by ``/api/me.json``. OAuth mode uses ``oauth.reddit.com``. The helper
+automatically selects ``REDDIT_COOKIES`` first, then ``REDDIT_TOKEN``.
+
+State-changing commands are dry-runs unless ``--confirm`` is the final argv
+token. Credentials, cookie values and modhashes are never emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gzip
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+WEB_BASE = "https://www.reddit.com"
+OAUTH_BASE = "https://oauth.reddit.com"
+USER_AGENT = "web:cloud.acedata.reddit:v2.0 (by /u/acedatacloud)"
+GATED_COMMANDS = {"submit-text", "submit-link"}
+SUBREDDIT_RE = re.compile(r"^[A-Za-z0-9_]{2,21}$")
+COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
+
+def output(value) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, default=str))
+
+
+def die(message: str, code: int = 1) -> None:
+    output({"error": message})
+    raise SystemExit(code)
+
+
+def split_confirmation(argv: list[str]) -> tuple[list[str], bool]:
+    confirmed = bool(argv) and argv[-1] == "--confirm"
+    return (argv[:-1] if confirmed else list(argv), confirmed)
+
+
+def parse_cookie_jar(raw: str) -> list[dict]:
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as error:
+        die(f"REDDIT_COOKIES is not valid JSON: {error}")
+    if not isinstance(jar, list):
+        die(f"REDDIT_COOKIES must be a JSON list of cookies, got {type(jar).__name__}")
+    normalized = []
+    for item in jar:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        value = item.get("value")
+        if not isinstance(name, str) or not COOKIE_NAME_RE.fullmatch(name) or not isinstance(value, str):
+            continue
+        if any(character == ";" or ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+            continue
+        domain = item.get("domain")
+        if not isinstance(domain, str) or not reddit_cookie_domain(domain):
+            continue
+        path = str(item.get("path") or "/")
+        if not path.startswith("/"):
+            continue
+        expiration = item.get("expirationDate")
+        if expiration not in (None, ""):
+            try:
+                if float(expiration) <= time.time():
+                    continue
+            except (TypeError, ValueError):
+                continue
+        normalized.append(
+            dict(
+                item,
+                name=name,
+                value=value,
+                domain=domain,
+                path=path,
+                secure=bool(item.get("secure")),
+            )
+        )
+    if not any(
+        cookie.get("name") == "reddit_session"
+        and cookie.get("value")
+        and cookie_applies(cookie, WEB_BASE + "/api/me.json")
+        for cookie in normalized
+    ):
+        die(
+            "REDDIT_COOKIES is missing a valid reddit_session — log in on reddit.com, "
+            "re-capture with the ACE extension, then reconnect at "
+            "https://auth.acedata.cloud/user/connections."
+        )
+    return normalized
+
+
+def reddit_cookie_domain(domain: str) -> bool:
+    normalized_domain = domain.strip().lstrip(".").lower()
+    return normalized_domain == "reddit.com" or normalized_domain.endswith(".reddit.com")
+
+
+def domain_matches(host: str, domain: str) -> bool:
+    raw_domain = domain.strip().lower()
+    normalized_domain = raw_domain.lstrip(".")
+    normalized_host = host.lower()
+    if not normalized_domain:
+        return False
+    if raw_domain.startswith("."):
+        return normalized_host == normalized_domain or normalized_host.endswith("." + normalized_domain)
+    return normalized_host == normalized_domain
+
+
+def cookie_domain_matches(cookie: dict, host: str) -> bool:
+    domain = str(cookie.get("domain") or "")
+    if cookie.get("hostOnly") is True:
+        return host.lower() == domain.lstrip(".").lower()
+    if cookie.get("hostOnly") is False:
+        normalized = domain.lstrip(".")
+        return bool(normalized) and (
+            host.lower() == normalized.lower() or host.lower().endswith("." + normalized.lower())
+        )
+    return domain_matches(host, domain)
+
+
+def path_matches(request_path: str, cookie_path: str) -> bool:
+    if request_path == cookie_path:
+        return True
+    if not request_path.startswith(cookie_path):
+        return False
+    return cookie_path.endswith("/") or request_path[len(cookie_path) :].startswith("/")
+
+
+def cookie_applies(cookie: dict, url: str) -> bool:
+    parsed = urllib.parse.urlsplit(url)
+    host = parsed.hostname or ""
+    domain = str(cookie.get("domain") or "")
+    path = str(cookie.get("path") or "/")
+    if not reddit_cookie_domain(domain) or not cookie_domain_matches(cookie, host):
+        return False
+    if not path.startswith("/") or not path_matches(parsed.path or "/", path):
+        return False
+    if cookie.get("secure") and parsed.scheme != "https":
+        return False
+    expiration = cookie.get("expirationDate")
+    if expiration not in (None, ""):
+        try:
+            if float(expiration) <= time.time():
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def cookie_header(jar: list[dict], url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    if not reddit_cookie_domain(host):
+        return ""
+    applicable = [
+        (index, cookie)
+        for index, cookie in enumerate(jar)
+        if cookie_applies(cookie, url)
+    ]
+    applicable.sort(key=lambda item: (-len(str(item[1].get("path") or "/")), item[0]))
+    parts = []
+    seen = set()
+    for _, cookie in applicable:
+        identity = (
+            cookie.get("name"),
+            cookie.get("domain"),
+            cookie.get("path") or "/",
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        parts.append(f"{cookie['name']}={cookie['value']}")
+    return "; ".join(parts)
+
+
+def normalize_subreddit(value: str) -> str:
+    subreddit = value.strip().strip("/")
+    if subreddit.lower().startswith("r/"):
+        subreddit = subreddit[2:]
+    if not SUBREDDIT_RE.fullmatch(subreddit):
+        die("subreddit must contain only letters, numbers or underscores (2-21 characters)")
+    return subreddit
+
+
+def validate_title(value: str) -> str:
+    title = value.strip()
+    if not title:
+        die("title cannot be empty")
+    if len(title) > 300:
+        die("title exceeds Reddit's 300-character limit")
+    return title
+
+
+def validate_link(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.username or parsed.password:
+        die("url must be an http(s) URL without embedded credentials")
+    return value.strip()
+
+
+def read_text(args: argparse.Namespace) -> str:
+    if args.text_file:
+        try:
+            with open(args.text_file, encoding="utf-8") as file_handle:
+                text = file_handle.read()
+        except OSError as error:
+            die(f"cannot read text file {args.text_file}: {error}")
+    else:
+        text = args.text or ""
+    if len(text) > 40_000:
+        die("text exceeds Reddit's 40,000-character limit")
+    return text
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Return 30x responses to the caller instead of replaying credentials."""
+
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+def open_request(request: urllib.request.Request):
+    return urllib.request.build_opener(NoRedirect()).open(request, timeout=30)
+
+
+class RedditClient:
+    def __init__(self, mode: str, *, cookies: list[dict] | None = None, token: str = ""):
+        self.mode = mode
+        self.cookies = cookies or []
+        self.token = token
+        self.modhash = ""
+        self.username = ""
+
+    @classmethod
+    def from_environment(cls) -> "RedditClient":
+        raw_cookies = os.environ.get("REDDIT_COOKIES", "").strip()
+        if raw_cookies:
+            return cls("cookie", cookies=parse_cookie_jar(raw_cookies))
+        token = os.environ.get("REDDIT_TOKEN", "").strip()
+        if token:
+            if "\r" in token or "\n" in token:
+                die("REDDIT_TOKEN contains invalid characters")
+            return cls("oauth", token=token)
+        die(
+            "No Reddit credential is available — connect Reddit with Cookie or OAuth at "
+            "https://auth.acedata.cloud/user/connections."
+        )
+
+    @property
+    def base_url(self) -> str:
+        return WEB_BASE if self.mode == "cookie" else OAUTH_BASE
+
+    def request(self, method: str, path: str, *, query: dict | None = None, form: dict | None = None):
+        is_write = method.upper() == "POST"
+        url = self.base_url + path
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+        }
+        if self.mode == "oauth":
+            headers["Authorization"] = f"Bearer {self.token}"
+        else:
+            headers.update({"Origin": WEB_BASE, "Referer": WEB_BASE + "/", "X-Requested-With": "XMLHttpRequest"})
+
+        data = None
+        if form is not None:
+            data = urllib.parse.urlencode(form).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        if self.mode == "cookie":
+            request.add_unredirected_header("Cookie", cookie_header(self.cookies, url))
+
+        try:
+            with open_request(request) as response:
+                status = response.status
+                raw = response.read()
+                if response.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.decompress(raw)
+        except urllib.error.HTTPError as error:
+            try:
+                status = error.code
+                raw = error.read()
+                if error.headers.get("Content-Encoding") == "gzip":
+                    raw = gzip.decompress(raw)
+            except Exception:
+                if is_write:
+                    die_unknown_write_outcome("The Reddit HTTP error response for the write request could not be read")
+                die("The Reddit HTTP error response could not be read; authenticated response content was omitted.")
+            finally:
+                with contextlib.suppress(Exception):
+                    error.close()
+        except urllib.error.URLError as error:
+            if is_write:
+                die_unknown_write_outcome("A network error interrupted the Reddit write request")
+            die(f"network error reaching Reddit: {error.reason}")
+        except Exception:
+            if is_write:
+                die_unknown_write_outcome("The Reddit write response could not be read or decompressed")
+            die("The Reddit response could not be read or decompressed; authenticated response content was omitted.")
+
+        text = raw.decode("utf-8", "replace")
+        if 300 <= status < 400:
+            if is_write:
+                die_unknown_write_outcome("Reddit redirected the write request; credentials were not forwarded")
+            die("Reddit returned an unexpected redirect; credentials were not forwarded. Reconnect before retrying the read.")
+        if status in {401, 403}:
+            die(
+                f"Reddit authentication failed ({status}) — the credential may be expired or blocked. "
+                "Reconnect at https://auth.acedata.cloud/user/connections."
+            )
+        if status == 429:
+            die("Reddit rate limit reached (429). Wait before retrying; do not loop-retry.")
+        if status >= 400:
+            if is_write and status >= 500:
+                die_unknown_write_outcome(f"Reddit returned HTTP {status} for the write request")
+            die(f"Reddit returned HTTP {status}; authenticated response content was omitted.")
+        if text.lstrip().startswith("<"):
+            if is_write:
+                die_unknown_write_outcome("Reddit returned HTML for the write request")
+            die("Reddit returned HTML instead of JSON — the session expired or the web endpoint changed.")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            if is_write:
+                die_unknown_write_outcome("Reddit returned invalid JSON for the write request")
+            die(f"Reddit returned non-JSON data ({status}); authenticated response content was omitted.")
+
+    def me(self) -> dict:
+        if self.mode == "cookie":
+            payload = self.request("GET", "/api/me.json", query={"raw_json": 1})
+            if not isinstance(payload, dict) or not isinstance(payload.get("data"), dict):
+                die("Reddit returned a malformed identity response; authenticated response content was omitted.")
+            data = payload["data"]
+            self.modhash = str(data.get("modhash") or "")
+        else:
+            data = self.request("GET", "/api/v1/me")
+            if not isinstance(data, dict):
+                die("Reddit returned a malformed identity response; authenticated response content was omitted.")
+        self.username = str(data.get("name") or "")
+        if not self.username:
+            die("Reddit did not return an authenticated username — reconnect the account.")
+        return data
+
+    def submissions(self, limit: int) -> list[dict]:
+        username = self.username or str(self.me().get("name") or "")
+        suffix = ".json" if self.mode == "cookie" else ""
+        payload = self.request(
+            "GET",
+            f"/user/{urllib.parse.quote(username, safe='')}/submitted{suffix}",
+            query={"limit": limit, "raw_json": 1},
+        )
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), dict):
+            die("Reddit returned a malformed submissions response; authenticated response content was omitted.")
+        children = payload["data"].get("children")
+        if not isinstance(children, list) or any(
+            not isinstance(child, dict)
+            or not valid_submission_data(child.get("data"))
+            for child in children
+        ):
+            die("Reddit returned a malformed submissions response; authenticated response content was omitted.")
+        return [child["data"] for child in children]
+
+    def submit(self, *, subreddit: str, title: str, kind: str, text: str = "", url: str = "") -> dict:
+        if self.mode == "cookie" and not self.modhash:
+            self.me()
+        form = {
+            "api_type": "json",
+            "kind": kind,
+            "sr": subreddit,
+            "title": title,
+            "resubmit": "true",
+            "sendreplies": "true",
+            "raw_json": "1",
+        }
+        if kind == "self":
+            form["text"] = text
+        else:
+            form["url"] = url
+        if self.mode == "cookie":
+            if not self.modhash:
+                die("Reddit did not return a modhash; the Cookie session cannot perform writes.")
+            form["uh"] = self.modhash
+
+        payload = self.request("POST", "/api/submit", form=form)
+        if not isinstance(payload, dict) or not isinstance(payload.get("json"), dict):
+            die_unknown_post_response()
+        json_payload = payload["json"]
+        errors = json_payload.get("errors")
+        if not isinstance(errors, list):
+            die_unknown_post_response()
+        if errors:
+            die(
+                "Reddit rejected the post. Check subreddit rules, account eligibility, "
+                "flair requirements and rate limits; authenticated error details were omitted."
+            )
+        post = json_payload.get("data")
+        if not isinstance(post, dict):
+            die_unknown_post_response()
+        post_url = post.get("url") or post.get("permalink")
+        if not isinstance(post_url, str) or not post_url:
+            die_unknown_post_response()
+        if post_url.startswith("/"):
+            post_url = WEB_BASE + post_url
+        parsed_post_url = urllib.parse.urlsplit(post_url)
+        if parsed_post_url.scheme != "https" or not parsed_post_url.hostname or not reddit_cookie_domain(
+            parsed_post_url.hostname
+        ):
+            die_unknown_post_response()
+        return {"ok": True, "posted": True, "id": post.get("id"), "name": post.get("name"), "url": post_url}
+
+
+def format_profile(data: dict, mode: str) -> dict:
+    return {
+        "auth_mode": mode,
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "total_karma": data.get("total_karma"),
+        "link_karma": data.get("link_karma"),
+        "comment_karma": data.get("comment_karma"),
+        "created_utc": data.get("created_utc"),
+    }
+
+
+def valid_submission_data(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    required_strings = ("id", "title", "subreddit", "permalink")
+    return all(isinstance(item.get(key), str) and item.get(key) for key in required_strings) and str(
+        item["permalink"]
+    ).startswith("/")
+
+
+def die_unknown_write_outcome(reason: str) -> None:
+    die(
+        f"{reason}; authenticated response content was omitted and the post outcome is unknown. "
+        "Check recent submissions before taking any further action and do not replay automatically."
+    )
+
+
+def die_unknown_post_response() -> None:
+    die_unknown_write_outcome("Reddit returned a malformed write response")
+
+
+def format_submission(item: dict) -> dict:
+    permalink = item.get("permalink")
+    return {
+        "id": item.get("id"),
+        "title": item.get("title"),
+        "subreddit": item.get("subreddit"),
+        "url": WEB_BASE + permalink if isinstance(permalink, str) and permalink.startswith("/") else item.get("url"),
+        "score": item.get("score"),
+        "num_comments": item.get("num_comments"),
+        "created_utc": item.get("created_utc"),
+    }
+
+
+def dry_run(args: argparse.Namespace) -> None:
+    value = {
+        "dry_run": True,
+        "command": args.command,
+        "subreddit": normalize_subreddit(args.subreddit),
+        "title": validate_title(args.title),
+        "note": "No request was sent. Re-run with --confirm as the final argument after explicit user approval.",
+    }
+    if args.command == "submit-text":
+        value["text_length"] = len(read_text(args))
+    else:
+        value["url"] = validate_link(args.url)
+    output(value)
+
+
+def positive_limit(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1 or parsed > 100:
+        raise argparse.ArgumentTypeError("limit must be between 1 and 100")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Reddit via OAuth or login cookies")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("whoami", help="show the connected Reddit identity")
+
+    submissions = commands.add_parser("submissions", help="list my recent submissions")
+    submissions.add_argument("--limit", type=positive_limit, default=10)
+
+    text_post = commands.add_parser("submit-text", help="submit a text post (gated)")
+    text_post.add_argument("--subreddit", "-r", required=True)
+    text_post.add_argument("--title", required=True)
+    text_source = text_post.add_mutually_exclusive_group(required=True)
+    text_source.add_argument("--text")
+    text_source.add_argument("--text-file", dest="text_file")
+
+    link_post = commands.add_parser("submit-link", help="submit a link post (gated)")
+    link_post.add_argument("--subreddit", "-r", required=True)
+    link_post.add_argument("--title", required=True)
+    link_post.add_argument("--url", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    parsed_argv, confirmed = split_confirmation(raw_argv)
+    args = build_parser().parse_args(parsed_argv)
+
+    if args.command in GATED_COMMANDS and not confirmed:
+        dry_run(args)
+        return
+
+    client = RedditClient.from_environment()
+    if args.command == "whoami":
+        output(format_profile(client.me(), client.mode))
+        return
+    if args.command == "submissions":
+        items = client.submissions(args.limit)
+        output({"auth_mode": client.mode, "count": len(items), "submissions": [format_submission(item) for item in items]})
+        return
+
+    subreddit = normalize_subreddit(args.subreddit)
+    title = validate_title(args.title)
+    if args.command == "submit-text":
+        output(client.submit(subreddit=subreddit, title=title, kind="self", text=read_text(args)))
+    elif args.command == "submit-link":
+        output(client.submit(subreddit=subreddit, title=title, kind="link", url=validate_link(args.url)))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/reddit/tests/test_reddit.py
+++ b/skills/reddit/tests/test_reddit.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import sys
+import time
+import unittest
+import urllib.error
+import urllib.parse
+from email.message import Message
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "reddit.py"
+SPEC = importlib.util.spec_from_file_location("reddit_skill_script", SCRIPT)
+reddit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = reddit
+SPEC.loader.exec_module(reddit)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status: int = 200):
+        self.status = status
+        self.payload = json.dumps(payload).encode()
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+class BrokenResponse(FakeResponse):
+    def read(self):
+        raise OSError("truncated response containing session-secret")
+
+
+class BrokenErrorBody(io.BytesIO):
+    def read(self, *_args, **_kwargs):
+        raise OSError("truncated HTTP error containing session-secret")
+
+
+COOKIE_JAR = json.dumps(
+    [
+        {"name": "reddit_session", "value": "session-secret", "domain": ".reddit.com", "path": "/"},
+        {"name": "loid", "value": "loid-value", "domain": ".reddit.com", "path": "/"},
+    ]
+)
+
+
+class RedditSkillTests(unittest.TestCase):
+    def test_cookie_header_is_restricted_to_reddit(self):
+        jar = reddit.parse_cookie_jar(COOKIE_JAR)
+        self.assertIn("reddit_session=session-secret", reddit.cookie_header(jar, "https://www.reddit.com/api/me.json"))
+        self.assertEqual("", reddit.cookie_header(jar, "https://example.com/"))
+
+    def test_cookie_jar_rejects_missing_wrong_domain_or_empty_session(self):
+        invalid_jars = [
+            [{"name": "reddit_session", "value": "secret", "path": "/"}],
+            [{"name": "reddit_session", "value": "secret", "domain": ".example.com", "path": "/"}],
+            [{"name": "reddit_session", "value": "", "domain": ".reddit.com", "path": "/"}],
+            [{"name": "reddit_session", "value": "secret; injected=yes", "domain": ".reddit.com", "path": "/"}],
+            [{"name": "reddit_session", "value": {"secret": True}, "domain": ".reddit.com", "path": "/"}],
+            [
+                {
+                    "name": "reddit_session",
+                    "value": "secret",
+                    "domain": ".reddit.com",
+                    "path": "/",
+                    "expirationDate": time.time() - 1,
+                }
+            ],
+        ]
+        for jar in invalid_jars:
+            with self.subTest(jar=jar), self.assertRaises(SystemExit), redirect_stdout(io.StringIO()):
+                reddit.parse_cookie_jar(json.dumps(jar))
+
+    def test_cookie_header_respects_host_only_domain_path_secure_and_expiry(self):
+        jar = reddit.parse_cookie_jar(
+            json.dumps(
+                [
+                    {"name": "reddit_session", "value": "root", "domain": ".reddit.com", "path": "/", "secure": True},
+                    {"name": "host_only", "value": "yes", "domain": "www.reddit.com", "path": "/"},
+                    {
+                        "name": "domain_cookie",
+                        "value": "yes",
+                        "domain": "reddit.com",
+                        "hostOnly": False,
+                        "path": "/",
+                    },
+                    {"name": "login_only", "value": "no", "domain": ".reddit.com", "path": "/login"},
+                    {
+                        "name": "expired",
+                        "value": "no",
+                        "domain": ".reddit.com",
+                        "path": "/",
+                        "expirationDate": time.time() - 1,
+                    },
+                ]
+            )
+        )
+        api_header = reddit.cookie_header(jar, "https://www.reddit.com/api/me.json")
+        self.assertIn("reddit_session=root", api_header)
+        self.assertIn("host_only=yes", api_header)
+        self.assertIn("domain_cookie=yes", api_header)
+        self.assertNotIn("login_only", api_header)
+        self.assertNotIn("expired", api_header)
+        self.assertNotIn("host_only", reddit.cookie_header(jar, "https://old.reddit.com/api/me.json"))
+        self.assertIn("domain_cookie=yes", reddit.cookie_header(jar, "https://old.reddit.com/api/me.json"))
+        self.assertNotIn("reddit_session", reddit.cookie_header(jar, "http://www.reddit.com/api/me.json"))
+
+    def test_cookie_mode_fetches_modhash_and_submits_text(self):
+        responses = [
+            FakeResponse({"data": {"id": "abc", "name": "tester", "modhash": "csrf-secret"}}),
+            FakeResponse({"json": {"errors": [], "data": {"id": "post1", "name": "t3_post1", "url": "https://www.reddit.com/r/test/comments/post1/title/"}}}),
+        ]
+        with patch.dict(os.environ, {"REDDIT_COOKIES": COOKIE_JAR}, clear=True), patch.object(
+            reddit, "open_request", side_effect=responses
+        ) as urlopen:
+            client = reddit.RedditClient.from_environment()
+            result = client.submit(subreddit="test", title="Title", kind="self", text="Body")
+
+        self.assertEqual("cookie", client.mode)
+        self.assertEqual("https://www.reddit.com/r/test/comments/post1/title/", result["url"])
+        me_request = urlopen.call_args_list[0].args[0]
+        submit_request = urlopen.call_args_list[1].args[0]
+        self.assertEqual("https://www.reddit.com/api/me.json?raw_json=1", me_request.full_url)
+        self.assertIn("reddit_session=session-secret", me_request.get_header("Cookie"))
+        form = urllib.parse.parse_qs(submit_request.data.decode())
+        self.assertEqual(["csrf-secret"], form["uh"])
+        self.assertEqual(["self"], form["kind"])
+        self.assertEqual(["Body"], form["text"])
+
+    def test_oauth_mode_uses_bearer_token(self):
+        with patch.dict(os.environ, {"REDDIT_TOKEN": "oauth-secret"}, clear=True), patch(
+            "reddit_skill_script.open_request",
+            return_value=FakeResponse({"id": "abc", "name": "tester", "total_karma": 12}),
+        ) as urlopen:
+            client = reddit.RedditClient.from_environment()
+            profile = client.me()
+
+        self.assertEqual("oauth", client.mode)
+        self.assertEqual("tester", profile["name"])
+        request = urlopen.call_args.args[0]
+        self.assertEqual("https://oauth.reddit.com/api/v1/me", request.full_url)
+        self.assertEqual("Bearer oauth-secret", request.get_header("Authorization"))
+
+    def test_dry_run_never_loads_credentials_or_calls_network(self):
+        stream = io.StringIO()
+        with patch.dict(os.environ, {}, clear=True), patch.object(reddit, "open_request") as urlopen, redirect_stdout(stream):
+            reddit.main(["submit-text", "--subreddit", "r/test", "--title", "Title", "--text", "Body"])
+
+        value = json.loads(stream.getvalue())
+        self.assertTrue(value["dry_run"])
+        self.assertEqual(4, value["text_length"])
+        urlopen.assert_not_called()
+
+    def test_confirm_is_only_recognized_as_final_argument(self):
+        args, confirmed = reddit.split_confirmation(["submit-text", "--text", "--confirm", "--title", "Title"])
+        self.assertFalse(confirmed)
+        self.assertIn("--confirm", args)
+        args, confirmed = reddit.split_confirmation(["submit-text", "--title", "Title", "--confirm"])
+        self.assertTrue(confirmed)
+        self.assertNotIn("--confirm", args)
+
+    def test_rejects_cookie_jar_without_reddit_session(self):
+        with self.assertRaises(SystemExit), redirect_stdout(io.StringIO()):
+            reddit.parse_cookie_jar(json.dumps([{"name": "loid", "value": "x", "domain": ".reddit.com"}]))
+
+    def test_redirect_is_rejected_without_following(self):
+        headers = Message()
+        headers["Location"] = "https://example.com/steal"
+        redirect = urllib.error.HTTPError(
+            "https://www.reddit.com/api/me.json",
+            302,
+            "Found",
+            headers,
+            io.BytesIO(b"redirect"),
+        )
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        with patch.object(reddit, "open_request", side_effect=redirect) as open_request, self.assertRaises(
+            SystemExit
+        ), redirect_stdout(io.StringIO()):
+            client.me()
+
+        open_request.assert_called_once()
+
+    def test_post_redirect_reports_unknown_outcome_without_retry_advice(self):
+        headers = Message()
+        headers["Location"] = "https://www.reddit.com/r/test/comments/post1/title/"
+        redirect = urllib.error.HTTPError(
+            "https://www.reddit.com/api/submit",
+            303,
+            "See Other",
+            headers,
+            io.BytesIO(b"redirect"),
+        )
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        stream = io.StringIO()
+        with patch.object(reddit, "open_request", side_effect=redirect) as open_request, self.assertRaises(
+            SystemExit
+        ), redirect_stdout(stream):
+            client.submit(subreddit="test", title="Title", kind="self", text="Body")
+
+        rendered = stream.getvalue()
+        self.assertIn("outcome is unknown", rendered)
+        self.assertIn("Check recent submissions", rendered)
+        self.assertIn("do not replay", rendered)
+        self.assertNotIn("retry once", rendered)
+        open_request.assert_called_once()
+
+    def test_post_body_failures_report_unknown_outcome_without_secret_details(self):
+        cases = [
+            FakeResponse({}, status=200),
+            FakeResponse({}, status=200),
+            BrokenResponse({}),
+        ]
+        cases[0].payload = b"<html>session-secret</html>"
+        cases[1].payload = b"not-json session-secret"
+        cases.append(FakeResponse({}, status=200))
+        cases[-1].payload = b"not-gzip session-secret"
+        cases[-1].headers = {"Content-Encoding": "gzip"}
+
+        for response in cases:
+            client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+            stream = io.StringIO()
+            with self.subTest(response=type(response).__name__), patch.object(
+                reddit, "open_request", return_value=response
+            ) as open_request, self.assertRaises(SystemExit), redirect_stdout(stream):
+                client.request("POST", "/api/submit", form={"api_type": "json"})
+            rendered = stream.getvalue()
+            self.assertIn("outcome is unknown", rendered)
+            self.assertIn("do not replay", rendered)
+            self.assertNotIn("session-secret", rendered)
+            open_request.assert_called_once()
+
+    def test_post_http_error_body_read_failure_reports_unknown_outcome(self):
+        error = urllib.error.HTTPError(
+            "https://www.reddit.com/api/submit",
+            500,
+            "Internal Server Error",
+            Message(),
+            BrokenErrorBody(b"unreadable"),
+        )
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        stream = io.StringIO()
+        with patch.object(reddit, "open_request", side_effect=error) as open_request, self.assertRaises(
+            SystemExit
+        ), redirect_stdout(stream):
+            client.request("POST", "/api/submit", form={"api_type": "json"})
+
+        rendered = stream.getvalue()
+        self.assertIn("outcome is unknown", rendered)
+        self.assertIn("Check recent submissions", rendered)
+        self.assertIn("do not replay", rendered)
+        self.assertNotIn("session-secret", rendered)
+        open_request.assert_called_once()
+
+    def test_authenticated_error_does_not_echo_reflected_secrets(self):
+        reflected = "session-secret csrf-secret oauth-secret"
+        error = urllib.error.HTTPError(
+            "https://www.reddit.com/api/submit",
+            500,
+            "Internal Server Error",
+            Message(),
+            io.BytesIO(reflected.encode()),
+        )
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        stream = io.StringIO()
+        with patch.object(reddit, "open_request", side_effect=error), self.assertRaises(SystemExit), redirect_stdout(
+            stream
+        ):
+            client.submit(subreddit="test", title="Title", kind="self", text="Body")
+
+        rendered = stream.getvalue()
+        self.assertIn("HTTP 500", rendered)
+        self.assertNotIn("session-secret", rendered)
+        self.assertNotIn("csrf-secret", rendered)
+        self.assertNotIn("oauth-secret", rendered)
+
+    def test_application_error_does_not_echo_reflected_secrets(self):
+        reflected = "session-secret csrf-secret oauth-secret"
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        stream = io.StringIO()
+        response = FakeResponse({"json": {"errors": [["BAD_REQUEST", reflected, reflected]], "data": {}}})
+        with patch.object(reddit, "open_request", return_value=response), self.assertRaises(
+            SystemExit
+        ), redirect_stdout(stream):
+            client.submit(subreddit="test", title="Title", kind="self", text="Body")
+
+        rendered = stream.getvalue()
+        self.assertIn("Reddit rejected the post", rendered)
+        self.assertNotIn("session-secret", rendered)
+        self.assertNotIn("csrf-secret", rendered)
+        self.assertNotIn("oauth-secret", rendered)
+
+    def test_submissions_rejects_malformed_json_shape(self):
+        client = reddit.RedditClient("oauth", token="oauth-secret")
+        client.username = "tester"
+        for payload in (
+            {},
+            [],
+            {"data": {}},
+            {"data": {"children": [{}]}},
+            {"data": {"children": [{"data": {}}]}},
+        ):
+            stream = io.StringIO()
+            with self.subTest(payload=payload), patch.object(
+                client, "request", return_value=payload
+            ), self.assertRaises(SystemExit), redirect_stdout(stream):
+                client.submissions(10)
+            self.assertIn("malformed submissions response", stream.getvalue())
+            self.assertNotIn("oauth-secret", stream.getvalue())
+
+    def test_submissions_accepts_documented_shape(self):
+        client = reddit.RedditClient("oauth", token="oauth-secret")
+        client.username = "tester"
+        payload = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "id": "post1",
+                            "title": "Title",
+                            "subreddit": "test",
+                            "permalink": "/r/test/comments/post1/title/",
+                        }
+                    }
+                ]
+            }
+        }
+        with patch.object(client, "request", return_value=payload):
+            self.assertEqual("post1", client.submissions(10)[0]["id"])
+
+    def test_identity_and_post_reject_malformed_json_shapes(self):
+        identity_client = reddit.RedditClient("oauth", token="oauth-secret")
+        identity_stream = io.StringIO()
+        with patch.object(identity_client, "request", return_value=[]), self.assertRaises(
+            SystemExit
+        ), redirect_stdout(identity_stream):
+            identity_client.me()
+        self.assertIn("malformed identity response", identity_stream.getvalue())
+
+        post_client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        post_client.modhash = "csrf-secret"
+        malformed_posts = (
+            {},
+            {"json": {}},
+            {"json": {"errors": None, "data": {"url": "https://www.reddit.com/r/test/comments/x/title/"}}},
+            {"json": {"errors": [], "data": {"url": ["not", "a", "string"]}}},
+            {"json": {"errors": [], "data": {"url": "https://example.com/not-reddit"}}},
+        )
+        for payload in malformed_posts:
+            post_stream = io.StringIO()
+            with self.subTest(payload=payload), patch.object(
+                post_client, "request", return_value=payload
+            ), self.assertRaises(SystemExit), redirect_stdout(post_stream):
+                post_client.submit(subreddit="test", title="Title", kind="self", text="Body")
+            self.assertIn("malformed write response", post_stream.getvalue())
+            self.assertIn("outcome is unknown", post_stream.getvalue())
+            self.assertIn("do not replay", post_stream.getvalue())
+            self.assertNotIn("csrf-secret", post_stream.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a standard-library Reddit helper that prefers `REDDIT_COOKIES` and falls back to `REDDIT_TOKEN`
- support connected identity, the user’s own recent submissions, and text/link posts
- make every write a network-free dry run until `--confirm` is the final argument
- apply browser-equivalent cookie domain, host-only, path, secure and expiry filtering and never forward credentials across redirects
- redact authenticated response bodies and classify every ambiguous write outcome as unknown, requiring a submissions check and prohibiting automatic replay
- validate strict Reddit response shapes before reporting publication success
- make every SKILL.md Bash recipe self-contained, update go-live documentation, and run helper tests in CI

Paired backend: https://github.com/AceDataCloud/AuthBackend/pull/288

## Validation
- `python3 -m unittest discover -s skills/reddit/tests -p "test_*.py"` (17 passed)
- `ruff check skills/reddit/scripts/reddit.py skills/reddit/tests/test_reddit.py`
- Python 3.9 `py_compile`
- GitHub Actions workflow YAML parse
- `.github/skills` / `.agents/skills` mirror checks
- `git diff --check`

## 🤖 对抗评审
Reviewer: independent Copilot subagent, four convergence rounds.

- fixed raw authenticated HTTP/JSON/application-error leakage
- fixed cookie header injection, missing domains, host-only/domain/path/secure/expiry semantics and conflicting session cookies
- fixed ambiguous redirects, network errors, 5xx, unreadable/truncated/gzip, HTML, invalid JSON and malformed post responses so writes are never blindly replayed
- fixed false success on malformed identity, submissions and post response shapes
- fixed cross-fence shell variable dependence and added CI collection
- verified writes cannot execute without final-position `--confirm`
- final round: `VERDICT: CLEAN`