### PR TITLE
docs(ai-chat): add flagship models (gpt-5.6, grok-4.5, gemini-3.5-flash)

### DIFF
--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -56,11 +56,11 @@ models include:
 
 | Family | Current examples |
 |--------|------------------|
-| OpenAI / reasoning | `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o3`, `o4-mini` |
+| OpenAI / reasoning | `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o3`, `o4-mini` |
 | OpenAI free-tier chat-completions | `gpt-5.5:free`, `gpt-5:free`, `gpt-4.1:free`, `gpt-4o:free`, `gpt-4o-mini:free`, `gpt-oss:free` |
 | Claude | `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
-| Gemini | `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
-| Grok | `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
+| Gemini | `gemini-3.5-flash`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
+| Grok | `grok-4.5`, `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
 | DeepSeek | `deepseek-r1`, `deepseek-r1-0528`, `deepseek-v3`, `deepseek-v3-250324`, `deepseek-v3.2-exp`, `deepseek-v4-flash` |
 | Kimi | `kimi-k3`, `kimi-k2.6`, `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking`, `kimi-k2-instruct-0905`, `kimi-k2-0905-preview`, `kimi-k2-turbo-preview`, `kimi-k2-0711-preview` |
 | GLM | `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5v`, `glm-3-turbo` |


### PR DESCRIPTION
## What

Prepends the current recommended flagship chat models to their provider rows in the `ai-chat` skill's model table (`skills/ai-chat/SKILL.md`), matching the live platform source of truth (`PlatformBackend/config/models.json`):

- OpenAI / reasoning: `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`
- Grok: `grok-4.5`
- Gemini: `gemini-3.5-flash`

## Why

These flagships shipped on the platform but the skill's model table still led with the previous generation (`gpt-5.5`, `grok-4`, `gemini-3.1-pro`). GLM/Kimi/Claude/DeepSeek rows were already current.

## Scope

Single-file, newest-first ordering — follows the `kimi-k3` (#652) precedent. The `.agents/` and `.github/` skill copies are symlinks to `skills/`, so the change propagates automatically; no per-model manifest or test enumerates these models.

## 🤖 对抗评审

Docs-only edit (model-name table). Strings verified character-exact vs `config/models.json`; flagship-first ordering matches the #652 precedent; symlink mirrors auto-propagate. No logic surface.
**VERDICT: CLEAN**