### PR TITLE
fix(tgstat): bound render retries to a wall-time budget

### DIFF
--- a/skills/tgstat/SKILL.md
+++ b/skills/tgstat/SKILL.md
@@ -12,7 +12,7 @@ allowed_tools: [Bash, web_search, web_fetch]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "2.2"
+  version: "2.3"
 ---
 
 # TGStat Research
@@ -104,6 +104,12 @@ command enriches the result from the ranking snapshot. Empty or missing metrics
 mean TGStat did not expose them on the public page; do not call that full
 statistics. Use `rankings` when you need reach / citation index for large
 public sources.
+
+Individual channel/chat pages are more aggressively bot-protected than the
+ranking pages, so an `info`/`stat` lookup may occasionally return a
+`render blocked` / `could not render` error. It fails fast (well under the
+Bash timeout) — retry once, or fall back to `rankings` and `search` for
+discovery, which are far more reliable.
 
 For ad selection, rank by relevant reach/activity rather than subscriber count
 alone. High subscribers with weak reach or chat MAU can indicate an inactive or

--- a/skills/tgstat/scripts/tgstat.py
+++ b/skills/tgstat/scripts/tgstat.py
@@ -316,24 +316,44 @@ def _render_token() -> str:
 # 422 antibot_blocked, and the render service can transiently 429/5xx.
 _RETRYABLE_RENDER_STATUS = frozenset({422, 425, 429, 500, 502, 503, 504})
 _RENDER_ATTEMPTS = 3
+# Total wall-time budget for one lookup. The agent sandbox kills a Bash command
+# at ~60s, so keep every render (incl. anti-bot retries) safely under that: a
+# stubborn page fails fast instead of being killed mid-retry.
+_RENDER_BUDGET_SECONDS = 46
+# Shared deadline across every render in a single command invocation, so a
+# multi-render command (info tries channel + chat + a ranking fallback) can
+# never exceed the sandbox cap by stacking per-render budgets.
+_OPERATION_DEADLINE: Optional[float] = None
+
+
+def _op_deadline() -> float:
+    global _OPERATION_DEADLINE
+    if _OPERATION_DEADLINE is None:
+        _OPERATION_DEADLINE = time.monotonic() + _RENDER_BUDGET_SECONDS + 2
+    return _OPERATION_DEADLINE
 
 
 def _request_with_url(url: str, timeout: int) -> Tuple[str, str]:
     # Public tgstat.com is behind Cloudflare; render it through the platform
     # WebExtrator service (headless Chromium) rather than fetching directly.
-    # Anti-bot blocks are intermittent, so retry with a longer settle and a
-    # cache bypass before giving up.
+    # Anti-bot blocks are intermittent, so retry with a cache bypass — but stay
+    # inside a wall-time budget so the caller never times out mid-retry.
     _validate_request_url(url)
-    render_timeout = max(20, min(timeout, 45))
+    render_timeout = max(15, min(timeout, 30))
     token = _render_token()
-    last_reason = ""
+    deadline = min(time.monotonic() + _RENDER_BUDGET_SECONDS, _op_deadline())
+    last_reason = "render timed out"
     for attempt in range(_RENDER_ATTEMPTS):
+        remaining = deadline - time.monotonic()
+        if remaining < 8:
+            break
+        nav_timeout = max(6, int(min(render_timeout, remaining - 5)))
         payload = json.dumps(
             {
                 "url": url,
                 "wait_until": "domcontentloaded",
-                "delay": RENDER_DELAY_SECONDS + 2 * attempt,
-                "timeout": render_timeout,
+                "delay": RENDER_DELAY_SECONDS + attempt,
+                "timeout": nav_timeout,
                 "block_resources": RENDER_BLOCK_RESOURCES,
                 "bypass_cache": attempt > 0,
             }
@@ -348,18 +368,20 @@ def _request_with_url(url: str, timeout: int) -> Tuple[str, str]:
             },
         )
         try:
-            with urllib.request.urlopen(request, timeout=render_timeout + 75) as response:
+            # `remaining` bounds the socket op; the render service returns one
+            # JSON body, so this single read is what the wall budget relies on.
+            with urllib.request.urlopen(request, timeout=remaining) as response:
                 envelope = json.loads(response.read().decode("utf-8", "replace"))
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", "replace")
             if exc.code in _RETRYABLE_RENDER_STATUS or "antibot" in body.lower():
                 last_reason = f"render blocked (HTTP {exc.code}): {_safe_error_body(body)}"
-                _render_backoff(attempt)
+                _render_backoff(attempt, deadline)
                 continue
             raise TGStatError(f"render service HTTP {exc.code}: {_safe_error_body(body)}") from exc
         except urllib.error.URLError as exc:
             last_reason = f"render service unreachable: {_safe_error_body(str(exc.reason))}"
-            _render_backoff(attempt)
+            _render_backoff(attempt, deadline)
             continue
         except json.JSONDecodeError as exc:
             raise TGStatError(f"render service returned invalid JSON: {_safe_error_body(str(exc))}") from exc
@@ -375,14 +397,18 @@ def _request_with_url(url: str, timeout: int) -> Tuple[str, str]:
             last_reason = f"empty or interstitial render (upstream status {render.get('status')})"
         else:
             last_reason = "render service returned no page data"
