### PR TITLE
fix(personal-wechat): import time for task polling

### DIFF
--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/skills/personal-wechat/tests/test_personal_wechat.py
+++ b/skills/personal-wechat/tests/test_personal_wechat.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "personal_wechat.py"
+SPEC = importlib.util.spec_from_file_location("personal_wechat_skill_script", SCRIPT)
+assert SPEC and SPEC.loader
+sys.path.insert(0, str(SCRIPT.parent))
+personal_wechat = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(personal_wechat)
+
+
+def test_wait_task_returns_successful_result() -> None:
+    with patch.object(
+        personal_wechat,
+        "request",
+        return_value={"status": "succeeded", "result": {"sent": True}},
+    ):
+        result = personal_wechat.wait_task("task-1", timeout=0.1)
+
+    assert result == {"sent": True}


### PR DESCRIPTION
## Summary
- import the standard library time module used by Personal WeChat task polling
- add a regression test for successful queued-task completion

## Validation
- python3 -m pytest -q skills/personal-wechat/tests (1 passed)
- python3 -m py_compile skills/personal-wechat/scripts/personal_wechat.py skills/personal-wechat/tests/test_personal_wechat.py
- git diff --check

## Rollout / rollback
- stdlib-only runtime fix; rollback by reverting this commit

## Adversarial review
- reviewer: Explore subagent, 1 round
- VERDICT: CLEAN
