### PR TITLE
feat(skills): declare connector method preferences

### DIFF
--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -13,6 +13,8 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "2.0"
+  connection_method_preferences:
+    reddit/reddit: [oauth, cookie]
 ---
 
 # Reddit — OAuth or login-cookie access
@@ -24,7 +26,7 @@ The connector injects exactly one of these credentials:
   echo, print, log or return it.**
 - `REDDIT_TOKEN`: official OAuth bearer token (`identity read submit`).
 
-The helper automatically prefers Cookie when present and otherwise uses OAuth.
+The helper automatically prefers official OAuth when present and otherwise uses Cookie.
 It sends Reddit's required descriptive User-Agent and never forwards cookies
 outside `reddit.com`.
 

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -3,7 +3,7 @@
 
 Cookie mode uses Reddit's first-party web JSON endpoints and the ``modhash``
 returned by ``/api/me.json``. OAuth mode uses ``oauth.reddit.com``. The helper
-automatically selects ``REDDIT_COOKIES`` first, then ``REDDIT_TOKEN``.
+automatically selects ``REDDIT_TOKEN`` first, then ``REDDIT_COOKIES``.
 
 State-changing commands are dry-runs unless ``--confirm`` is the final argv
 token. Credentials, cookie values and modhashes are never emitted.
@@ -241,14 +241,14 @@ class RedditClient:
 
     @classmethod
     def from_environment(cls) -> "RedditClient":
-        raw_cookies = os.environ.get("REDDIT_COOKIES", "").strip()
-        if raw_cookies:
-            return cls("cookie", cookies=parse_cookie_jar(raw_cookies))
         token = os.environ.get("REDDIT_TOKEN", "").strip()
         if token:
             if "\r" in token or "\n" in token:
                 die("REDDIT_TOKEN contains invalid characters")
             return cls("oauth", token=token)
+        raw_cookies = os.environ.get("REDDIT_COOKIES", "").strip()
+        if raw_cookies:
+            return cls("cookie", cookies=parse_cookie_jar(raw_cookies))
         die(
             "No Reddit credential is available — connect Reddit with Cookie or OAuth at "
             "https://auth.acedata.cloud/user/connections."

--- a/skills/weibo/SKILL.md
+++ b/skills/weibo/SKILL.md
@@ -12,6 +12,8 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
+  connection_method_preferences:
+    weibo/weibo: [cookie]
 ---
 
 # weibo — read & post on 微博 via your own cookies

--- a/tests/test_reddit_method_preference.py
+++ b/tests/test_reddit_method_preference.py
@@ -1,0 +1,46 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _module():
+    path = Path(__file__).resolve().parents[1] / "skills" / "reddit" / "scripts" / "reddit.py"
+    spec = importlib.util.spec_from_file_location("reddit_skill", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _cookies():
+    return json.dumps(
+        [
+            {
+                "name": "reddit_session",
+                "value": "cookie-token",
+                "domain": ".reddit.com",
+                "path": "/",
+            }
+        ]
+    )
+
+
+def test_oauth_is_preferred_when_both_credentials_exist(monkeypatch):
+    reddit = _module()
+    monkeypatch.setenv("REDDIT_TOKEN", "oauth-token")
+    monkeypatch.setenv("REDDIT_COOKIES", _cookies())
+
+    client = reddit.RedditClient.from_environment()
+
+    assert client.mode == "oauth"
+    assert client.token == "oauth-token"
+
+
+def test_cookie_remains_the_fallback(monkeypatch):
+    reddit = _module()
+    monkeypatch.delenv("REDDIT_TOKEN", raising=False)
+    monkeypatch.setenv("REDDIT_COOKIES", _cookies())
+
+    client = reddit.RedditClient.from_environment()
+
+    assert client.mode == "cookie"


### PR DESCRIPTION
## Summary
- Declare canonical connector method preferences for the two current multi-method skills.
- Prefer Reddit official OAuth over cookie credentials while retaining cookie fallback.
- Keep Weibo cookie-only until its helper actually supports the official OAuth method.
- Preserve existing `connections: [alias]` required-connection parsing; preference keys use canonical slash-form Connector identifiers.

## Validation
- Frontmatter YAML parsed for Reddit and Weibo.
- 2 Reddit precedence/fallback tests passed.
- Ruff and `git diff --check` passed.

## Adversarial review
- Verified Reddit OAuth and cookie operations share complete capability coverage and do not leak credentials on redirects.
- Slash-form preference keys are intentional canonical Connector identifiers, distinct from legacy provider aliases in `connections`.
- Verdict: `CLEAN`.