### PR TITLE
fix(discord): repair SKILL.md frontmatter YAML so sync stops skipping it

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: Work with the user's Discord account. Two modes, auto-selected by how they connected — OAuth (read-only identity + server list) or User Token / BYOC (full personal-account actions: list channels, read messages, send & reply). Use when the user mentions Discord, asks which servers they are in, or wants to read/post in a channel as themselves.
+description: Work with the user's Discord account. Two modes, auto-selected by how they connected — OAuth (read-only identity and server list) or User Token / BYOC (full personal-account actions — list channels, read messages, send and reply). Use when the user mentions Discord, asks which servers they are in, or wants to read/post in a channel as themselves.
 when_to_use: |
   Trigger for anything on the user's connected Discord account. What you can do
   depends on how they connected:


### PR DESCRIPTION
## What

One-line fix: the `discord` skill's `description:` frontmatter had an **unquoted colon inside a flow scalar** (`...full personal-account actions: list channels...`). YAML reads that colon as a mapping separator, so the whole frontmatter fails to parse.

Reworded to remove the colon (and the `&`/`+` specials) so it parses cleanly.

## Why (this is a prod-breaking bug that passed CI)

AuthBackend's `sync_skills` parses each SKILL.md's frontmatter with a real YAML parser. On the broken line it raised `bad frontmatter: mapping values are not allowed here` and **silently skipped the entire `discord` skill**. Result: the dual-mode (OAuth + BYOC user-token) content merged in #682 **never reached the DB**, and aichat2 kept serving the *old* read-only discord skill. That's why the BYOC path looked dead in E2E even though the connector + sandbox were correct.

Verified by running `sync_skills` inside the auth-backend pod:
```
skipping discord — bad frontmatter: mapping values are not allowed here
  line 2, column 193: ...actions: list channels, read messages, ...
sync done — sources=1 seen=90 upserted=88 skipped=1 failed=1
```
and by confirming the DB `discord` skill content still lacked `discord_user.py` / `DISCORD_USER_TOKEN`.

**Root cause of the CI miss:** `validate.yml` extracts frontmatter fields with `grep`/`sed`, not a real YAML parse — so a syntactically invalid frontmatter passes CI but breaks the downstream sync. (Follow-up worth considering: add a real `yaml.safe_load` check to validate.yml.)

## 🤖 对抗评审

Trivial one-line YAML-quoting fix on a data file. Self-review: `name`==dir, description 348≤1024, `connections`/`allowed_tools` intact, `yaml.safe_load` of the frontmatter now succeeds. `VERDICT: CLEAN`.
