### PR TITLE
Fix NanoBanana hosted MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Skills provide **knowledge** (when to use, parameters, gotchas). MCP servers pro
 | seedance-video | [mcp-seedance](https://pypi.org/project/mcp-seedance/) | `pip install mcp-seedance` | `https://seedance.mcp.acedata.cloud/mcp` |
 | happyhorse-video | [mcp-happyhorse](https://pypi.org/project/mcp-happyhorse/) | `pip install mcp-happyhorse` | `https://happyhorse.mcp.acedata.cloud/mcp` |
 | maestro-video | [mcp-maestro](https://pypi.org/project/mcp-maestro/) | `pip install mcp-maestro` | `https://maestro.mcp.acedata.cloud/mcp` |
-| nano-banana-image | [mcp-nano-banana](https://pypi.org/project/mcp-nano-banana/) | `pip install mcp-nano-banana` | `https://nano-banana.mcp.acedata.cloud/mcp` |
+| nano-banana-image | [mcp-nano-banana](https://pypi.org/project/mcp-nano-banana/) | `pip install mcp-nano-banana` | `https://nanobanana.mcp.acedata.cloud/mcp` |
 | short-url | [mcp-shorturl](https://pypi.org/project/mcp-shorturl/) | `pip install mcp-shorturl` | `https://short-url.mcp.acedata.cloud/mcp` |
 | wan-video | [mcp-wan](https://pypi.org/project/mcp-wan/) | `pip install mcp-wan` | `https://wan.mcp.acedata.cloud/mcp` |
 | acedatacloud | [mcp-acedatacloud](https://pypi.org/project/mcp-acedatacloud/) | `pip install mcp-acedatacloud` | `https://mcp.acedata.cloud/mcp` |

--- a/skills/_shared/mcp-servers.md
+++ b/skills/_shared/mcp-servers.md
@@ -17,7 +17,7 @@ Each AceDataCloud service has a corresponding MCP server that provides tool-use 
 | seedance-video | `pip install mcp-seedance` | `https://seedance.mcp.acedata.cloud/mcp` |
 | happyhorse-video | `pip install mcp-happyhorse` | `https://happyhorse.mcp.acedata.cloud/mcp` |
 | maestro-video | `pip install mcp-maestro` | `https://maestro.mcp.acedata.cloud/mcp` |
-| nano-banana-image | `pip install mcp-nano-banana` | `https://nano-banana.mcp.acedata.cloud/mcp` |
+| nano-banana-image | `pip install mcp-nano-banana` | `https://nanobanana.mcp.acedata.cloud/mcp` |
 | short-url | `pip install mcp-shorturl` | `https://short-url.mcp.acedata.cloud/mcp` |
 | wan-video | `pip install mcp-wan` | `https://wan.mcp.acedata.cloud/mcp` |
 | acedatacloud | `pip install mcp-acedatacloud` | `https://mcp.acedata.cloud/mcp` |

--- a/skills/nano-banana-image/SKILL.md
+++ b/skills/nano-banana-image/SKILL.md
@@ -86,4 +86,4 @@ POST /nano-banana/images
 - Aspect ratio uses colon notation (e.g., `"16:9"`) not pixel dimensions
 - The Gemini-based model excels at understanding complex, conversational editing instructions
 
-> **MCP:** `pip install mcp-nano-banana` | Hosted: `https://nano-banana.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)
+> **MCP:** `pip install mcp-nano-banana` | Hosted: `https://nanobanana.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)


### PR DESCRIPTION
## Summary
- correct the NanoBanana hosted MCP endpoint to the deployed nanobanana.mcp.acedata.cloud hostname
- update the canonical Skill, shared MCP catalog, and repository catalog

## Validation
- 23 repository unit tests passed
- all 85 Skill frontmatter files and both synced symlinks validated
- old host: TLS verification fails; canonical host: TLS verification succeeds and returns expected unauthenticated 401

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)
- VERDICT: CLEAN