### PR TITLE
chore(browser): sync locator contract digest

### DIFF
--- a/skills/xiaohongshu/contracts/browser-manifest.compact.json
+++ b/skills/xiaohongshu/contracts/browser-manifest.compact.json
@@ -1,8 +1,8 @@
 {
   "_generated": {
     "generator": "aichat2/worker/scripts/generate-browser-manifest.ts",
-    "source_commit": "1126a2bc02a002a0227831ff691abc0ae0dc4456",
-    "wire_contract_digest": "sha256:1a9e10cdfd839f79f0cb51db31cd07b68eb86126cc993527502f7a5a3ad9ab11",
+    "source_commit": "e834de475b3c567989c6fc74a7a662e58a50732b",
+    "wire_contract_digest": "sha256:c6bba645acd73ab44d4866f7062813556bd9c5ee166c7acf7f12bbc2d878cda8",
     "facade_catalog_digest": "sha256:756005f4ef222efcdf06dd559e403b3cdd3c0e16a2e05cadaabb594809434f3e"
   },
   "facades": {

--- a/skills/xiaohongshu/contracts/browser-manifest.compact.json
+++ b/skills/xiaohongshu/contracts/browser-manifest.compact.json
@@ -1,7 +1,7 @@
 {
   "_generated": {
     "generator": "aichat2/worker/scripts/generate-browser-manifest.ts",
-    "source_commit": "e834de475b3c567989c6fc74a7a662e58a50732b",
+    "source_commit": "38f585523b137950352dbcb00b6666fc8e0217eb",
     "wire_contract_digest": "sha256:c6bba645acd73ab44d4866f7062813556bd9c5ee166c7acf7f12bbc2d878cda8",
     "facade_catalog_digest": "sha256:756005f4ef222efcdf06dd559e403b3cdd3c0e16a2e05cadaabb594809434f3e"
   },


### PR DESCRIPTION
## Summary
- update Xiaohongshu's generated compact browser manifest provenance to PlatformService PR #1641 source `e834de475b3c567989c6fc74a7a662e58a50732b`
- pin wire digest `sha256:c6bba645acd73ab44d4866f7062813556bd9c5ee166c7acf7f12bbc2d878cda8`
- keep the facade catalog unchanged

## Dependency and rollout
- stacked on https://github.com/AceDataCloud/PlatformService/pull/1641
- internal execution and live canary remain blocked until all consumers and device-ready proof align

## Validation
- Xiaohongshu contract + cross-site boundary suites: 11 passed

## Adversarial review
- compact manifest confirmed as the intended Skills consumer; no missing generated file