-        _render_backoff(attempt)
+        _render_backoff(attempt, deadline)
     raise TGStatError(f"could not render {_safe_url(url)}: {last_reason}")
 
 
-def _render_backoff(attempt: int) -> None:
-    # Skip the wait after the final attempt; give Cloudflare a moment otherwise.
-    if attempt < _RENDER_ATTEMPTS - 1:
-        time.sleep(min(2 + 2 * attempt, 6))
+def _render_backoff(attempt: int, deadline: float) -> None:
+    # Short settle between attempts, but never sleep past the wall-time budget.
+    if attempt >= _RENDER_ATTEMPTS - 1:
+        return
+    remaining = deadline - time.monotonic()
+    if remaining <= 8:
+        return
+    time.sleep(min(1.5 + attempt, 3.0, remaining - 8))
 
 
 def _request(url: str, timeout: int) -> str:
@@ -588,7 +614,7 @@ def command_stat(args: argparse.Namespace) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default=os.environ.get("TGSTAT_PUBLIC_HOST", DEFAULT_PUBLIC_BASE))
-    parser.add_argument("--timeout", type=int, default=45)
+    parser.add_argument("--timeout", type=int, default=30)
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("profile").set_defaults(func=command_profile)
@@ -616,6 +642,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    global _OPERATION_DEADLINE
+    _OPERATION_DEADLINE = None  # fresh render budget per command invocation
     args = build_parser().parse_args()
     try:
         args.func(args)

--- a/tests/test_tgstat.py
+++ b/tests/test_tgstat.py
@@ -34,6 +34,11 @@ class _FakeHTTPResponse:
 
 
 class TGStatParserTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # The render budget is a module global set lazily on first render; reset
+        # it so tests don't leak a stale deadline into one another.
+        tgstat._OPERATION_DEADLINE = None
+
     def test_skill_has_one_frontmatter_block(self) -> None:
         skill = SCRIPT.parent.parent / "SKILL.md"
         text = skill.read_text(encoding="utf-8")
@@ -130,6 +135,17 @@ class TGStatParserTests(unittest.TestCase):
     def test_render_requires_configured_token(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True), self.assertRaises(tgstat.TGStatError):
             tgstat._request_with_url("https://tgstat.com/channel/@durov", 30)
+
+    def test_render_stops_when_budget_exhausted(self) -> None:
+        # monotonic jumps past the deadline before the first attempt runs, so the
+        # loop must fast-fail without ever calling urlopen (no sandbox timeout).
+        times = [0.0, 0.0, 100.0, 100.0, 100.0]
+        with mock.patch.dict(os.environ, {"TGSTAT_RENDER_TOKEN": "t"}, clear=True), mock.patch.object(
+            tgstat.time, "monotonic", side_effect=times
+        ), mock.patch.object(tgstat.urllib.request, "urlopen") as urlopen:
+            with self.assertRaises(tgstat.TGStatError):
+                tgstat._request_with_url("https://tgstat.com/channel/@durov", 30)
+            urlopen.assert_not_called()
 
     def test_numeric_ids_are_normalized_for_public_pages(self) -> None:
         self.assertEqual(tgstat._normalize_target("53248")[0], "id53248")


### PR DESCRIPTION
## Summary
When Cloudflare anti-bot (HTTP 422) blocks a tgstat render, the retry loop could exceed the agent sandbox's ~60s Bash command cap and get killed mid-retry (seen live: `timeout of 60000ms exceeded`, wasting agent turns). This bounds every lookup to a wall-time budget so a stubborn page fails fast instead.

## Changes (`scripts/tgstat.py`)
- Per-command **shared render deadline** (`_OPERATION_DEADLINE`, budget 46s, reset per `main()` invocation). `info --type auto` (channel + chat + ranking fallback) can no longer stack per-render budgets past the cap.
- Each attempt's `urlopen` timeout = time remaining to the deadline (telescopes to one deadline instead of `3 × timeout`); loop breaks when `< 8s` left.
- Render nav timeout capped 45→30s; default `--timeout` 45→30.
- `SKILL.md`: note that individual pages are more bot-protected than ranking pages — `info`/`stat` may return a fast `render blocked` error; prefer `rankings`/`search` for discovery.

## Validation (live)
- good lookup `info @durov` → real subscribers, ~8–29s
- anti-bot lookup `info @neural_houses` (channel+chat) → clean fail at **44s** (was >60s → killed)
- `rankings` ~25s, full metrics
- 23 unit tests pass, `ruff` clean

## ������ 对抗评审
Reviewer: `general-purpose` subagent. Core telescoping math verified sound (no urlopen≤0, nav_timeout always < socket timeout, no negative sleep / infinite loop). Found **3 RISKs, all fixed**:
1. `_OPERATION_DEADLINE` never reset → in-process reuse / test-isolation landmine. **Fixed**: reset to `None` at the top of `main()`; `setUp` resets it in tests.
2. `urlopen(timeout=)` is per-socket-op, not wall-clock → a chunked body could exceed the budget. **Mitigated**: the render service returns a single JSON body (one bounded read); documented at the call site. Low-risk (trusted first-party upstream).
3. New timing path untested. **Fixed**: added `test_render_stops_when_budget_exhausted` (mocks `time.monotonic`, asserts fast-fail + no `urlopen` call).

`VERDICT: 3 RISK(S)` → resolved.