### PR TITLE
feat(telegram): forum topic support (list-topics + send --topic)

### DIFF
--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: telegram
-description: Full personal Telegram control over MTProto (Telethon) with the user's own account — list/search chats, read & summarize history, see unread, look up contacts & chat info, download media, and send / reply / forward / edit / delete / react / send files / mark read / join & leave groups. Use when the user mentions Telegram, a Telegram chat/group/contact, "我的 Telegram", reading/replying/forwarding/summarizing Telegram messages, their unread Telegram, joining or leaving a Telegram group/channel, or sending a file/message on Telegram.
+description: Full personal Telegram control over MTProto (Telethon) with the user's own account — list/search chats, read & summarize history, see unread, look up contacts & chat info, list a forum group's topics, download media, and send / reply / forward / edit / delete / react / send files / mark read / join & leave groups, including posting into a forum topic thread. Use when the user mentions Telegram, a Telegram chat/group/contact, "我的 Telegram", reading/replying/forwarding/summarizing Telegram messages, their unread Telegram, joining or leaving a Telegram group/channel, posting into a forum group's topic, or sending a file/message on Telegram.
 when_to_use: |
   Trigger for anything on the user's personal Telegram account: list recent
   conversations or just the unread ones, read / summarize a chat or group,
   search one chat or across all chats, look up a contact or a chat's info,
-  download a photo/file from a message, or take an action — send, reply,
-  forward, edit, delete, react, send a file, mark a chat read, or join / leave
-  a group or channel. This drives the user's OWN account over MTProto (not a
-  bot), so it sees everything they see.
+  download a photo/file from a message, list a forum group's topics, or take an
+  action — send, reply, forward, edit, delete, react, send a file, mark a chat
+  read, post into a forum topic, or join / leave a group or channel. This drives
+  the user's OWN account over MTProto (not a bot), so it sees everything they see.
 connections: [telegram]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.3"
