### PR TITLE
Fix resilient X identity and read capabilities

### DIFF
--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -44,13 +44,14 @@ python3 -c "import twikit" || { echo "sandbox missing twikit; deploy the sandbox
 # script (re-run this setup at the top of every fresh-shell Bash block below).
 X="$SKILL_DIR/scripts/x.py"; [ -f "$X" ] || X=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/x.py' 2>/dev/null | head -1)
 [ -f "$X" ] || { echo "x script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
-python3 "$X" whoami          # who is logged in
+python3 "$X" whoami          # confirm the shipped CLI can read the authenticated account
 ```
 
 ## Read commands (run directly)
 
 ```sh
-python3 $X whoami                                            # the logged-in account
+python3 $X whoami --expect GermeyAce                         # verify this exact account
+python3 $X whoami                                            # discover the authenticated account
 python3 $X search --query "ai agents" --product Latest --limit 20   # Top | Latest | Media
 python3 $X search-users --query "openai" --limit 10
 python3 $X timeline --limit 20                               # my home timeline
@@ -64,12 +65,20 @@ python3 $X trends --category trending --limit 20             # trending|for-you|
 ## Verify the connection first
 
 ```sh
-python3 $X whoami
-# → {"id": "...", "screen_name": "...", "followers_count": ...}
+python3 $X whoami --expect GermeyAce
+# → {"id": "...", "screen_name": "GermeyAce", "identity_verified": true, ...}
 ```
 
-On an auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+`whoami` reads the authenticated account's screen name from X account settings,
+then resolves its public profile. `--expect` compares that server-authenticated
+screen name with the required account before any write. This avoids X's
+Cloudflare-blocked `UserByRestId` endpoint without trusting a local identity
+cookie. Always use `--expect` when the user names the required account.
+
+On an actual auth error the cookie is expired — have the user reconnect at
+<https://auth.acedata.cloud/user/connections>. A Cloudflare block is different:
+reconnecting cookies does not fix it. Use `--expect` for identity checks; other
+blocked endpoints need `X_PROXY` or the official X API. Do **not** loop-retry.
 
 ## Write commands — GATED (dry-run unless trailing `--confirm`)
 
@@ -102,13 +111,17 @@ python3 $X delete --id 123456 --confirm                        # delete one of M
 
 - **This is the user's real X account.** Confirm before any write — posts are
   immediate and public.
-- **Not E2E-verified** (see the warning above) — expect to validate the first run.
+- **Live writes are not E2E-verified.** Read commands were verified on 2026-07-06;
+  validate the first confirmed write carefully.
 - **twikit is a scraper of X's non-public API.** It can break when X changes its
   internal endpoints. The bundled script carries an AceDataCloud compatibility
   patch for the current `ondemand.s` webpack chunk map used to generate
   transaction IDs. If `Couldn't get KEY_BYTE indices` appears again, report it
   as X/twikit upstream drift — do NOT ask the user to reconnect cookies for that
   specific error.
+- X currently returns a dependency error for its dedicated `UserMedia` query.
+  The CLI falls back to the normal Tweets timeline and filters media posts
+  locally; the response includes a `fallback` field when this happens.
 - **ToS / rate-limit / ban risk.** This acts through the web API, not the
   official API — high-frequency automation can get the account rate-limited or
   suspended. Keep volume human-like.

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -19,6 +19,7 @@ breakage.
 
 Examples:
   python3 x.py whoami
+    python3 x.py whoami --expect GermeyAce
   python3 x.py search --query "python" --product Latest --limit 20
   python3 x.py timeline --limit 20
   python3 x.py user-tweets --user elonmusk --type Tweets --limit 20
@@ -38,7 +39,6 @@ import json
 import os
 import re
 import sys
-from urllib.parse import unquote
 
 UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
@@ -90,11 +90,26 @@ def load_cookie_dict() -> dict:
     return cookies
 
 
-def current_user_id_from_cookies() -> str | None:
-    twid = load_cookie_dict().get("twid", "")
-    decoded = unquote(twid)
-    match = re.search(r"(?:^|[&?])u=(\d+)", decoded) or re.search(r"u=(\d+)", decoded)
-    return match.group(1) if match else None
+def normalize_screen_name(value: str) -> str:
+    screen_name = value.strip().lstrip("@")
+    if not re.fullmatch(r"[A-Za-z0-9_]{1,15}", screen_name):
+        die("--expect must be a valid X screen name (1-15 letters, digits, or underscores)")
+    return screen_name
+
+
+def cloudflare_block_message(error: Exception) -> str | None:
+    text = str(error)
+    if "Cloudflare" not in text or not any(
+        marker in text for marker in ("Sorry, you have been blocked", "Attention Required!")
+    ):
+        return None
+    ray_match = re.search(r"Cloudflare Ray ID:.*?([a-f0-9]{16})", text, re.IGNORECASE | re.DOTALL)
+    ray = f" Ray ID: {ray_match.group(1)}." if ray_match else ""
+    return (
+        "X blocked this automated web-API request at Cloudflare; the login cookies may still be valid."
+        f"{ray} For identity checks, use `whoami --expect <screen_name>`; for other blocked endpoints, "
+        "configure X_PROXY or use the official X API."
+    )
 
 
 def make_client():
@@ -230,10 +245,34 @@ async def resolve_user(client, target: str):
 
 # ── read commands ───────────────────────────────────────────────────
 
-async def cmd_whoami(client, _args):
-    user_id = current_user_id_from_cookies()
-    u = await client.get_user_by_id(user_id) if user_id else await client.user()
-    out(fmt_user(u))
+async def cmd_whoami(client, args):
+    settings, _ = await client.v11.settings()
+    authenticated_screen_name = settings.get("screen_name") if isinstance(settings, dict) else None
+    if not isinstance(authenticated_screen_name, str) or not re.fullmatch(
+        r"[A-Za-z0-9_]{1,15}", authenticated_screen_name
+    ):
+        die("X account settings did not return a valid screen name; stopped without performing any write")
+    expected = getattr(args, "expect", None)
+    if expected:
+        expected_screen_name = normalize_screen_name(expected)
+        if authenticated_screen_name.casefold() != expected_screen_name.casefold():
+            die(
+                f"connected X account is @{authenticated_screen_name}, not @{expected_screen_name}; "
+                "stopped without performing any write"
+            )
+    u = await client.get_user_by_screen_name(authenticated_screen_name)
+    result = fmt_user(u)
+    result.update(
+        {
+            "identity_verified": True,
+            "verification": (
+                "authenticated_settings_matches_expected_screen_name"
+                if expected
+                else "authenticated_settings_screen_name"
+            ),
+        }
+    )
+    out(result)
 
 
 async def cmd_search(client, args):
@@ -258,20 +297,42 @@ async def cmd_timeline(client, args):
 
 async def cmd_user_tweets(client, args):
     u = await resolve_user(client, args.user)
-    tweets = await client.get_user_tweets(u.id, args.type, count=args.limit)
-    items = list(tweets)[: args.limit]
-    out({"user": fmt_user(u), "type": args.type,
-         "count": len(items), "tweets": [fmt_tweet(t) for t in items]})
+    fallback = None
+    try:
+        tweets = await client.get_user_tweets(u.id, args.type, count=args.limit)
+        items = list(tweets)[: args.limit]
+    except Exception as error:
+        media_dependency_error = (
+            args.type == "Media"
+            and (
+                (isinstance(error, KeyError) and error.args == ("code",))
+                or "Dependency: Unspecified" in str(error)
+            )
+        )
+        if not media_dependency_error:
+            raise
+        fallback_count = min(max(args.limit * 3, 40), 100)
+        tweets = await client.get_user_tweets(u.id, "Tweets", count=fallback_count)
+        items = [tweet for tweet in tweets if bool(getattr(tweet, "media", None))][: args.limit]
+        fallback = "Tweets (locally filtered for media)"
+    result = {
+        "user": fmt_user(u),
+        "type": args.type,
+        "count": len(items),
+        "tweets": [fmt_tweet(t) for t in items],
+    }
+    if fallback:
+        result["fallback"] = fallback
+    out(result)
 
 
 async def cmd_tweet(client, args):
-    try:
-        tweets = await client.get_tweets_by_ids([args.id])
-        t = tweets[0] if tweets else None
-    except Exception:
-        t = None
+    tweets = await client.get_tweets_by_ids([args.id])
+    t = tweets[0] if tweets else None
     if t is None:
-        t = await client.get_tweet_by_id(args.id)
+        die("tweet not found / unavailable")
+    if str(getattr(t, "id", "")) != args.id:
+        die("tweet id mismatch in X response")
     out(fmt_tweet(t))
 
 
@@ -409,7 +470,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="x.py", description="X (Twitter) cookie CLI")
     sub = p.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("whoami", help="show or verify the logged-in account")
+    sp.add_argument("--expect", help="verify the cookie account matches this @screen_name")
 
     sp = sub.add_parser("search", help="search tweets by keyword")
     sp.add_argument("--query", required=True)
@@ -489,12 +551,21 @@ def main() -> None:
     except (AccountLocked, AccountSuspended) as e:
         die(f"account locked/suspended by X: {e}")
     except TooManyRequests as e:
+        cloudflare_message = cloudflare_block_message(e)
+        if cloudflare_message:
+            die(cloudflare_message)
         die(f"rate limited by X — wait and retry, or slow down. ({e})")
     except (NotFound, TweetNotAvailable, UserNotFound, UserUnavailable) as e:
         die(f"not found / unavailable: {e}")
     except Forbidden as e:
+        cloudflare_message = cloudflare_block_message(e)
+        if cloudflare_message:
+            die(cloudflare_message)
         die(f"forbidden by X (content rule, protected account, or ToS): {e}")
     except TwitterException as e:
+        cloudflare_message = cloudflare_block_message(e)
+        if cloudflare_message:
+            die(cloudflare_message)
         die(f"X API error: {e}")
     except Exception as e:
         # twikit scrapes X's non-public API; a bare error here usually means an

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).parents[1] / "skills" / "x" / "scripts" / "x.py"
+SPEC = importlib.util.spec_from_file_location("x_skill", SCRIPT)
+assert SPEC and SPEC.loader
+x = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(x)
+
+
+def user(user_id: str = "4807296432", screen_name: str = "GermeyAce") -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, screen_name=screen_name, name="Germey Ace")
+
+
+def tweet(tweet_id: str, *, media: bool) -> SimpleNamespace:
+    return SimpleNamespace(id=tweet_id, text=f"tweet {tweet_id}", media=[object()] if media else [])
+
+
+def run_payload(coroutine) -> dict:
+    output = io.StringIO()
+    with redirect_stdout(output):
+        asyncio.run(coroutine)
+    return json.loads(output.getvalue())
+
+
+def run_error(coroutine) -> dict:
+    output = io.StringIO()
+    with redirect_stdout(output), unittest.TestCase().assertRaises(SystemExit):
+        asyncio.run(coroutine)
+    return json.loads(output.getvalue())
+
+
+class XSkillTests(unittest.TestCase):
+    def test_whoami_expect_uses_authenticated_settings_without_user_by_id(self) -> None:
+        class V11:
+            async def settings(self):
+                return {"screen_name": "GermeyAce"}, None
+
+        class Client:
+            v11 = V11()
+
+            async def get_user_by_screen_name(self, screen_name):
+                self_test.assertEqual(screen_name, "GermeyAce")
+                return user()
+
+            async def get_user_by_id(self, _user_id):
+                raise AssertionError("expected-account verification must not call UserByRestId")
+
+        self_test = self
+        result = run_payload(x.cmd_whoami(Client(), SimpleNamespace(expect="@GermeyAce")))
+        self.assertEqual(result["screen_name"], "GermeyAce")
+        self.assertTrue(result["identity_verified"])
+        self.assertEqual(result["verification"], "authenticated_settings_matches_expected_screen_name")
+
+    def test_whoami_expect_rejects_wrong_connected_account(self) -> None:
+        class V11:
+            async def settings(self):
+                return {"screen_name": "OtherAccount"}, None
+
+        class Client:
+            v11 = V11()
+
+            async def get_user_by_screen_name(self, _screen_name):
+                raise AssertionError("mismatch must stop before public profile lookup")
+
+        error = run_error(x.cmd_whoami(Client(), SimpleNamespace(expect="GermeyAce")))["error"]
+        self.assertIn("@OtherAccount", error)
+        self.assertIn("not @GermeyAce", error)
+
+    def test_whoami_without_expect_uses_authenticated_settings(self) -> None:
+        class V11:
+            async def settings(self):
+                return {"screen_name": "GermeyAce"}, None
+
+        class Client:
+            v11 = V11()
+
+            async def get_user_by_screen_name(self, screen_name):
+                return user(screen_name=screen_name)
+
+        result = run_payload(x.cmd_whoami(Client(), SimpleNamespace(expect=None)))
+        self.assertEqual(result["screen_name"], "GermeyAce")
+        self.assertEqual(result["verification"], "authenticated_settings_screen_name")
+
+    def test_user_media_falls_back_to_tweets_and_filters_media(self) -> None:
+        calls = []
+
+        class Client:
+            async def get_user_by_screen_name(self, _screen_name):
+                return user()
+
+            async def get_user_tweets(self, _user_id, tweet_type, count):
+                calls.append((tweet_type, count))
+                if tweet_type == "Media":
+                    raise KeyError("code")
+                return [tweet("1", media=False), tweet("2", media=True), tweet("3", media=True)]
+
+        result = run_payload(
+            x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+        )
+        self.assertEqual(calls, [("Media", 1), ("Tweets", 40)])
+        self.assertEqual(result["type"], "Media")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["tweets"][0]["id"], "2")
+        self.assertEqual(result["fallback"], "Tweets (locally filtered for media)")
+
+    def test_user_media_does_not_hide_unrelated_errors(self) -> None:
+        class Client:
+            async def get_user_by_screen_name(self, _screen_name):
+                return user()
+
+            async def get_user_tweets(self, _user_id, _tweet_type, count):
+                raise KeyError("unexpected")
+
+        with self.assertRaisesRegex(KeyError, "unexpected"):
+            asyncio.run(
+                x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+            )
+
+    def test_user_media_falls_back_on_explicit_dependency_error(self) -> None:
+        class Client:
+            async def get_user_by_screen_name(self, _screen_name):
+                return user()
+
+            async def get_user_tweets(self, _user_id, tweet_type, count):
+                if tweet_type == "Media":
+                    raise RuntimeError("Dependency: Unspecified")
+                return [tweet("1", media=True)]
+
+        result = run_payload(
+            x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+        )
+        self.assertEqual(result["fallback"], "Tweets (locally filtered for media)")
+
+    def test_tweet_uses_batch_endpoint_without_broken_detail_fallback(self) -> None:
+        class Client:
+            async def get_tweets_by_ids(self, ids):
+                self_test.assertEqual(ids, ["123"])
+                return [tweet("123", media=False)]
+
+            async def get_tweet_by_id(self, _tweet_id):
+                raise AssertionError("TweetDetail fallback must not be called")
+
+        self_test = self
+        self.assertEqual(run_payload(x.cmd_tweet(Client(), SimpleNamespace(id="123")))["id"], "123")
+
+    def test_tweet_reports_not_found_when_batch_is_empty(self) -> None:
+        class Client:
+            async def get_tweets_by_ids(self, _ids):
+                return []
+
+        error = run_error(x.cmd_tweet(Client(), SimpleNamespace(id="missing")))["error"]
+        self.assertIn("not found", error)
+
+    def test_tweet_rejects_mismatched_batch_result(self) -> None:
+        class Client:
+            async def get_tweets_by_ids(self, _ids):
+                return [tweet("other", media=False)]
+
+        error = run_error(x.cmd_tweet(Client(), SimpleNamespace(id="requested")))["error"]
+        self.assertIn("id mismatch", error)
+
+    def test_cloudflare_block_message_is_concise(self) -> None:
+        error = RuntimeError(
+            'status: 403, message: "<title>Attention Required! | Cloudflare</title>'
+            'Sorry, you have been blocked Cloudflare Ray ID: '
+            '<strong class="font-semibold">a1e188325e6409cc</strong> huge html"'
+        )
+        message = x.cloudflare_block_message(error)
+        self.assertIsNotNone(message)
+        self.assertIn("Cloudflare", message)
+        self.assertIn("a1e188325e6409cc", message)
+        self.assertNotIn("huge html", message)
+
+    def test_whoami_parser_accepts_expected_screen_name(self) -> None:
+        args = x.build_parser().parse_args(["whoami", "--expect", "GermeyAce"])
+        self.assertEqual(args.expect, "GermeyAce")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore `whoami` through authenticated X account settings and add strict `--expect <screen_name>` verification
- recover `UserMedia` via bounded Tweets-timeline filtering and keep single-tweet reads on the working batch endpoint
- classify Cloudflare blocks concisely across 403, 429, and generic X errors
- add focused regression coverage and update the X skill playbook

## Validation
- `python3 -m pytest -q` — 73 passed, 25 subtests passed
- `ruff check skills/x/scripts/x.py tests/test_x.py`
- `python3 -m py_compile skills/x/scripts/x.py tests/test_x.py`
- `git diff --check`
- production sandbox read-only proof: generic and expected-account `whoami` returned `GermeyAce`; Media fallback and single-tweet reads succeeded
- no live X writes were executed

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- RISK: Cloudflare HTTP 429 was misclassified as ordinary X rate limiting → fixed by applying Cloudflare detection to `TooManyRequests`
- NIT: dependency fallback and batch tweet ID integrity lacked coverage → fixed with regressions and an ID mismatch guard
- NIT: generic `TwitterException` Cloudflare output and stale E2E wording → fixed
- NIT: import-time argv capture → not adopted; pre-existing behavior outside this scoped change, and tests call command handlers directly

Final verdict: `VERDICT: CLEAN`.
