### PR TITLE
test(browser): enforce cross-site core isolation

### DIFF
--- a/skills/xiaohongshu/tests/test_cross_site_boundary.py
+++ b/skills/xiaohongshu/tests/test_cross_site_boundary.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+SKILLS_DIR = Path(__file__).parents[2]
+BROWSER_CORE = Path(__file__).parents[1] / "contracts" / "browser-manifest.compact.json"
+TIKTOK_SKILL = SKILLS_DIR / "tiktok" / "SKILL.md"
+
+
+def test_browser_core_has_no_xiaohongshu_or_tiktok_semantics() -> None:
+    core = BROWSER_CORE.read_text(encoding="utf-8").casefold()
+
+    for site_term in (
+        "xiaohongshu",
+        "creator.xiaohongshu.com",
+        "tiktok",
+        "open.tiktokapis.com",
+        "publish_id",
+        "pull_from_url",
+    ):
+        assert site_term not in core
+
+
+def test_tiktok_remains_an_api_skill_until_browser_canary_is_approved() -> None:
+    skill = TIKTOK_SKILL.read_text(encoding="utf-8")
+
+    assert "allowed_tools: [Bash]" in skill
+    assert "https://open.tiktokapis.com/v2" in skill
+    assert "execution:\n  browser:" not in skill
+    assert "browser." not in skill


### PR DESCRIPTION
## Summary
- add executable checks that the generated browser core contains neither Xiaohongshu nor TikTok semantics
- assert TikTok remains on its audited OAuth/API path until a browser canary is explicitly approved
- first P0-6 cross-site boundary slice from https://github.com/AceDataCloud/Index/pull/285

## Validation
- `test_cross_site_boundary.py` — 2 passed
- Ruff check + format pass

## Scope
No Douyin/TikTok live canary is claimed; Legal/Product approval is still missing.

## Minimal adversarial review
Review confirmed the test preserves current TikTok API behavior and blocks premature browser routing.