### PR TITLE
Mirror upstream Xiaohongshu MCP workflows in Skill

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -21,12 +21,19 @@ execution:
       - tabs
       - snapshot
       - screenshot
+      - element_info
       - navigate
       - click
       - click_at
+      - hover
       - form_input
+      - type_text
+      - select_option
+      - set_checked
       - key
       - scroll
+      - scroll_to
+      - wait_for
       - file_upload
 license: Apache-2.0
 metadata:
@@ -61,6 +68,7 @@ Read only the reference needed for the current request:
 | Image, video, long article, schedule, original, visibility, products | [publish](./references/publish.md) |
 | Like, favorite, comment, reply | [interactions](./references/interactions.md) |
 | Any uncertain write result or interrupted workflow | [reconciliation](./references/reconciliation.md) |
+| Feature parity, route contracts, and selector diagnostics | [MCP parity](./references/mcp-parity.md) |
 
 For publish/search validation and feed-card parsing, use the shipped stdlib-only contract helper:
 

--- a/skills/xiaohongshu/references/browse.md
+++ b/skills/xiaohongshu/references/browse.md
@@ -15,24 +15,27 @@ Use `parse-feed-snapshot` when a machine-checked card list is useful. Preserve `
 
 ## Recommendations
 
-Read the attached home/recommendation page. Scroll in bounded steps and read after each step. Return only the requested number of notes with title, author state, visible engagement, and canonical URL. Stop when enough results are collected, the page repeats, a warning appears, or the user limit is reached.
+Navigate to `https://www.xiaohongshu.com/` (or the attached recommendation page), then wait in 300 ms bounded intervals for feed cards to hydrate, for at most 8 seconds. Read the attached page. Scroll in bounded steps and read after each step. Return only the requested number of notes with title, author state, visible engagement, and canonical URL. Stop when enough results are collected, the page repeats, a warning appears, the 8-second hydration window expires without cards, or the user limit is reached.
 
 ## Search and filters
 
 1. Normalize `{keyword, filters}` with `normalize-filters` before interacting. Supported filters are sort, note type, publish time, search scope, and location.
-2. Read the current page, open the search control, fill the exact keyword, and submit with a fresh visible control or supported key.
-3. Read the result page. Apply requested filters one at a time using fresh refs and verify each visible selected state.
-4. Return bounded cards. Never invent query tokens, counts, or hidden IDs.
+2. Navigate to `https://www.xiaohongshu.com/search_result?keyword=<encoded>&source=web_explore_feed`, or use the visible search control when already attached there. Never invent a query token.
+3. Wait for visible results. To filter, hover the visible `筛选` control, wait for the panel, then choose exact labels one group at a time in this order: sort, note type, publish time, search scope, location. Use the normalized labels from `normalize-filters` rather than positional guesses.
+4. After every selection, wait for the panel/result state to settle and verify the exact selected label before continuing. If the hover panel closes, reacquire it; never click a stale option ref.
+5. Return bounded cards. Never invent query tokens, counts, or hidden IDs.
 
 ## Detail and comments
 
-Open a note from its fresh result ref or same-origin canonical URL. Read visible text, media labels, author, engagement, and the first visible comment batch. For more comments/replies, expand and scroll in bounded batches, reading after every transition and stopping at the requested limit. This is not a guaranteed full-comment export.
+Open a note from its fresh result ref or same-origin canonical URL. Prefer clicking the fresh feed link so any required page token remains browser-local. Retry navigation at most three times with a short bounded delay, then stop. Read visible text, media labels, author, engagement, and the first visible comment batch.
+
+For more comments/replies, first scroll to the comment area. In each bounded round: expand at most three visible `展开 N 条回复` controls, read the count, scroll the last visible comment into view, then scroll about 70% of one viewport. Stop at the requested count, visible end marker, no-comment state, 20 stagnant rounds, warning, or caller limit. Never copy the upstream 500-attempt default into chat automation.
 
 Pass the final semantic snapshot to `parse-note-snapshot --note-url <canonical-url>`. Preserve missing, ambiguous, and truncated states instead of filling absent fields. Only nodes with an explicit `comment` role are returned as structured comments; generic list items are never assumed to be comments.
 
 ## Profile
 
