### PR TITLE
Fix Xiaohongshu Chromium profile path

### DIFF
--- a/skills/xiaohongshu/scripts/xiaohongshu.py
+++ b/skills/xiaohongshu/scripts/xiaohongshu.py
@@ -282,6 +282,10 @@ def _chromium_child_env(workdir: Path) -> dict[str, str]:
     }
 
 
+def _create_runtime_temp_directory() -> tempfile.TemporaryDirectory[str]:
+    return tempfile.TemporaryDirectory(prefix="acedata-xhs-", dir="/tmp")
+
+
 def _chromium_arguments(
     chromium: str,
     profile_dir: Path,
@@ -693,7 +697,7 @@ class DirectXiaohongshuRuntime:
         from xhs.stealth import STEALTH_ARGS
 
         chromium = _resolve_executable("XIAOHONGSHU_CHROMIUM_BIN", CHROMIUM_PATHS)
-        self.temp_dir = tempfile.TemporaryDirectory(prefix="acedata-xhs-")
+        self.temp_dir = _create_runtime_temp_directory()
         self.workdir = Path(self.temp_dir.name)
         self.workdir.chmod(0o700)
         profile_dir = self.workdir / "profile"

--- a/skills/xiaohongshu/tests/test_xiaohongshu.py
+++ b/skills/xiaohongshu/tests/test_xiaohongshu.py
@@ -300,6 +300,15 @@ class CommandSafetyTests(unittest.TestCase):
         self.assertNotIn(MODULE.COOKIE_ENV, child_env)
         self.assertEqual(child_env["HOME"], "/tmp/xhs")
 
+    def test_runtime_profile_ignores_long_sandbox_tmpdir(self) -> None:
+        sandbox_tmpdir = "/tmp/sessions/" + "session-" * 20
+        with patch.dict(os.environ, {"TMPDIR": sandbox_tmpdir}, clear=False):
+            temp_dir = MODULE._create_runtime_temp_directory()
+        try:
+            self.assertEqual(Path(temp_dir.name).parent, Path("/tmp"))
+        finally:
+            temp_dir.cleanup()
+
     def test_confirmed_write_dispatches_converted_cookies_in_memory(self) -> None:
         args = argparse.Namespace(
             command="like",


### PR DESCRIPTION
## Summary
- create Xiaohongshu Chromium runtime profiles directly under `/tmp`
- avoid inheriting the sandbox's long per-session `TMPDIR`, which exceeds Chromium's Unix socket path limit
- add a regression test with a deliberately long sandbox-style `TMPDIR`

## Root cause
Production `/execute` sets `TMPDIR` to a per-session directory. The Skill nested its random Chromium profile beneath that path, and Chromium aborted with `Socket path too long` before CDP startup.

A/B diagnosis on the production sandbox:
- direct short-path runtime: 20/20 passed
- normal `/execute`: 20/20 failed
- short session path: 2/2 passed
- only forcing `TemporaryDirectory(dir="/tmp")`: 20/20 passed across both replicas

FD mapping, executable, permissions, flags, and CDP transport were independently verified and are not causal.

## Validation
- Xiaohongshu tests: 35 passed
- Python compile: passed
- `git diff --check`: passed

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)
- `VERDICT: CLEAN`