+  version: "1.4"
 ---
 
 We drive **personal** Telegram over MTProto with [Telethon](https://docs.telethon.dev/) —
@@ -68,6 +68,7 @@ https://auth.acedata.cloud/user/connections.
 | Search across ALL chats | `python3 "$TG" search-global "kw" 30` |
 | List contacts | `python3 "$TG" contacts` |
 | Info about a chat/user | `python3 "$TG" chat-info <target>` |
+| List a forum group's topics (threads) | `python3 "$TG" list-topics <target>` |
 | t.me link to a message | `python3 "$TG" message-link <target> <msg_id>` |
 
 `<target>` = numeric id (most reliable — from `list-chats`), `@username`, phone, or exact chat
@@ -101,6 +102,7 @@ argument**. Never bulk-send.
 
 ```sh
 python3 "$TG" send    <target> "text"                          # → dry_run; add --confirm to send
+python3 "$TG" send    <target> "text" --topic <top_message> --confirm  # into a forum topic thread
 python3 "$TG" reply   <target> <msg_id> "text" --confirm
 python3 "$TG" forward <from_target> <msg_id> <to_target> --confirm
 python3 "$TG" edit    <target> <msg_id> "new text" --confirm   # own messages
@@ -117,6 +119,13 @@ else's group is a real membership change on the account — treat it like any ot
 dry-run, confirm, then `--confirm`. Never auto-join then bulk-message; that gets accounts
 spam-limited.
 
+**Posting into a forum group.** Some supergroups are *forums*: messages live in topics
+(threads), and a plain `send` to the group root is rejected with `TOPIC_CLOSED`. Run
+`list-topics <target>` first, pick a topic with `"closed": false` (an open chat/offtopic
+thread — often titled `Беседка`/`Флуд`/`Chat`/`Offtopic`/`General`), then post with
+`send <target> "text" --topic <top_message> --confirm` (its `top_message` id is the thread
+anchor).
+
 The dry run returns `{"dry_run": true, "command": ..., "args": [...]}` — present that to the
 user verbatim as the confirmation prompt.
 
@@ -132,6 +141,11 @@ user verbatim as the confirmation prompt.
   scanning dialogs); names need an exact match, usernames need a leading `@`.
 - **`message-link`** only works for public channels/supergroups; private 1:1 / basic groups
   return an error (no shareable link exists).
+- **`TOPIC_CLOSED` on send** = a forum supergroup; you can't post to the root. `list-topics`,
+  pick an open (`"closed": false`) thread, and `send ... --topic <top_message>`.
+- **`ChatWriteForbiddenError` on send** = usually a channel's linked *discussion* group: you
+  must be subscribed to the parent channel (`join <parent_channel>`) before you can write in
+  its comment group, even though the group itself doesn't ban posting.
 - **`edit`/`delete`** generally only apply to the user's own messages (admins can delete others
   in groups they manage).
 

--- a/skills/telegram/scripts/tg.py
+++ b/skills/telegram/scripts/tg.py
@@ -117,6 +117,19 @@ def need(n):
         raise ValueError(f"{cmd} needs {n} argument(s), got {len(args)}")
 
 
+def _pop_opt(argv, name):
+    """Extract `--name VALUE` from argv; return (value_or_None, remaining_argv).
+
+    Only a standalone `--name` token matches, so a message that merely contains
+    the flag text as part of one argument is left untouched.
+    """
+    if name in argv:
+        i = argv.index(name)
+        if i + 1 < len(argv):
+            return argv[i + 1], argv[:i] + argv[i + 2:]
+    return None, argv
+
+
 async def run():
     if cmd in GATED and not CONFIRM:
         out({"dry_run": True, "command": cmd, "args": args,
@@ -185,6 +198,18 @@ async def run():
                 pass
             out(info)
 
+        elif cmd == "list-topics":
+            # Forum-style supergroups organize messages into topics (threads).
+            # A plain send to the group root is rejected (TOPIC_CLOSED); you must
+            # post into an open topic via `send --topic <top_message>`.
+            need(1); ent = await resolve(cl, args[0])
+            limit = int(args[1]) if len(args) > 1 else 100
+            res = await cl(functions.messages.GetForumTopicsRequest(
+                channel=ent, offset_date=0, offset_id=0, offset_topic=0, limit=limit))
+            out([{"id": getattr(t, "id", None), "title": getattr(t, "title", None),
+                  "closed": getattr(t, "closed", None), "hidden": getattr(t, "hidden", None),
+                  "top_message": getattr(t, "top_message", None)} for t in res.topics])
+
         elif cmd == "message-link":
             need(2); ent = await resolve(cl, args[0]); mid = int(args[1])
             try:
@@ -205,9 +230,15 @@ async def run():
 
         # ---- gated writes (need trailing --confirm) ----
         elif cmd == "send":
-            need(2); ent = await resolve(cl, args[0])
-            m = await cl.send_message(ent, args[1])
-            out({"sent": True, "id": m.id})
+            # `--topic <top_message>` posts into a forum topic thread (reply_to);
+            # required for forum-style supergroups where a root send is rejected.
+            topic, sargs = _pop_opt(args, "--topic")
+            if len(sargs) < 2:
+                raise ValueError("send needs <target> <text> (optional --topic <id>)")
+            ent = await resolve(cl, sargs[0])
+            kw = {"reply_to": int(topic)} if topic is not None else {}
+            m = await cl.send_message(ent, sargs[1], **kw)
+            out({"sent": True, "id": m.id, "topic": int(topic) if topic is not None else None})
 
         elif cmd == "reply":
             need(3); ent = await resolve(cl, args[0])


### PR DESCRIPTION
## Summary
During a live RU-market Telegram 拓客 run (tgstat discover → join → post), the `telegram` skill could join real AI communities but **couldn't post in the ones that matter** — forum-style supergroups reject a root `send` with `TOPIC_CLOSED`, because their messages live in topics (threads). This adds the missing last-mile.

## Changes (`scripts/tg.py`)
- **`list-topics <target> [limit]`** — new **read-only** command (NOT gated). Lists a forum group's topics via `functions.messages.GetForumTopicsRequest`, returning `{id, title, closed, hidden, top_message}` per topic so you can pick an open thread.
- **`send <target> "text" --topic <top_message>`** — the gated `send` now takes an optional `--topic`, mapped to Telethon `send_message(..., reply_to=int(topic))`, which posts into that forum topic thread. Plain `send` (no `--topic`) is byte-for-byte unchanged except a benign extra `"topic": null` in the JSON.
- `_pop_opt(argv, name)` — tiny helper to pull a `--name VALUE` pair out of the arg list (exact-token match only).
- `SKILL.md`: documents `list-topics` + `send --topic`, adds a "posting into a forum group" recipe and two gotchas (`TOPIC_CLOSED` → use a topic; `ChatWriteForbiddenError` → subscribe the parent channel of a linked discussion group). v1.3→1.4.

## Why (verified live)
- `GetForumTopicsRequest` lives in `telethon.tl.functions.messages` (NOT `.channels` — that only has `ToggleForumRequest`). Confirmed against a real forum group this session.
- Posted a real greeting into an open topic of a 6.7k-member RU AI forum via exactly this `reply_to=<top_message>` path, so the mechanism is proven end-to-end.

## Safety (unchanged gate)
`--topic` lives **inside** the `send` branch, which runs only **after** the dry-run gate. The gate keys on `sys.argv[-1] == "--confirm"` computed before the client connects, so `--topic` can't weaken it: `send <t> "text" --topic 141961 --confirm` → real send into the topic; `send <t> "--topic 5 --confirm"` (flag as message text) → one token ≠ `--confirm` → dry-run, nothing sent. `list-topics` is read-only and correctly excluded from `GATED`.

`py_compile` clean; SKILL.md frontmatter validates (v1.4).

## 🤖 对抗评审
Reviewer: `general-purpose` subagent. **VERDICT: CLEAN.** Traced the token flow and Telethon `send_message` source: the `--confirm` gate is airtight (`_pop_opt` runs post-gate, can't alter `cmd`/`CONFIRM`; a message merely containing `--topic`/`--confirm` never matches the exact-token checks); `_pop_opt` guards `--topic` as last-token (`i+1 < len`), empty argv, and non-int/negative values (`int()` → caught by top-level handler → clean `{"error": ...}`); `list-topics` correctly read-only, `GetForumTopicsRequest` signature matches, non-forum targets raise+format cleanly, `ForumTopicDeleted` handled via `getattr` defaults; no secret leak/injection; plain `send` behaves identically. Non-material nits only (redundant `int(topic)` in output; duplicate `--topic` silently ignored).