-Open the fresh author link from a result/detail page. Return visible profile text, followers/following/engagement totals, and bounded recent notes. Do not expose unrelated private account data.
+Open the fresh author link from a result/detail page. For the current account, use the sidebar `我` profile channel rather than fabricating an ID. Return visible profile text, followers/following/engagement totals, and bounded recent notes. Profile notes can be grouped/lazy-loaded; flatten only visibly observed note batches. Do not expose unrelated private account data.
 
 Pass the final semantic snapshot to `parse-profile-snapshot --profile-url <canonical-url>` before reporting structured profile data. `visible_metrics` contains explicitly labeled profile metrics. Preserve `visible_counts` separately as unlabeled page counters; never reinterpret them as followers, following, likes, or favorites.
 

--- a/skills/xiaohongshu/references/interactions.md
+++ b/skills/xiaohongshu/references/interactions.md
@@ -6,22 +6,22 @@ Always open and read the exact target note first. Derive it from the user's URL 
 
 1. Read the target control's visible label and checked/pressed/selected state.
 2. If the current state already matches the explicit request, no-op and report it.
-3. Otherwise click once, read again, and confirm the target state.
-4. If state remains ambiguous, do not retry automatically.
+3. Otherwise click once, poll the fresh state every 500 ms for at most 4 seconds, and confirm the exact target state.
+4. If the state is readable and clearly unchanged, one retry is allowed because the action is reversible; never exceed two total clicks. If state cannot be read, do not retry.
 
 ## Comment
 
 1. Draft the exact comment and show the target note plus full text.
 2. Obtain explicit chat confirmation.
-3. Open the visible editor, fill it, and read the draft back.
+3. Open the visible comment placeholder, then fill the visible contenteditable comment input and read the draft back.
 4. If the target or exact text differs, stop.
-5. Click Send once after the confirmed preview, then follow reconciliation.
+5. Click the visible submit button once after the confirmed preview. Poll the visible comments for the exact text every 300 ms for at most 4 seconds; absence is an unknown/failed result, not success.
 
 ## Reply
 
-1. Locate the exact visible target comment and author, expanding replies in bounded steps if needed.
+1. Locate the exact visible target comment and author. Prefer an exact comment ID when visible; otherwise match the explicitly confirmed user. Expand/scroll in bounded steps, stop at the end marker, and never search more than 100 rounds.
 2. Show the target and full reply preview; obtain explicit confirmation.
 3. Open that comment's reply control, fill the reply, and read the visible target/text back.
-4. Submit once, then follow reconciliation.
+4. Submit once, then require the exact reply text to appear within 4 seconds before reporting success.
 
 Comments and replies are public account actions. The attached exact-origin session does not replace explicit chat preview confirmation.

--- a/skills/xiaohongshu/references/login.md
+++ b/skills/xiaohongshu/references/login.md
@@ -2,21 +2,23 @@
 
 ## Status
 
-1. Attach `https://www.xiaohongshu.com` and call `browser.snapshot` with that exact origin.
-2. Determine login only from visible signed-in controls, profile links, or an explicit login prompt. Do not claim cryptographic account attestation.
-3. If the state is ambiguous or the snapshot is truncated before account controls, ask the user to inspect the tab.
+1. Navigate or attach `https://www.xiaohongshu.com/explore` and wait up to 30 seconds in bounded intervals.
+2. Treat a visible sidebar profile channel (`我` / profile link) as signed in. Treat a visible login prompt or QR container as signed out. URL alone is not sufficient unless it visibly redirects to login.
+3. Determine login only from visible signed-in controls, profile links, or an explicit login prompt. Do not claim cryptographic account attestation.
+4. If `browser.snapshot` is unavailable on the dense page, use `browser.screenshot` for this status check. If neither proves the state, ask the user to inspect the tab.
 
 ## QR login
 
-1. Open the visible login control with a fresh ref.
-2. Read again. If a QR is present, call `browser.screenshot` and present the image; never extract QR payloads or session tokens.
-3. The user scans locally. Wait in bounded intervals and read again until a visible signed-in state appears or the QR expires.
-4. On expiry, ask before reopening a fresh QR. Never loop indefinitely.
+1. Open the visible login control with a fresh ref or screenshot-bound point.
+2. Read again. The upstream page contract renders the QR under the login container; call `browser.screenshot` and present the visible image, never the QR payload or session token.
+3. The user scans locally. Poll every 500 ms only through bounded `browser.wait_for`/fresh observations, with a maximum matching the visible QR expiry (never more than 5 minutes).
+4. Success requires the visible sidebar profile channel to appear. A disappeared QR alone is not success.
+5. On expiry, ask before reopening a fresh QR. Never loop indefinitely.
 
 ## Switch or sign out
 
 1. Show the visible current-account context and ask for explicit confirmation.
