### PR TITLE
Fix Xiaohongshu trusted publish flow

### DIFF
--- a/skills/xiaohongshu/scripts/vendor/xhs/cdp.py
+++ b/skills/xiaohongshu/scripts/vendor/xhs/cdp.py
@@ -11,6 +11,7 @@ import os
 import random
 import select
 import time
+from collections import deque
 from typing import Any
 
 from .errors import CDPError, ElementNotFoundError
@@ -105,6 +106,7 @@ class Page:
         self.session_id = session_id
         self._transport = cdp._transport
         self._id_counter = 1000
+        self._events: deque[dict[str, Any]] = deque(maxlen=256)
 
     def _send_session(self, method: str, params: dict | None = None) -> dict:
         """向 session 发送命令。"""
@@ -132,7 +134,24 @@ class Page:
                 if "error" in data:
                     raise CDPError(f"CDP 错误: {data['error']}")
                 return data.get("result", {})
+            if "method" in data and data.get("sessionId") == self.session_id:
+                self._events.append(data)
         raise CDPError(f"等待 session 响应超时 (id={msg_id})")
+
+    def clear_events(self) -> None:
+        self._events.clear()
+
+    def wait_for_event(self, timeout: float) -> dict[str, Any] | None:
+        if self._events:
+            return self._events.popleft()
+        try:
+            raw = self._transport.recv(timeout)
+        except TimeoutError:
+            return None
+        data = json.loads(raw)
+        if "method" in data and data.get("sessionId") == self.session_id:
+            return data
+        return None
 
     def navigate(self, url: str) -> None:
         """导航到指定 URL。"""
@@ -334,6 +353,97 @@ class Page:
         time.sleep(random.uniform(0.03, 0.08))
         self.mouse_click(x, y)
         return True
+
+    def click_pierced_button(self, host_name: str, button_text: str) -> bool:
+        document = self._send_session("DOM.getDocument", {"depth": -1, "pierce": True})
+        targets: list[dict[str, Any]] = []
+
+        def attrs(node: dict[str, Any]) -> dict[str, str]:
+            values = node.get("attributes") or []
+            return dict(zip(values[0::2], values[1::2]))
+
+        def content(node: dict[str, Any]) -> str:
+            chunks = [node.get("nodeValue") or ""]
+            for child in node.get("children") or []:
+                chunks.append(content(child))
+            for shadow_root in node.get("shadowRoots") or []:
+                chunks.append(content(shadow_root))
+            return "".join(chunks).strip()
+
+        def find_button(node: dict[str, Any]) -> None:
+            properties = attrs(node)
+            if (
+                node.get("nodeName") == "BUTTON"
+                and content(node) == button_text
+                and "disabled" not in properties
+                and properties.get("aria-disabled") != "true"
+            ):
+                targets.append(node)
+                return
+            for child in node.get("children") or []:
+                find_button(child)
+            for shadow_root in node.get("shadowRoots") or []:
+                find_button(shadow_root)
+
+        def find_host(node: dict[str, Any]) -> None:
+            properties = attrs(node)
+            if node.get("nodeName") == host_name.upper() and properties.get("is-publish") == "true":
+                for shadow_root in node.get("shadowRoots") or []:
+                    find_button(shadow_root)
+                return
+            for child in node.get("children") or []:
+                find_host(child)
+
+        find_host(document["root"])
+        for target in targets:
+            node_ref = {"backendNodeId": target["backendNodeId"]}
+            try:
+                self._send_session("DOM.scrollIntoViewIfNeeded", node_ref)
+                model = self._send_session("DOM.getBoxModel", node_ref).get("model")
+            except CDPError:
+                continue
+            if not model or not model.get("width") or not model.get("height"):
+                continue
+            quad = model.get("border") or model.get("content")
+            if not quad or len(quad) < 8:
+                continue
+            x = sum(quad[0::2]) / 4
+            y = sum(quad[1::2]) / 4
+            hit = self._send_session(
+                "DOM.getNodeForLocation",
+                {"x": int(x), "y": int(y), "includeUserAgentShadowDOM": True},
+            )
+            hit_id = hit.get("backendNodeId")
+            if hit_id != target.get("backendNodeId"):
+                if not hit_id:
+                    continue
+                try:
+                    hit_object_id = self._send_session(
+                        "DOM.resolveNode", {"backendNodeId": hit_id}
+                    ).get("object", {}).get("objectId")
+                    button_object_id = self._send_session(
+                        "DOM.resolveNode", node_ref
+                    ).get("object", {}).get("objectId")
+                    if not hit_object_id or not button_object_id:
+                        continue
+                    contains = self._send_session(
+                        "Runtime.callFunctionOn",
+                        {
+                            "objectId": hit_object_id,
+                            "functionDeclaration": "function(button) { return button.contains(this); }",
+                            "arguments": [{"objectId": button_object_id}],
+                            "returnByValue": True,
+                        },
+                    ).get("result", {}).get("value")
+                except CDPError:
+                    contains = False
+                if contains is not True:
+                    continue
+            self.mouse_move(x, y)
+            time.sleep(random.uniform(0.03, 0.08))
+            self.mouse_click(x, y)
+            return True
+        return False
 
     def input_text(self, selector: str, text: str) -> None:
         """向指定选择器的元素输入文本。"""

