### PR TITLE
Bind Xiaohongshu browser execution to its Connector

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -15,6 +15,7 @@ when_to_use: |
 connections: [xiaohongshu]
 execution:
   browser:
+    provider: xiaohongshu/xiaohongshu
     origins:
       - https://www.xiaohongshu.com
       - https://creator.xiaohongshu.com

--- a/skills/xiaohongshu/tests/test_browser_contract.py
+++ b/skills/xiaohongshu/tests/test_browser_contract.py
@@ -62,6 +62,7 @@ def test_browser_execution_frontmatter_contract() -> None:
     )
     assert "  Use the user's locally connected browser for complete Xiaohongshu / RED workflows:" in frontmatter
     assert re.search(r"^execution:\n  browser:\n", frontmatter, re.MULTILINE)
+    assert re.search(r"^    provider: xiaohongshu/xiaohongshu$", frontmatter, re.MULTILINE)
     assert _nested_list(frontmatter, "origins") == EXPECTED_ORIGINS
     assert _nested_list(frontmatter, "capabilities") == EXPECTED_CAPABILITIES
     assert not re.search(r"^allowed_tools:.*\bBash\b", frontmatter, re.MULTILINE)


### PR DESCRIPTION
## Summary

Declare the exact canonical `xiaohongshu/xiaohongshu` Connector identifier in the Xiaohongshu Skill's browser execution block. This prevents aichat2 from resolving an alias or an unrelated generic browser Connection.

## Validation

- Xiaohongshu browser contract: `3 passed`.
- Added a contract assertion for the canonical provider.
- `git diff --check`: passed.

## Dependencies

Pairs with AuthBackend PR https://github.com/AceDataCloud/AuthBackend/pull/310 and the aichat2 exact-Connection PR. Implements the Skill portion of https://github.com/AceDataCloud/Index/pull/250.

## Review policy

Do not auto-approve or auto-merge. Owner/CODEOWNER review is required.