-2. Use visible logout/switch controls with fresh refs after chat confirmation.
+2. Use visible logout/switch controls with fresh refs after chat confirmation. Do not copy the upstream Cookie-deletion shortcut; this Skill never clears or exports Cookies.
 3. Let the user complete credentials, SMS, QR, or verification locally.
 4. Read again and report only the visible resulting account state.
 

--- a/skills/xiaohongshu/references/mcp-parity.md
+++ b/skills/xiaohongshu/references/mcp-parity.md
@@ -1,0 +1,49 @@
+# Xiaohongshu MCP feature parity
+
+This Skill benchmarks its business workflows against `xpzouying/xiaohongshu-mcp` commit
+`a7d1f2f7f45e0b1c27de67c8f8a19131ba321725`. Reimplement the behavior through generic
+`browser.*` capabilities; never copy its CDP runtime into the extension.
+
+| Reference feature | Skill workflow |
+|---|---|
+| `check_login_status` | [login status](./login.md#status) |
+| `get_login_qrcode` | [QR login](./login.md#qr-login) |
+| `publish_content` | [image publish](./publish.md#execute) |
+| `publish_with_video` | [video publish](./publish.md#execute) |
+| long-article pipeline | [long article steps](./publish.md#execute) |
+| `list_feeds` | [recommendations](./browse.md#recommendations) |
+| `search_feeds` + five filter groups | [search and filters](./browse.md#search-and-filters) |
+| `get_feed_detail` + comment loading | [detail and comments](./browse.md#detail-and-comments) |
+| `user_profile` / `get_me` | [profile](./browse.md#profile) |
+| `post_comment_to_feed` | [comment](./interactions.md#comment) |
+| `reply_comment_in_feed` | [reply](./interactions.md#reply) |
+| `like_feed` / unlike | [like and favorite](./interactions.md#like-and-favorite) |
+| `favorite_feed` / unfavorite | [like and favorite](./interactions.md#like-and-favorite) |
+
+## Selector recognition hints
+
+These are Xiaohongshu-specific diagnostics owned by this Skill. Use visible semantics first and reacquire
+fresh refs after every transition.
+
+- Creator mode tabs: `div.creator-tab`, exact text `上传图文`, `上传视频`, `写长文`.
+- Upload input: `input.upload-input`, fallback single visible/associated `input[type=file]`.
+- Image completion: `.img-preview-area .pr` count.
+- Image/video title: placeholder containing `填写标题`, fallback visible title input.
+- Long-title field: `textarea.d-text[placeholder="输入标题"]`.
+- Body/editor: `div.tiptap.ProseMirror`, fallback visible `div.ProseMirror[contenteditable=true]`.
+- Publish: enabled `xhs-publish-btn`, fallback visible `.publish-page-publish-btn button.bg-red`.
+- Comment opener/input/submit: `div.input-box div.content-edit span`, `p.content-input`, `div.bottom button.submit`.
+- Like/favorite: `.like-lottie`, `.collect-icon`; always verify resulting state.
+
+Selectors are recognition hints, not permission to run arbitrary JavaScript or CSS queries. If generic
+browser observations cannot identify a unique visible target, use a screenshot-bound action or stop.
+
+## Deliberate non-parity
+
+Do not import upstream behaviors that violate the local-browser security boundary:
+
+- no Cookie deletion/export or account state reset;
+- no arbitrary CDP/evaluate, remote debugging port, or headless profile;
+- no local filesystem paths or direct URL downloads in `browser.file_upload`;
+- no hidden `window.__INITIAL_STATE__` extraction; report only visible browser observations;
+- no 500-round unattended comment crawling; all loops are bounded and user-request limited.

--- a/skills/xiaohongshu/references/publish.md
+++ b/skills/xiaohongshu/references/publish.md
@@ -20,13 +20,15 @@ Show the exact normalized preview: post type, title, full body, tags, media name
 ## Execute
 
 1. Ask the user to open `https://creator.xiaohongshu.com`, attach that tab, and locally verify the signed-in account.
-2. Read the page and stop on warnings or unexpected account context.
-3. Select image, video, or long-article mode using fresh refs.
-4. Upload approved resource IDs through `browser.file_upload`, or wait for the user to select local media. Read until exact filenames/thumbnails and processing completion are visible.
-5. Fill title/body using fresh refs. For rich-text editors, read immediately after input; if the exact value is not visible, stop rather than repeatedly injecting it.
-6. Add tags/topics, template/layout, products, visibility, originality, and schedule one at a time. Read and verify each state.
-7. Before the final action, read again and compare every visible field with the confirmed preview. Stop on mismatch.
-8. Click Publish/Schedule exactly once after the final confirmed chat preview.
-9. Follow [reconciliation](./reconciliation.md). Report success only from a visible success state or destination, and include the canonical URL when available.
+2. Navigate to `https://creator.xiaohongshu.com/publish/publish?source=official`. Wait for load, then allow two seconds for creator widgets and one bounded DOM-settle interval. Read or screenshot the page and stop on warnings, login redirects, or unexpected account context.
+3. Select mode by exact visible tab text: `上传图文`, `上传视频`, or `写长文`. Prefer a fresh semantic ref; if the tab is visually blocked by a popover, stop for user inspection instead of deleting page nodes. Verify the selected mode after clicking.
+4. For image posts, upload one approved resource at a time and wait until the visible preview count reaches the submitted count before the next resource (up to 60 seconds per image). For video, wait until processing completes and Publish becomes enabled, up to 10 minutes. If resource resolution is unavailable, wait for the user to select local media and verify the same preview/processing state.
+5. Fill the image/video title using the visible title textbox (recognition hints: placeholder containing `填写标题`, then the single visible title input fallback). Fill body in the visible TipTap/ProseMirror contenteditable editor. Use `browser.form_input` for replacement or focus with `browser.click`/`click_at` then `browser.type_text` for rich text. Read immediately after each field; stop if the exact normalized value is not visible.
+6. Limit tags to the first 10 confirmed tags. Insert them one at a time, close any topic suggestion popover by focusing the title, and verify visible chips/text before continuing.
+7. Configure options one at a time and verify each exact state: schedule (1 hour–14 days), visibility (`公开可见`, `仅自己可见`, `仅互关好友可见`), originality, and products. If originality was requested but cannot be confirmed, abort rather than publishing non-original. Bind a product only when the exact intended product is visibly selected; never accept a first fuzzy match silently.
+8. For long article: choose `写长文` → `新的创作`; fill `输入标题` textarea and ProseMirror body; click `一键排版`; enumerate visible template names; select the confirmed template and verify its selected state; click `下一步`; then fill the separate publish-page description editor.
+9. Before the final action, read or screenshot again and compare media count, title, full body, tags, options, products, and schedule with the confirmed preview. Stop on mismatch.
+10. Locate Publish through two page generations: visible enabled `xhs-publish-btn` widget first, then visible legacy red Publish button. Reject `submit-disabled=true`, `disabled`, `aria-disabled=true`, or disabled styling. Click exactly once after the final confirmed chat preview.
+11. Follow [reconciliation](./reconciliation.md). Immediate success requires leaving `/publish/publish` or a visible success destination within 15 seconds. Remaining on the form is not success. Return the canonical note URL when visible.
 
 Never mix image/video media unless the visible current UI explicitly supports it. Bind products only when the account visibly exposes the feature and the exact selected products appear in the final preview.

--- a/skills/xiaohongshu/references/reconciliation.md
+++ b/skills/xiaohongshu/references/reconciliation.md
@@ -12,4 +12,12 @@ Use this after timeout, disconnect, stale ref, navigation, an ambiguous result, 
 5. If `not_applied`, reversible actions may be attempted once from the verified state. Irreversible actions require a fresh preview and renewed chat confirmation.
 6. If `unknown`, stop and ask the user to inspect the local tab. Never retry publish, schedule, comment, or reply while unknown.
 
+Action-specific success signals benchmarked from the local-browser workflow:
+
+- Image upload: preview count reaches the submitted image count; a file-input event alone is not success.
+- Video upload: Publish becomes enabled after processing; file selection alone is not success.
+- Publish/schedule: URL leaves `/publish/publish` or a visible success destination appears within 15 seconds.
+- Comment/reply: the exact submitted text renders in the comments area within 4 seconds.
+- Like/favorite: the visible/semantic state equals the requested boolean; click completion alone is not success.
+
 Preserve the page on CAPTCHA, moderation, rate limit, account restriction, or unusual-activity warnings. Do not dismiss, solve, bypass, or retry around them.

--- a/skills/xiaohongshu/tests/test_browser_contract.py
+++ b/skills/xiaohongshu/tests/test_browser_contract.py
@@ -12,6 +12,7 @@ REFERENCES = {
     "publish.md",
     "interactions.md",
     "reconciliation.md",
+    "mcp-parity.md",
 }
 EXPECTED_ORIGINS = {
     "https://www.xiaohongshu.com",
@@ -21,12 +22,19 @@ EXPECTED_CAPABILITIES = {
     "tabs",
     "snapshot",
     "screenshot",
+    "element_info",
     "navigate",
     "click",
     "click_at",
+    "hover",
     "form_input",
+    "type_text",
+    "select_option",
+    "set_checked",
     "key",
     "scroll",
+    "scroll_to",
+    "wait_for",
     "file_upload",
 }
 DEPLOYED_BROWSER_TOOLS = {
@@ -140,8 +148,8 @@ def test_browser_skill_matches_complete_local_runtime() -> None:
     assert "ask the user to open `https://creator.xiaohongshu.com`" in text
     assert "opaque resource ids" in text
     assert "trusted_input" not in _nested_list(_frontmatter(SKILL.read_text(encoding="utf-8")), "capabilities")
-    assert "browser.read_page" not in text
-    assert "browser.wait" not in text
+    assert not re.search(r"\bbrowser\.read_page\b", text)
+    assert not re.search(r"\bbrowser\.wait\b", text)
     assert "local approval" not in text
     assert "publish image, video, or long-article notes" in text
     assert "long_article" in text
@@ -165,3 +173,47 @@ def test_browser_skill_matches_complete_local_runtime() -> None:
     assert "reconciliation after uncertain browser writes" in text
     assert "stop on warning" in text
     assert "explicit confirmation" in text
+
+
+def test_upstream_mcp_feature_parity_and_skill_ownership() -> None:
+    text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in [SKILL, *(SKILL_DIR / "references").glob("*.md")]
+    ).casefold()
+
+    for feature in (
+        "check_login_status",
+        "get_login_qrcode",
+        "publish_content",
+        "publish_with_video",
+        "list_feeds",
+        "search_feeds",
+        "get_feed_detail",
+        "user_profile",
+        "get_me",
+        "post_comment_to_feed",
+        "reply_comment_in_feed",
+        "like_feed",
+        "favorite_feed",
+    ):
+        assert feature in text
+
+    for invariant in (
+        "上传图文",
+        "上传视频",
+        "写长文",
+        "新的创作",
+        "一键排版",
+        "xhs-publish-btn",
+        "submit-disabled=true",
+        "img-preview-area",
+        "10 minutes",
+        "15 seconds",
+        "4 seconds",
+        "never exceed two total clicks",
+    ):
+        assert invariant.casefold() in text
+
+    assert "a7d1f2f7f45e0b1c27de67c8f8a19131ba321725" in text
+    assert "no arbitrary cdp/evaluate" in text
+    assert "no cookie deletion/export" in text


### PR DESCRIPTION
## Summary
- benchmark Xiaohongshu business workflows against `xpzouying/xiaohongshu-mcp@a7d1f2f7`
- keep all Xiaohongshu routes, selector hints, state machines, bounded retries, idempotency, and reconciliation in the Skill layer
- cover login/QR, image/video/long-article publish, feeds/search/detail/profile, comments/replies, like/unlike, and favorite/unfavorite
- add deterministic publish success and interaction state checks
- explicitly reject upstream Cookie/CDP/headless/local-path shortcuts

No extension or aichat2 capability code is changed.

## Validation
- 21 Xiaohongshu Skill tests passed
- `git diff --check`

## Adversarial review
Initial review found the new parity reference was untracked. It is included in this commit. Final content review found no architecture leakage or functional P1/P2.