--- a/skills/xiaohongshu/scripts/vendor/xhs/publish.py
+++ b/skills/xiaohongshu/scripts/vendor/xhs/publish.py
@@ -7,6 +7,8 @@ import logging
 import random
 import re
 import time
+import base64
+from urllib.parse import urlsplit
 
 from .cdp import Page
 from .errors import (
@@ -255,45 +257,160 @@ def click_publish_button(page: Page) -> None:
         """
     )
 
-    # 2) dispatchEvent 触发发布
-    fire_result = page.evaluate(
+    # 2) 点击 closed shadow DOM 内的真实按钮（CDP Input，isTrusted=true）
+    host_state = page.evaluate(
         """
         (() => {
             const host = document.querySelector('xhs-publish-btn[is-publish="true"]');
             if (!host) return 'not_found';
             if (host.getAttribute('submit-disabled') === 'true') return 'disabled';
             window.__xhsPublishStartedAt = Date.now();
-            if (typeof host._onPublish === 'function') host._onPublish();
-            else host.dispatchEvent(new CustomEvent('publish', {
-                bubbles: true, composed: true, cancelable: true
-            }));
-            return 'fired';
+            return 'ready';
         })()
         """
     )
-    if fire_result == "not_found":
+    if host_state == "not_found":
         raise PublishError("未找到 <xhs-publish-btn> 发布按钮容器")
-    if fire_result == "disabled":
+    if host_state == "disabled":
         raise PublishError("发布按钮 submit-disabled=true，不可发布")
+    page._send_session("Network.enable")
+    page.clear_events()
+    if not page.click_pierced_button("xhs-publish-btn", "发布"):
+        raise PublishError("未找到可安全点击的原生发布按钮")
 
-    # 3) 轮询等待 publish API 响应（15s 超时）
+    # 3) 优先从 CDP Network 事件读取响应，页面 hook 仅作兼容兜底
     deadline = time.monotonic() + 15
     result = None
+    requests: dict[str, bool] = {}
+
+    def publish_path_kind(url: str) -> str:
+        segments = {part for part in urlsplit(url).path.lower().split("/") if part}
+        note_segments = {"note", "notes", "publish_note", "create_note"}
+        if not segments & note_segments:
+            return ""
+        if segments & {"publish", "publish_note"}:
+            return "publish"
+        if segments & {"create", "create_note"}:
+            return "create"
+        return ""
+
+    def publish_result(body: str) -> dict[str, Any] | None:
+        try:
+            parsed = json.loads(body)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        serialized = json.dumps(parsed, ensure_ascii=False)
+        has_publish_evidence = bool(
+            re.search(r'"note_id"\s*:\s*"[^"\s]+"', serialized)
+            or re.search(r'"code"\s*:\s*-913\d', serialized)
+            or "禁止发笔记" in serialized
+            or "HTTPBizError" in serialized
+        )
+        return parsed if has_publish_evidence else None
+
+    def find_field(value: Any, name: str) -> Any:
+        if isinstance(value, dict):
+            if name in value:
+                return value[name]
+            for item in value.values():
+                found = find_field(item, name)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for item in value:
+                found = find_field(item, name)
+                if found is not None:
+                    return found
+        return None
+
+    def find_risk(value: Any) -> tuple[int, str] | None:
+        if isinstance(value, dict):
+            code_value = value.get("code")
+            if isinstance(code_value, int) and -9140 <= code_value <= -9130:
+                return code_value, str(value.get("msg") or "账号被风控")
+            for item in value.values():
+                found = find_risk(item)
+                if found:
+                    return found
+        elif isinstance(value, list):
+            for item in value:
+                found = find_risk(item)
+                if found:
+                    return found
+        return None
+
     while time.monotonic() < deadline:
-        result = page.evaluate("window.__xhsPublishResult")
+        event = page.wait_for_event(min(0.3, max(0.01, deadline - time.monotonic())))
+        if event and event.get("method") == "Network.requestWillBeSent":
+            params = event.get("params") or {}
+            request = params.get("request") or {}
+            method = str(request.get("method") or "")
+            url = str(request.get("url") or "")
+            path_kind = publish_path_kind(url)
+            if method in {"POST", "PUT", "PATCH"} and path_kind:
+                requests[str(params.get("requestId") or "")] = path_kind == "publish"
+        elif event and event.get("method") == "Network.loadingFinished":
+            params = event.get("params") or {}
+            request_id = str(params.get("requestId") or "")
+            if request_id in requests:
+                authoritative_success = requests[request_id]
+                try:
+                    response_body = page._send_session(
+                        "Network.getResponseBody", {"requestId": request_id}
+                    )
+                    body = response_body.get("body", "")
+                    if response_body.get("base64Encoded") is True:
+                        body = base64.b64decode(body, validate=True).decode("utf-8")
+                    parsed = publish_result(body)
+                    if parsed:
+                        risk = find_risk(parsed)
+                        note_id = find_field(parsed, "note_id")
+                        if risk or authoritative_success or not note_id:
+                            result = {"source": "cdp", **parsed}
+                except (CDPError, ValueError, UnicodeDecodeError):
+                    result = None
+                finally:
+                    requests.pop(request_id, None)
+        elif event and event.get("method") == "Network.loadingFailed":
+            request_id = str((event.get("params") or {}).get("requestId") or "")
+            requests.pop(request_id, None)
+        if not result:
+            fallback = page.evaluate("window.__xhsPublishResult")
+            if isinstance(fallback, dict):
+                fallback_code = fallback.get("code")
+                fallback_msg = str(fallback.get("msg") or "")
+                if (
+                    isinstance(fallback_code, int)
+                    and fallback_code != 0
+                    or "HTTPBizError" in fallback_msg
+                    or "禁止发笔记" in fallback_msg
+                ):
+                    result = fallback
         if result:
             break
-        time.sleep(0.3)
 
     if not result:
         raise PublishError("15s 内未捕获到发布成功反馈")
 
     # 4) 解析业务码
     source = result.get("source", "unknown")
-    code = result.get("code")
-    msg = result.get("msg", "")
+    nested_risk = find_risk(result)
+    if nested_risk:
+        raise AccountRiskControlError(*nested_risk)
+    code = find_field(result, "code")
+    msg = find_field(result, "msg") or ""
     success = result.get("success")
+    note_id = find_field(result, "note_id")
+    if not isinstance(note_id, str):
+        note_id = ""
     logger.info("捕获发布响应（来源=%s code=%s msg=%r）", source, code, msg)
+
+    if note_id:
+        logger.info("发布成功（CDP 已返回 note_id）")
+        time.sleep(2)
+        return
 
     if code == 0 or success is True:
         confirmed = page.evaluate(
@@ -972,13 +1089,16 @@ def _set_visibility(page: Page, visibility: str) -> None:
 
     selected = page.evaluate(
         f"""
-        (() => [...document.querySelectorAll({json.dumps(VISIBILITY_OPTIONS)})]
-            .some(opt => opt.textContent.includes({json.dumps(visibility)}) && (
+        (() => {{
+            const legacySelected = [...document.querySelectorAll({json.dumps(VISIBILITY_OPTIONS)})]
+                .some(opt => opt.textContent.includes({json.dumps(visibility)}) && (
                 opt.classList.contains('active')
                 || opt.classList.contains('selected')
                 || opt.getAttribute('aria-selected') === 'true'
                 || opt.querySelector('input:checked')
-            )))()
+            ));
+            return legacySelected;
+        }})()
         """
     )
     if not selected:

--- a/skills/xiaohongshu/tests/test_xiaohongshu.py
+++ b/skills/xiaohongshu/tests/test_xiaohongshu.py
@@ -538,13 +538,366 @@ class CommandSafetyTests(unittest.TestCase):
         import xhs.publish as publish
 
         page = MagicMock()
-        page.evaluate.side_effect = [None, "fired", *([None] * 60)]
+        page.evaluate.side_effect = [None, "ready", *([None] * 60)]
+        page.wait_for_event.return_value = None
+        page.click_pierced_button.return_value = True
         with (
             patch.object(publish.time, "monotonic", side_effect=[0, 0, *range(1, 17)]),
-            patch.object(publish.time, "sleep"),
             self.assertRaisesRegex(publish.PublishError, "未捕获到发布成功反馈"),
         ):
             publish.click_publish_button(page)
+
+    def test_publish_ignores_creator_telemetry_and_waits_for_finished_body(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [None, "ready", None, None, None, None, True]
+        page.click_pierced_button.return_value = True
+        page.wait_for_event.side_effect = [
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "telemetry",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://creator.xiaohongshu.com/api/telemetry",
+                    },
+                },
+            },
+            {"method": "Network.loadingFinished", "params": {"requestId": "telemetry"}},
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "publish",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://edith.xiaohongshu.com/api/sns/web/v1/note/publish",
+                    },
+                },
+            },
+            {
+                "method": "Network.responseReceived",
+                "params": {"requestId": "publish"},
+            },
+            {"method": "Network.loadingFinished", "params": {"requestId": "publish"}},
+        ]
+
+        def send(method: str, _params: dict | None = None) -> dict:
+            if method == "Network.getResponseBody":
+                return {"body": '{"code":0,"data":{"note_id":"note"}}'}
+            return {}
+
+        page._send_session.side_effect = send
+        with (
+            patch.object(publish.time, "monotonic", return_value=0),
+            patch.object(publish.time, "sleep"),
+        ):
+            publish.click_publish_button(page)
+
+        body_calls = [
+            call
+            for call in page._send_session.call_args_list
+            if call.args and call.args[0] == "Network.getResponseBody"
+        ]
+        self.assertEqual(len(body_calls), 1)
+        self.assertEqual(body_calls[0].args[1], {"requestId": "publish"})
+
+    def test_publish_decodes_base64_body_and_ignores_success_fallback(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import base64
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [
+            None,
+            "ready",
+            {"code": 0, "success": True, "note_id": "autosave"},
+            {"code": 0, "success": True, "note_id": "autosave"},
+            True,
+        ]
+        page.click_pierced_button.return_value = True
+        page.wait_for_event.side_effect = [
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "publish",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://edith.xiaohongshu.com/api/note/publish",
+                    },
+                },
+            },
+            {"method": "Network.responseReceived", "params": {"requestId": "publish"}},
+            {"method": "Network.loadingFinished", "params": {"requestId": "publish"}},
+        ]
+        encoded = base64.b64encode(b'{"data":{"note_id":"published"}}').decode()
+
+        def send(method: str, _params: dict | None = None) -> dict:
+            if method == "Network.getResponseBody":
+                return {"body": encoded, "base64Encoded": True}
+            return {}
+
+        page._send_session.side_effect = send
+        with (
+            patch.object(publish.time, "monotonic", return_value=0),
+            patch.object(publish.time, "sleep"),
+        ):
+            publish.click_publish_button(page)
+
+        self.assertEqual(
+            [call.args[0] for call in page._send_session.call_args_list].count(
+                "Network.getResponseBody"
+            ),
+            1,
+        )
+
+    def test_publish_classifies_nested_risk_control_response(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [None, "ready", None]
+        page.click_pierced_button.return_value = True
+        page.wait_for_event.side_effect = [
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "publish",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://edith.xiaohongshu.com/api/note/publish",
+                    },
+                },
+            },
+            {"method": "Network.loadingFinished", "params": {"requestId": "publish"}},
+        ]
+        page._send_session.side_effect = lambda method, _params=None: (
+            {"body": '{"code":0,"data":{"code":-9136,"msg":"禁止发笔记"}}'}
+            if method == "Network.getResponseBody"
+            else {}
+        )
+        with (
+            patch.object(publish.time, "monotonic", return_value=0),
+            self.assertRaises(publish.AccountRiskControlError),
+        ):
+            publish.click_publish_button(page)
+
+    def test_create_note_id_cannot_outrun_publish_response(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [None, "ready", None, None, None, True]
+        page.click_pierced_button.return_value = True
+        page.wait_for_event.side_effect = [
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "create",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://edith.xiaohongshu.com/api/note/create",
+                    },
+                },
+            },
+            {"method": "Network.loadingFinished", "params": {"requestId": "create"}},
+            {
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "publish",
+                    "request": {
+                        "method": "POST",
+                        "url": "https://edith.xiaohongshu.com/api/note/publish",
+                    },
+                },
+            },
+            {"method": "Network.loadingFinished", "params": {"requestId": "publish"}},
+        ]
+
+        def send(method: str, params: dict | None = None) -> dict:
+            if method != "Network.getResponseBody":
+                return {}
+            note_id = "draft" if params == {"requestId": "create"} else "published"
+            return {"body": json.dumps({"data": {"note_id": note_id}})}
+
+        page._send_session.side_effect = send
+        with (
+            patch.object(publish.time, "monotonic", return_value=0),
+            patch.object(publish.time, "sleep"),
+        ):
+            publish.click_publish_button(page)
+
+        body_ids = [
+            call.args[1]["requestId"]
+            for call in page._send_session.call_args_list
+            if call.args and call.args[0] == "Network.getResponseBody"
+        ]
+        self.assertEqual(body_ids, ["create", "publish"])
+
+    def test_page_retains_unsolicited_events_while_waiting_for_response(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        from xhs.cdp import Page
+
+        transport = MagicMock()
+        expected_event = {
+            "method": "Network.responseReceived",
+            "sessionId": "session",
+            "params": {"requestId": "request"},
+        }
+        transport.recv.side_effect = [
+            json.dumps(expected_event),
+            json.dumps({"id": 1001, "result": {"ok": True}}),
+        ]
+        page = Page(MagicMock(_transport=transport), "target", "session")
+
+        self.assertEqual(page._wait_session(1001), {"ok": True})
+        self.assertEqual(page.wait_for_event(0), expected_event)
+
+    def test_page_event_queue_is_bounded(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        from xhs.cdp import Page
+
+        page = Page(MagicMock(_transport=MagicMock()), "target", "session")
+        for index in range(300):
+            page._events.append({"method": "Network.event", "index": index})
+        self.assertEqual(len(page._events), 256)
+        self.assertEqual(page._events[0]["index"], 44)
+
+    def test_pierced_publish_button_requires_coordinate_hit(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        from xhs.cdp import Page
+
+        page = Page(MagicMock(_transport=MagicMock()), "target", "session")
+        page._send_session = MagicMock(
+            side_effect=[
+                {
+                    "root": {
+                        "nodeName": "#document",
+                        "children": [
+                            {
+                                "nodeName": "XHS-PUBLISH-BTN",
+                                "attributes": ["is-publish", "true"],
+                                "shadowRoots": [
+                                    {
+                                        "nodeName": "#document-fragment",
+                                        "children": [
+                                            {
+                                                "nodeName": "BUTTON",
+                                                "backendNodeId": 42,
+                                                "children": [
+                                                    {"nodeName": "#text", "nodeValue": "发布"}
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+                {},
+                {
+                    "model": {
+                        "width": 10,
+                        "height": 10,
+                        "border": [0, 0, 10, 0, 10, 10, 0, 10],
+                    }
+                },
+                {"backendNodeId": 43},
+                {"object": {"objectId": "hit"}},
+                {"object": {"objectId": "button"}},
+                {"result": {"value": False}},
+            ]
+        )
+        page.mouse_click = MagicMock()
+
+        self.assertFalse(page.click_pierced_button("xhs-publish-btn", "发布"))
+        page.mouse_click.assert_not_called()
+
+    def test_pierced_publish_button_skips_hidden_first_candidate(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        from xhs.cdp import Page
+
+        def button(backend_node_id: int) -> dict:
+            return {
+                "nodeName": "BUTTON",
+                "backendNodeId": backend_node_id,
+                "children": [{"nodeName": "#text", "nodeValue": "发布"}],
+            }
+
+        page = Page(MagicMock(_transport=MagicMock()), "target", "session")
+        page._send_session = MagicMock(
+            side_effect=[
+                {
+                    "root": {
+                        "nodeName": "#document",
+                        "children": [
+                            {
+                                "nodeName": "XHS-PUBLISH-BTN",
+                                "attributes": ["is-publish", "true"],
+                                "shadowRoots": [
+                                    {
+                                        "nodeName": "#document-fragment",
+                                        "children": [button(41), button(42)],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+                {},
+                {"model": {"width": 0, "height": 0, "border": [0] * 8}},
+                {},
+                {
+                    "model": {
+                        "width": 10,
+                        "height": 10,
+                        "border": [0, 0, 10, 0, 10, 10, 0, 10],
+                    }
+                },
+                {"backendNodeId": 42},
+            ]
+        )
+        page.mouse_move = MagicMock()
+        page.mouse_click = MagicMock()
+
+        with patch("xhs.cdp.time.sleep"):
+            self.assertTrue(page.click_pierced_button("xhs-publish-btn", "发布"))
+        page.mouse_click.assert_called_once()
+
+    def test_visibility_requires_explicit_selected_marker(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [True, False]
+        with (
+            patch.object(publish.time, "sleep"),
+            self.assertRaisesRegex(publish.PublishError, "可见范围未确认生效"),
+        ):
+            publish._set_visibility(page, "仅自己可见")
+        script = page.evaluate.call_args_list[1].args[0]
+        self.assertNotIn("dropdown?.textContent", script)
+
+    def test_visibility_accepts_explicit_selected_marker(self) -> None:
+        if str(MODULE.VENDOR_DIR) not in sys.path:
+            sys.path.insert(0, str(MODULE.VENDOR_DIR))
+        import xhs.publish as publish
+
+        page = MagicMock()
+        page.evaluate.side_effect = [True, True]
+        with patch.object(publish.time, "sleep"):
+            publish._set_visibility(page, "仅自己可见")
 
     def test_verification_challenge_stops_without_navigation_retry(self) -> None:
         if str(MODULE.VENDOR_DIR) not in sys.path:


### PR DESCRIPTION
## Summary
- click Xiaohongshu's real enabled native publish button inside the closed shadow DOM using trusted CDP mouse events
- retain a bounded per-page CDP event queue and observe publish responses through `Network.*` events
- wait for `Network.loadingFinished`, decode base64 bodies, and normalize nested note IDs / risk-control errors
- correlate only note publish/create endpoint paths; create/autosave responses cannot declare publish success
- keep page XHR/fetch/toast hooks as error-only fallback
- fail closed when private visibility has no explicit selected/checked marker

## Production evidence
A non-mutating creator-form inspection with the only valid active Cookie connection uploaded a generated image and filled an ephemeral private form, stopping before publish. It confirmed:
- enabled visible `<xhs-publish-btn>` host
- closed shadow DOM with a real enabled native `button` named `发布`
- native `click` listener and host `publish` listener
- CDP box center hit-tests into the native button
- active service worker, so page-level XHR/fetch hooks are not authoritative

The previous private publish attempt invoked the old `_onPublish`/synthetic-event path once and timed out without producing a note. No interaction writes were attempted.

## Validation
- Xiaohongshu focused suite: 45 passed
- repository unittest: 18 passed
- all Python Skill tests: 62 passed + 20 subtests
- Python compile and `git diff --check`: passed
- editor diagnostics: zero
- temporary production probes: zero

## Rollout
This PR must remain OPEN for manual review. After the user merges it, wait for Skill catalog sync, then perform one uniquely titled `仅自己可见` publish and reconcile account state before testing comment/reply/like/favorite.

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: creator hostname caused telemetry false matches → fixed with pathname segment correlation
- RISK: response body read before completion → fixed by waiting for `Network.loadingFinished`
- RISK: hidden first shadow button blocked active candidate → fixed by iterating visible hit-tested candidates
- RISK: page fallback could outrun CDP → fixed; fallback is error-only
- RISK: nested note ID and base64 responses mishandled → fixed and tested
- RISK: descendant hit nodes rejected valid buttons → fixed with resolved-node containment
- RISK: visibility broad text could publish publicly → removed; explicit marker required
- RISK: nested risk code shadowed by outer success → nested -913x takes precedence
- RISK: create/autosave note ID declared publish success → only true publish endpoint may declare success