### PR TITLE
feat(xiaohongshu): parse note and profile snapshots

### DIFF
--- a/skills/xiaohongshu/references/browse.md
+++ b/skills/xiaohongshu/references/browse.md
@@ -34,7 +34,7 @@ Pass the final semantic snapshot to `parse-note-snapshot --note-url <canonical-u
 
 Open the fresh author link from a result/detail page. Return visible profile text, followers/following/engagement totals, and bounded recent notes. Do not expose unrelated private account data.
 
-Pass the final semantic snapshot to `parse-profile-snapshot --profile-url <canonical-url>` before reporting structured profile data. Report only explicitly labeled profile metrics; never reinterpret unrelated page numbers as followers, following, likes, or favorites.
+Pass the final semantic snapshot to `parse-profile-snapshot --profile-url <canonical-url>` before reporting structured profile data. `visible_metrics` contains explicitly labeled profile metrics. Preserve `visible_counts` separately as unlabeled page counters; never reinterpret them as followers, following, likes, or favorites.
 
 ## Content planning
 

--- a/skills/xiaohongshu/scripts/xhs_contract.py
+++ b/skills/xiaohongshu/scripts/xhs_contract.py
@@ -27,6 +27,7 @@ PROFILE_PATH = re.compile(r"^/user/profile/([A-Za-z0-9]+)$")
 TITLE_UNIT = re.compile(r"[\u3400-\u9fff]|[A-Za-z0-9]+")
 COUNT_VALUE = re.compile(r"^(\d+(?:\.\d+)?)([万千]?)$")
 PROFILE_METRIC = re.compile(r"^(关注|粉丝|获赞与收藏|获赞|收藏)\s*([\d,.]+(?:万|千|w|W|k|K)?)$")
+ENGAGEMENT_METRIC = re.compile(r"^(赞|点赞|收藏|评论|分享)\s*[:：]?\s*([\d,.]+(?:万|千|w|W|k|K)?)$")
 
 
 class ContractError(ValueError):
@@ -239,7 +240,9 @@ def _visible_counts(nodes: List[Dict]) -> List[str]:
     values = []
     for node in nodes:
         name = _named_text(node)
-        if node.get("role") in {"button", "section"} and COUNT_VALUE.fullmatch(name):
+        if node.get("role") in {"button", "section"} and (
+            COUNT_VALUE.fullmatch(name) or ENGAGEMENT_METRIC.fullmatch(name)
+        ):
             values.append(name)
     return values
 
@@ -292,10 +295,13 @@ def parse_profile_snapshot(snapshot: dict, profile_url: str) -> dict:
     notes = []
     seen = set()
     metrics = []
+    counts = []
     for node in nodes:
         name = _named_text(node)
         if node.get("role") == "section" and PROFILE_METRIC.fullmatch(name):
             metrics.append(name)
+        elif node.get("role") in {"button", "section"} and COUNT_VALUE.fullmatch(name):
+            counts.append(name)
         note = _path_match(node.get("href"), NOTE_PATH)
         if note and name and note.group(1) not in seen:
             seen.add(note.group(1))
@@ -305,6 +311,7 @@ def parse_profile_snapshot(snapshot: dict, profile_url: str) -> dict:
         "canonical_url": canonical_url,
         "display_name": _first_named(nodes, {"heading"}),
         "visible_metrics": metrics,
+        "visible_counts": counts,
         "notes": notes,
         "truncated": bool(snapshot.get("truncated", False)),
     }

--- a/skills/xiaohongshu/tests/fixtures/note.json
+++ b/skills/xiaohongshu/tests/fixtures/note.json
@@ -4,8 +4,9 @@
     {"role": "heading", "name": "示例笔记"},
     {"role": "link", "name": "示例作者", "href": "https://www.xiaohongshu.com/user/profile/user123"},
     {"role": "article", "name": "这是脱敏后的示例正文"},
-    {"role": "button", "name": "128"},
+    {"role": "button", "name": "赞：128"},
     {"role": "comment", "name": "示例评论"},
+    {"role": "link", "name": "赞过的人", "href": "https://www.xiaohongshu.com/user/profile/liker999"},
     {"role": "link", "name": "评论者", "href": "https://www.xiaohongshu.com/user/profile/commenter456"}
   ],
   "truncated": false

--- a/skills/xiaohongshu/tests/test_contract_script.py
+++ b/skills/xiaohongshu/tests/test_contract_script.py
@@ -202,7 +202,7 @@ def test_parse_note_fixture() -> None:
     assert result["title"] == "示例笔记"
     assert result["author_state"] == "available"
     assert result["profile_url"] == "https://www.xiaohongshu.com/user/profile/user123"
-    assert result["visible_engagement"] == ["128"]
+    assert result["visible_engagement"] == ["赞：128"]
     assert result["comments"] == ["示例评论"]
 
 
@@ -228,6 +228,32 @@ def test_parse_note_ignores_generic_list_items_before_author() -> None:
     assert result["comments"] == []
 
 
+def test_parse_note_refuses_to_guess_between_pre_comment_profiles() -> None:
+    snapshot = {
+        "origin": "https://www.xiaohongshu.com",
+        "nodes": [
+            {"role": "heading", "name": "示例笔记"},
+            {
+                "role": "link",
+                "name": "赞过的人",
+                "href": "https://www.xiaohongshu.com/user/profile/liker999",
+            },
+            {
+                "role": "link",
+                "name": "示例作者",
+                "href": "https://www.xiaohongshu.com/user/profile/user123",
+            },
+        ],
+    }
+
+    result = xhs_contract.parse_note_snapshot(
+        snapshot, "https://www.xiaohongshu.com/explore/abc123"
+    )
+
+    assert result["author"] is None
+    assert result["author_state"] == "ambiguous"
+
+
 def test_parse_profile_fixture() -> None:
     fixture = Path(__file__).parent / "fixtures" / "profile.json"
     result = xhs_contract.parse_profile_snapshot(
@@ -238,6 +264,7 @@ def test_parse_profile_fixture() -> None:
     assert result["canonical_url"] == "https://www.xiaohongshu.com/user/profile/user123"
     assert result["display_name"] == "示例作者"
     assert result["visible_metrics"] == ["粉丝 128"]
+    assert result["visible_counts"] == ["999", "5678"]
     assert result["notes"] == [
         {"note_id": "abc123", "title": "最近笔记", "url": "https://www.xiaohongshu.com/explore/abc123"}
     ]


### PR DESCRIPTION
## Summary
- add deterministic note-detail and profile semantic snapshot parsers
- preserve canonical URLs, ambiguous/missing author states, labeled engagement, and unlabeled profile counts
- document the new read workflow commands and add sanitized fixtures

## Validation
- `python3 -m unittest discover -s tests -p "test_*.py"` — 23 passed
- `python3 -m pytest -q skills/xiaohongshu/tests` — 20 passed
- `python3 -m compileall -q skills/xiaohongshu/scripts`
- `git diff --cached --check`

## Production evidence
- Recommendation workflow passed before this change: https://studio.acedata.cloud/chatgpt/conversations/c4e44352-5dfb-494f-bbf1-5fd7259aac7b
- Detail E2E reached the real note page but exposed the missing parser command: https://studio.acedata.cloud/chatgpt/conversations/3c9278ae-ea75-491e-b30b-40b0fc3e7942

## 🤖 对抗评审
- Round 1: 3 risks found (comment-profile author pollution, labeled engagement loss, unlabeled profile count loss); all fixed with regression fixtures/tests.
- Round 2: clean after fixes.
- Final re-review: `VERDICT: CLEAN`.