### PR TITLE
feat(discord): add permission-first DM support

### DIFF
--- a/skills/discordbot/SKILL.md
+++ b/skills/discordbot/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: discordbot
-description: List channels, read recent messages, and send messages on Discord using the user's own bot, via the Discord REST API. Use when the user wants their Discord BOT to post a message, read a channel, or list servers/channels — anything that acts in a server the bot was invited to.
+description: List channels, read recent messages, send channel messages, and send a single user-initiated DM on Discord using the user's own bot via the Discord REST API.
 when_to_use: |
   Trigger when the user wants to send, read, or list things on Discord
   through their bot: list the servers/channels the bot can see, read recent
-  messages in a channel, or post / reply in a channel. Messages are sent as
-  the BOT, not the user's personal account, and only in servers the bot has
-  been invited to with the right permissions.
+  messages in a channel, post / reply in a channel, or DM one user who has
+  explicitly initiated the interaction. Messages are sent as the BOT, not
+  the user's personal account, and only where the bot has access.
 connections: [discordbot]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 We drive the [Discord API](https://discord.com/developers/docs/reference)
@@ -33,8 +33,21 @@ bot token is wrong/reset — ask the user to re-paste it at
 `auth.acedata.cloud/user/connections`. A `429` carries `retry_after`
 (seconds) — sleep that long, then retry; never parallelize.
 
-**Before sending a message, confirm the exact channel and content with the
-user.** Sending is irreversible and public to that channel.
+## Sending safety
+
+- Before sending, confirm the exact destination and final content with the
+  user. Sending is irreversible.
+- A DM must be initiated by a recipient action, such as asking the bot for
+  details by replying with an advertised keyword. Server membership, a public
+  profile, or appearing in a member list is not consent.
+- Send to exactly one recipient per invocation. Never enumerate members,
+  create DM channels in a loop, or send unsolicited/bulk outreach.
+- For an unattended scheduled run, send only when its task definition already
+  contains one exact `recipient_id`, `consent_channel_id`,
+  `consent_message_id`, `consent_keyword`, and approved `content`. If any is
+  missing, return a draft without sending.
+- Do not follow up unless the recipient replies. Treat `stop`, `unsubscribe`,
+  or an equivalent refusal as a permanent opt-out.
 
 ## Recipes
 
@@ -77,7 +90,7 @@ bot. Needs the *Read Message History* permission in that channel.
 CHANNEL_ID="123456789012345678"
 curl -sS -H "Authorization: Bot $DISCORDBOT_TOKEN" \
   "https://discord.com/api/v10/channels/$CHANNEL_ID/messages?limit=20" \
-  | jq 'map({author: .author.username, ts: .timestamp, content})'
+  | jq 'map({id, author_id: .author.id, author: .author.username, author_bot: .author.bot, ts: .timestamp, content})'
 ```
 
 ### Send a message to a channel
@@ -103,6 +116,34 @@ curl -sS -X POST \
         '{content: $c, message_reference: {message_id: $m}}')"
 ```
 
+### Send one opt-in DM
+
+Use only after applying every rule in **Sending safety**. The helper fetches
+the source message from Discord and verifies that its non-bot author matches
+`RECIPIENT_ID` and its complete text matches `CONSENT_KEYWORD`. Do not call the
+Create DM endpoint directly. Matching is case-insensitive and collapses
+surrounding or repeated whitespace.
+
+```sh
+RECIPIENT_ID="123456789012345678"
+CONSENT_CHANNEL_ID="223456789012345678"
+CONSENT_MESSAGE_ID="323456789012345678"
+CONSENT_KEYWORD="details"
+
+python3 "$SKILL_DIR/scripts/discordbot.py" send-opt-in-dm \
+  --recipient-id "$RECIPIENT_ID" \
+  --consent-channel-id "$CONSENT_CHANNEL_ID" \
+  --consent-message-id "$CONSENT_MESSAGE_ID" \
+  --consent-keyword "$CONSENT_KEYWORD" \
+  --content "Here are the details you requested."
+```
+
+The command is a dry-run unless the final argument is `--confirm`. In a
+pre-authorized scheduled task, use final `--unattended-confirm` instead. The
+helper validates all IDs, verifies the opt-in message, and skips an identical
+message already present in the DM history. Discord may block or rate-limit bots
+that open many DMs; do not retry by targeting another account.
+
 ## Notes
 
 - A "server" in the UI is a "guild" in the API; messages live in channels
@@ -113,5 +154,7 @@ curl -sS -X POST \
   URL → pick a server (the user needs *Manage Server* there).
 - This is a bot, not the user's account — it cannot read the user's DMs or
   the user's full server list, only what the bot itself can access.
+- A bot can open its own DM channel with one consenting user; that does not
+  grant access to the connected user's personal DMs.
 - Mentions: `<@USER_ID>` pings a user, `<#CHANNEL_ID>` links a channel. Plain
   text is fine for normal messages.

--- a/skills/discordbot/scripts/discordbot.py
+++ b/skills/discordbot/scripts/discordbot.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Permission-first Discord Bot actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+API_BASE = "https://discord.com/api/v10"
+SNOWFLAKE_RE = re.compile(r"[0-9]{17,20}")
+
+
+class DiscordBotError(RuntimeError):
+    pass
+
+
+def out(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def normalize_text(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def validate_snowflake(name: str, value: str) -> str:
+    value = value.strip()
+    if not SNOWFLAKE_RE.fullmatch(value):
+        raise DiscordBotError(f"{name} must be a 17-20 digit Discord snowflake")
+    return value
+
+
+def validate_send_input(
+    recipient_id: str,
+    consent_channel_id: str,
+    consent_message_id: str,
+    consent_keyword: str,
+    content: str,
+) -> dict[str, str]:
+    values = {
+        "recipient_id": validate_snowflake("recipient_id", recipient_id),
+        "consent_channel_id": validate_snowflake("consent_channel_id", consent_channel_id),
+        "consent_message_id": validate_snowflake("consent_message_id", consent_message_id),
+        "consent_keyword": consent_keyword.strip(),
+        "content": content.strip(),
+    }
+    if not values["consent_keyword"] or len(values["consent_keyword"]) > 64:
+        raise DiscordBotError("consent_keyword must contain 1-64 characters")
+    if not values["content"] or len(values["content"]) > 2000:
+        raise DiscordBotError("content must contain 1-2000 characters")
+    return values
+
+
+def api_request(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    token = os.environ.get("DISCORDBOT_TOKEN", "").strip()
+    if not token:
+        raise DiscordBotError(
+            "DISCORDBOT_TOKEN is not set; connect Discord Bot at "
+            "https://auth.acedata.cloud/user/connections"
+        )
+    body = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        f"{API_BASE}{path}",
+        data=body,
+        method=method,
+        headers={
+            "Authorization": f"Bot {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "AceDataCloud-DiscordBot/1.1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            detail = json.loads(raw.decode())
+            message = str(detail.get("message") or detail.get("code") or "request rejected")
+            retry_after = detail.get("retry_after")
+        except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
+            message = "request rejected"
+            retry_after = None
+        suffix = f"; retry_after={retry_after}" if retry_after is not None else ""
+        raise DiscordBotError(f"Discord API {exc.code}: {message}{suffix}") from None
+    except urllib.error.URLError as exc:
+        raise DiscordBotError(f"Discord API unavailable: {exc.reason}") from None
+
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode())
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DiscordBotError("Discord API returned invalid JSON") from exc
+
+
+def send_opt_in_dm(
+    recipient_id: str,
+    consent_channel_id: str,
+    consent_message_id: str,
+    consent_keyword: str,
+    content: str,
+) -> dict[str, Any]:
+    values = validate_send_input(
+        recipient_id,
+        consent_channel_id,
+        consent_message_id,
+        consent_keyword,
+        content,
+    )
+    recipient_id = values["recipient_id"]
+    consent_channel_id = values["consent_channel_id"]
+    consent_message_id = values["consent_message_id"]
+    consent_keyword = values["consent_keyword"]
+    content = values["content"]
+
+    bot = api_request("GET", "/users/@me")
+    bot_id = validate_snowflake("bot id", str(bot.get("id", "")))
+    if not bot.get("bot"):
+        raise DiscordBotError("connected credential is not a Discord bot token")
+
+    source = api_request("GET", f"/channels/{consent_channel_id}/messages/{consent_message_id}")
+    if str(source.get("id", "")) != consent_message_id:
+        raise DiscordBotError("Discord returned a different consent message")
+    author = source.get("author") or {}
+    if str(author.get("id", "")) != recipient_id:
+        raise DiscordBotError("consent message author does not match recipient_id")
+    if author.get("bot"):
+        raise DiscordBotError("bot-authored messages cannot grant DM consent")
+    if normalize_text(str(source.get("content", ""))) != normalize_text(consent_keyword):
+        raise DiscordBotError("consent message does not exactly match consent_keyword")
+
+    dm = api_request("POST", "/users/@me/channels", {"recipient_id": recipient_id})
+    dm_channel_id = validate_snowflake("DM channel id", str(dm.get("id", "")))
+
+    history = api_request("GET", f"/channels/{dm_channel_id}/messages?limit=100")
+    if not isinstance(history, list):
+        raise DiscordBotError("Discord returned invalid DM history")
+    duplicate = next(
+        (
+            message
+            for message in history
+            if str((message.get("author") or {}).get("id", "")) == bot_id
+            and str(message.get("content", "")) == content
+        ),
+        None,
+    )
+    if duplicate:
+        return {
+            "status": "duplicate_skipped",
+            "recipient_id": recipient_id,
+            "consent_message_id": consent_message_id,
+            "dm_channel_id": dm_channel_id,
+            "message_id": duplicate.get("id"),
+        }
+
+    sent = api_request("POST", f"/channels/{dm_channel_id}/messages", {"content": content})
+    return {
+        "status": "sent",
+        "recipient_id": recipient_id,
+        "consent_message_id": consent_message_id,
+        "dm_channel_id": dm_channel_id,
+        "message_id": sent.get("id"),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    send = commands.add_parser("send-opt-in-dm", help="send one DM after verifying an exact opt-in message")
+    send.add_argument("--recipient-id", required=True)
+    send.add_argument("--consent-channel-id", required=True)
+    send.add_argument("--consent-message-id", required=True)
+    send.add_argument("--consent-keyword", required=True)
+    send.add_argument("--content", required=True)
+    send.add_argument("--confirm", action="store_true", help=argparse.SUPPRESS)
+    send.add_argument("--unattended-confirm", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def parse_cli(raw: list[str] | None = None) -> tuple[argparse.Namespace, str]:
+    raw = list(sys.argv[1:] if raw is None else raw)
+    parser = build_parser()
+    args = parser.parse_args(raw)
+    if args.confirm and args.unattended_confirm:
+        parser.error("choose only one confirmation mode")
+    confirm_mode = "--confirm" if args.confirm else "--unattended-confirm" if args.unattended_confirm else ""
+    if confirm_mode and (not raw or raw[-1] != confirm_mode):
+        parser.error(f"{confirm_mode} must be the final argument")
+    return args, confirm_mode
+
+
+def main() -> None:
+    args, confirm_mode = parse_cli()
+    try:
+        values = validate_send_input(
+            args.recipient_id,
+            args.consent_channel_id,
+            args.consent_message_id,
+            args.consent_keyword,
+            args.content,
+        )
+        if not confirm_mode:
+            out(
+                {
+                    "status": "dry_run",
+                    "recipient_id": values["recipient_id"],
+                    "consent_channel_id": values["consent_channel_id"],
+                    "consent_message_id": values["consent_message_id"],
+                    "consent_keyword": values["consent_keyword"],
+                    "content": values["content"],
+                    "next": "rerun with trailing --confirm after user approval",
+                }
+            )
+            return
+        out(send_opt_in_dm(**values))
+    except DiscordBotError as exc:
+        out({"error": str(exc)})
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_discordbot.py
+++ b/tests/test_discordbot.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import unittest
+
+
+SKILL = Path(__file__).parents[1] / "skills" / "discordbot" / "SKILL.md"
+
+
+class DiscordBotSkillTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.content = SKILL.read_text(encoding="utf-8")
+
+    def test_skill_has_one_frontmatter_block(self) -> None:
+        self.assertTrue(self.content.startswith("---\n"))
+        self.assertEqual(self.content.count("\n---\n"), 1)
+        self.assertIn('version: "1.1"', self.content)
+
+    def test_read_recipe_returns_opt_in_evidence_fields(self) -> None:
+        self.assertIn("author_id: .author.id", self.content)
+        self.assertIn("id, author_id:", self.content)
+
+    def test_dm_recipe_uses_official_single_recipient_endpoint(self) -> None:
+        self.assertIn('python3 "$SKILL_DIR/scripts/discordbot.py" send-opt-in-dm', self.content)
+        self.assertIn('--recipient-id "$RECIPIENT_ID"', self.content)
+        self.assertIn('--consent-message-id "$CONSENT_MESSAGE_ID"', self.content)
+        self.assertIn("Send to exactly one recipient per invocation", self.content)
+
+    def test_unattended_dm_requires_preapproved_evidence(self) -> None:
+        self.assertIn("one exact `recipient_id`", self.content)
+        self.assertIn("`consent_channel_id`", self.content)
+        self.assertIn("`consent_message_id`", self.content)
+        self.assertIn("`consent_keyword`", self.content)
+        self.assertIn("approved `content`", self.content)
+        self.assertIn("return a draft without sending", self.content)
+
+    def test_bulk_and_nonconsensual_dm_are_forbidden(self) -> None:
+        self.assertIn("Server membership, a public", self.content)
+        self.assertIn("profile, or appearing in a member list is not consent", self.content)
+        self.assertIn("Never enumerate members", self.content)
+        self.assertIn("Do not call the", self.content)
+        self.assertIn("Create DM endpoint directly", self.content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discordbot_script.py
+++ b/tests/test_discordbot_script.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "skills" / "discordbot" / "scripts" / "discordbot.py"
+SPEC = importlib.util.spec_from_file_location("discordbot_skill", SCRIPT)
+assert SPEC and SPEC.loader
+discordbot = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(discordbot)
+
+RECIPIENT_ID = "123456789012345678"
+CHANNEL_ID = "223456789012345678"
+CONSENT_MESSAGE_ID = "323456789012345678"
+BOT_ID = "423456789012345678"
+DM_CHANNEL_ID = "523456789012345678"
+SENT_MESSAGE_ID = "623456789012345678"
+
+
+class DiscordBotScriptTests(unittest.TestCase):
+    def call_send(self):
+        return discordbot.send_opt_in_dm(
+            recipient_id=RECIPIENT_ID,
+            consent_channel_id=CHANNEL_ID,
+            consent_message_id=CONSENT_MESSAGE_ID,
+            consent_keyword="details",
+            content="Here are the details.",
+        )
+
+    @patch.object(discordbot, "api_request")
+    def test_send_verifies_consent_and_posts_one_dm(self, api_request) -> None:
+        api_request.side_effect = [
+            {"id": BOT_ID, "bot": True},
+            {
+                "id": CONSENT_MESSAGE_ID,
+                "author": {"id": RECIPIENT_ID, "bot": False},
+                "content": "  DETAILS  ",
+            },
+            {"id": DM_CHANNEL_ID},
+            [],
+            {"id": SENT_MESSAGE_ID},
+        ]
+
+        result = self.call_send()
+
+        self.assertEqual(result["status"], "sent")
+        self.assertEqual(result["message_id"], SENT_MESSAGE_ID)
+        self.assertEqual(
+            api_request.call_args_list,
+            [
+                unittest.mock.call("GET", "/users/@me"),
+                unittest.mock.call("GET", f"/channels/{CHANNEL_ID}/messages/{CONSENT_MESSAGE_ID}"),
+                unittest.mock.call("POST", "/users/@me/channels", {"recipient_id": RECIPIENT_ID}),
+                unittest.mock.call("GET", f"/channels/{DM_CHANNEL_ID}/messages?limit=100"),
+                unittest.mock.call("POST", f"/channels/{DM_CHANNEL_ID}/messages", {"content": "Here are the details."}),
+            ],
+        )
+
+    @patch.object(discordbot, "api_request")
+    def test_rejects_consent_from_another_user_before_opening_dm(self, api_request) -> None:
+        api_request.side_effect = [
+            {"id": BOT_ID, "bot": True},
+            {
+                "id": CONSENT_MESSAGE_ID,
+                "author": {"id": "723456789012345678", "bot": False},
+                "content": "details",
+            },
+        ]
+
+        with self.assertRaisesRegex(discordbot.DiscordBotError, "author does not match"):
+            self.call_send()
+        self.assertEqual(api_request.call_count, 2)
+
+    @patch.object(discordbot, "api_request")
+    def test_rejects_non_exact_consent_keyword_before_opening_dm(self, api_request) -> None:
+        api_request.side_effect = [
+            {"id": BOT_ID, "bot": True},
+            {
+                "id": CONSENT_MESSAGE_ID,
+                "author": {"id": RECIPIENT_ID, "bot": False},
+                "content": "tell me details maybe",
+            },
+        ]
+
+        with self.assertRaisesRegex(discordbot.DiscordBotError, "exactly match"):
+            self.call_send()
+        self.assertEqual(api_request.call_count, 2)
+
+    @patch.object(discordbot, "api_request")
+    def test_identical_prior_dm_is_not_sent_again(self, api_request) -> None:
+        api_request.side_effect = [
+            {"id": BOT_ID, "bot": True},
+            {
+                "id": CONSENT_MESSAGE_ID,
+                "author": {"id": RECIPIENT_ID, "bot": False},
+                "content": "details",
+            },
+            {"id": DM_CHANNEL_ID},
+            [
+                {
+                    "id": SENT_MESSAGE_ID,
+                    "author": {"id": BOT_ID, "bot": True},
+                    "content": "Here are the details.",
+                }
+            ],
+        ]
+
+        result = self.call_send()
+
+        self.assertEqual(result["status"], "duplicate_skipped")
+        self.assertEqual(api_request.call_count, 4)
+
+    @patch.object(discordbot, "api_request")
+    def test_invalid_recipient_is_rejected_without_network(self, api_request) -> None:
+        with self.assertRaisesRegex(discordbot.DiscordBotError, "recipient_id"):
+            discordbot.send_opt_in_dm(
+                recipient_id="not-a-user",
+                consent_channel_id=CHANNEL_ID,
+                consent_message_id=CONSENT_MESSAGE_ID,
+                consent_keyword="details",
+                content="Here are the details.",
+            )
+        api_request.assert_not_called()
+
+    @patch.object(discordbot, "api_request")
+    def test_bot_authored_consent_is_rejected(self, api_request) -> None:
+        api_request.side_effect = [
+            {"id": BOT_ID, "bot": True},
+            {
+                "id": CONSENT_MESSAGE_ID,
+                "author": {"id": RECIPIENT_ID, "bot": True},
+                "content": "details",
+            },
+        ]
+
+        with self.assertRaisesRegex(discordbot.DiscordBotError, "bot-authored"):
+            self.call_send()
+        self.assertEqual(api_request.call_count, 2)
+
+    def test_content_equal_to_confirm_flag_is_not_confirmation(self) -> None:
+        args, confirm_mode = discordbot.parse_cli(
+            [
+                "send-opt-in-dm",
+                "--recipient-id",
+                RECIPIENT_ID,
+                "--consent-channel-id",
+                CHANNEL_ID,
+                "--consent-message-id",
+                CONSENT_MESSAGE_ID,
+                "--consent-keyword",
+                "details",
+                "--content=--confirm",
+            ]
+        )
+
+        self.assertEqual(args.content, "--confirm")
+        self.assertEqual(confirm_mode, "")
+
+    def test_confirmation_flag_must_be_final(self) -> None:
+        with self.assertRaises(SystemExit):
+            discordbot.parse_cli(
+                [
+                    "send-opt-in-dm",
+                    "--confirm",
+                    "--recipient-id",
+                    RECIPIENT_ID,
+                    "--consent-channel-id",
+                    CHANNEL_ID,
+                    "--consent-message-id",
+                    CONSENT_MESSAGE_ID,
+                    "--consent-keyword",
+                    "details",
+                    "--content",
+                    "Approved content",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a controlled `send-opt-in-dm` helper for Discord Bot
- verify the source message, author, exact opt-in keyword, and single recipient before opening a DM
- dry-run by default; require final `--confirm` or pre-authorized `--unattended-confirm`
- suppress duplicate identical messages and sanitize API errors

## Validation
- `python3 -m unittest discover -s tests -v` (47 passed)
- `ruff check skills/discordbot/scripts/discordbot.py tests/test_discordbot.py tests/test_discordbot_script.py`
- Python compile, shell recipe syntax, and `git diff --check`

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: raw DM curl lacked input/error enforcement → 已修：replaced with a typed helper and mock API tests
- RISK: scheduled consent existed only in prose → 已修：helper fetches and verifies the source message, recipient, non-bot author, and exact keyword
- RISK: confirmation argument could collide with content → 已修：native argparse flags plus final-position enforcement
- RISK: HTTP exception chain could retain the bot token → 已修：sanitized errors raised without the request-bearing cause
- Final verdict: CLEAN