### PR TITLE
feat(telegram): add join/leave commands (gated)

### DIFF
--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: telegram
-description: Full personal Telegram control over MTProto (Telethon) with the user's own account — list/search chats, read & summarize history, see unread, look up contacts & chat info, download media, and send / reply / forward / edit / delete / react / send files / mark read. Use when the user mentions Telegram, a Telegram chat/group/contact, "我的 Telegram", reading/replying/forwarding/summarizing Telegram messages, their unread Telegram, or sending a file/message on Telegram.
+description: Full personal Telegram control over MTProto (Telethon) with the user's own account — list/search chats, read & summarize history, see unread, look up contacts & chat info, download media, and send / reply / forward / edit / delete / react / send files / mark read / join & leave groups. Use when the user mentions Telegram, a Telegram chat/group/contact, "我的 Telegram", reading/replying/forwarding/summarizing Telegram messages, their unread Telegram, joining or leaving a Telegram group/channel, or sending a file/message on Telegram.
 when_to_use: |
   Trigger for anything on the user's personal Telegram account: list recent
   conversations or just the unread ones, read / summarize a chat or group,
   search one chat or across all chats, look up a contact or a chat's info,
   download a photo/file from a message, or take an action — send, reply,
-  forward, edit, delete, react, send a file, or mark a chat read. This drives
-  the user's OWN account over MTProto (not a bot), so it sees everything they see.
+  forward, edit, delete, react, send a file, mark a chat read, or join / leave
+  a group or channel. This drives the user's OWN account over MTProto (not a
+  bot), so it sees everything they see.
 connections: [telegram]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.2"
+  version: "1.3"
 ---
 
 We drive **personal** Telegram over MTProto with [Telethon](https://docs.telethon.dev/) —
@@ -42,7 +43,7 @@ python3 "$TG" whoami
 ```
 
 Every state-changing command (`send`, `reply`, `send-file`, `forward`, `edit`, `delete`,
-`react`, `mark-read`) is **gated**: without a trailing `--confirm` it only DRY-RUNS (prints what
+`react`, `mark-read`, `join`, `leave`) is **gated**: without a trailing `--confirm` it only DRY-RUNS (prints what
 it would do, changes nothing). Read commands run directly. `--confirm` is honored **only as the
 last argument** so a message/caption that merely contains "--confirm" can never silently confirm.
 
@@ -106,7 +107,15 @@ python3 "$TG" edit    <target> <msg_id> "new text" --confirm   # own messages
 python3 "$TG" delete  <target> <msg_id> --confirm              # destructive
 python3 "$TG" react   <target> <msg_id> "👍" --confirm
 python3 "$TG" mark-read <target> --confirm                     # sends read receipts
+python3 "$TG" join    <@username|t.me/link|t.me/+invite> --confirm  # join a public group/channel or a private invite
+python3 "$TG" leave   <target> --confirm                       # leave a group/channel (not private chats)
 ```
+
+`join` accepts a public `@username` / `t.me/<name>` (→ JoinChannelRequest) or a private
+invite link `t.me/+HASH` / `t.me/joinchat/HASH` (→ ImportChatInviteRequest). Joining someone
+else's group is a real membership change on the account — treat it like any other write:
+dry-run, confirm, then `--confirm`. Never auto-join then bulk-message; that gets accounts
+spam-limited.
 
 The dry run returns `{"dry_run": true, "command": ..., "args": [...]}` — present that to the
 user verbatim as the confirmation prompt.

--- a/skills/telegram/scripts/tg.py
+++ b/skills/telegram/scripts/tg.py
@@ -19,10 +19,10 @@ import tempfile
 import urllib.request
 from urllib.parse import urlparse
 
-from telethon import TelegramClient
+from telethon import TelegramClient, errors, utils
 from telethon.sessions import StringSession
 from telethon.tl import functions
-from telethon.tl.types import ReactionEmoji
+from telethon.tl.types import ReactionEmoji, User
 
 API_ID = int(os.environ["TELEGRAM_API_ID"])
 API_HASH = os.environ["TELEGRAM_API_HASH"]
@@ -35,7 +35,7 @@ CONFIRM = bool(_raw) and _raw[-1] == "--confirm"
 a = _raw[:-1] if CONFIRM else list(_raw)
 cmd = a[0] if a else "help"
 args = a[1:]
-GATED = {"send", "reply", "send-file", "forward", "edit", "delete", "react", "mark-read"}
+GATED = {"send", "reply", "send-file", "forward", "edit", "delete", "react", "mark-read", "join", "leave"}
 
 
 def out(o):
@@ -251,6 +251,33 @@ async def run():
             need(1); ent = await resolve(cl, args[0])
             await cl.send_read_acknowledge(ent)
             out({"marked_read": True})
+
+        elif cmd == "join":
+            need(1); target = args[0]
+            # A public @username / t.me/<user> resolves + JoinChannelRequest; a
+            # private invite (t.me/+HASH, joinchat/HASH, tg://join?invite=HASH)
+            # can't be resolved without joining, so import it by hash directly.
+            link_hash, is_invite = utils.parse_username(target)
+            try:
+                if is_invite:
+                    res = await cl(functions.messages.ImportChatInviteRequest(link_hash))
+                    chat = (getattr(res, "chats", None) or [None])[0]
+                    out({"joined": True, "via": "invite",
+                         "id": getattr(chat, "id", None), "title": getattr(chat, "title", None)})
+                else:
+                    ent = await resolve(cl, target)
+                    await cl(functions.channels.JoinChannelRequest(ent))
+                    out({"joined": True, "via": "public", "id": ent.id,
+                         "title": getattr(ent, "title", None), "username": getattr(ent, "username", None)})
+            except errors.UserAlreadyParticipantError:
+                out({"joined": True, "already_member": True, "target": target})
+
+        elif cmd == "leave":
+            need(1); ent = await resolve(cl, args[0])
+            if isinstance(ent, User):
+                out({"error": "leave applies to groups/channels, not private chats"}); return
+            await cl.delete_dialog(ent)
+            out({"left": True, "id": ent.id})
 
         else:
             out({"error": f"unknown command: {cmd}"}); sys.exit(1)


### PR DESCRIPTION
## Summary
The telegram skill could read/search/send but had no way to **join** a group/channel — the missing capability for the RU AI Telegram 拓客 funnel (discover via tgstat → join target community → engage). Adds `join` and `leave`, both **gated behind `--confirm`** like every other write.

## Changes (`scripts/tg.py`)
- `join <@username | t.me/link | t.me/+invite>`: public → `JoinChannelRequest`; private invite (`t.me/+HASH`, `joinchat/HASH`, `tg://join?invite=`) → `ImportChatInviteRequest`. `utils.parse_username` distinguishes the two; already-member → clean `{joined, already_member}`.
- `leave <target>`: `delete_dialog` (→ LeaveChannelRequest for channels / DeleteChatUserRequest for basic groups), guarded against private `User` chats so it can never delete a DM’s history.
- Both added to the `GATED` set — they **dry-run** unless `--confirm` is the last arg. No membership change happens without confirmation (the dry-run guard returns before the client even connects).
- `SKILL.md`: documents both, updates the gated list + description, v1.2→1.3.

## API verification
All calls verified against Telethon’s official docs (`readthedocs/examples/chats-and-channels.rst`) and `telethon/__init__` export surface (`errors`, `utils` are public). `py_compile` clean; Skills CI does not lint skill scripts (existing semicolon style).

## Safety
This drives the user’s **real** account. Gating is mandatory; the skill instructs: dry-run → show the user → explicit yes → `--confirm`. Never auto-join-then-bulk-message (spam-limits the account). Outreach sends stay one-by-one, human-confirmed.

## ������ 对抗评审
Reviewer: `general-purpose` subagent. **VERDICT: CLEAN.** Verified: join/leave are in `GATED` and the dry-run guard returns before connecting (no unconfirmed membership change possible); public-vs-invite branch correct with no `None`-hash crash; `leave` `User`-guard blocks destructive DM history deletion (bots are `User`s, covered); imports valid (`errors.UserAlreadyParticipantError`, `utils.parse_username` real); non-caught errors format cleanly via the top-level handler; no secret leak / SSRF. Two harmless UX nits noted (raw invite hash without prefix; join-request-approval groups return a generic error).