### PR TITLE
fix(xiaohongshu): align browser authority descriptors

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -11,7 +11,7 @@ when_to_use: |
   comment, reply, like, or favorite on Xiaohongshu, including implicit requests
   such as "发一篇种草笔记" when Xiaohongshu is clear from context.
 connections: [xiaohongshu]
-skill_revision: 4.1.0
+skill_revision: 4.2.0
 allowed_tools:
   - browser.snapshot
   - browser.get_text
@@ -35,6 +35,7 @@ allowed_tools:
   - browser.batch
 execution:
   browser:
+    skill_revision: 4.2.0
     provider: xiaohongshu/xiaohongshu
     origins:
       - https://www.xiaohongshu.com
@@ -51,7 +52,19 @@ execution:
       - file.upload
     operations:
       read_content:
-        action_class: read
+        minimum_action_class: read
+        allowed_commands:
+          - act/hover
+          - act/scroll
+          - act/scroll_to
+          - navigate/url
+          - observe/accessibility
+          - observe/element
+          - observe/find
+          - observe/screenshot
+          - observe/visible_text
+          - tabs/manage
+          - wait/condition
         allowed_tools:
           - browser.snapshot
           - browser.get_text
@@ -67,10 +80,30 @@ execution:
         preview_schema:
           type: object
           required: []
-        semantic_key:
-          template: "xiaohongshu:read:{origin}:{resource}"
+        semantic_key_template: "{provider}:{operation_id}:{normalized_input_hash}"
       publish_note:
-        action_class: protected.publish
+        minimum_action_class: protected.publish
+        allowed_commands:
+          - act/batch
+          - act/check
+          - act/click
+          - act/fill
+          - act/hover
+          - act/press
+          - act/scroll
+          - act/scroll_to
+          - act/select
+          - act/type
+          - dialog/handle
+          - navigate/url
+          - observe/accessibility
+          - observe/element
+          - observe/find
+          - observe/screenshot
+          - observe/visible_text
+          - tabs/manage
+          - transfer/upload
+          - wait/condition
         allowed_tools:
           - browser.snapshot
           - browser.get_text
@@ -99,10 +132,27 @@ execution:
             - content_hash
             - media_hashes
             - visibility
-        semantic_key:
-          template: "xiaohongshu:publish:{account}:{content_hash}"
+        semantic_key_template: "{provider}:{operation_id}:{preview_hash}:{normalized_input_hash}"
       comment_or_reply:
-        action_class: protected.interaction
+        minimum_action_class: protected.interaction
+        allowed_commands:
+          - act/batch
+          - act/click
+          - act/fill
+          - act/hover
+          - act/press
+          - act/scroll
+          - act/scroll_to
+          - act/type
+          - dialog/handle
+          - navigate/url
+          - observe/accessibility
+          - observe/element
+          - observe/find
+          - observe/screenshot
+          - observe/visible_text
+          - tabs/manage
+          - wait/condition
         allowed_tools:
           - browser.snapshot
           - browser.get_text
@@ -126,10 +176,21 @@ execution:
           required:
             - target
             - content_hash
-        semantic_key:
-          template: "xiaohongshu:interaction:{target}:{content_hash}"
+        semantic_key_template: "{provider}:{operation_id}:{preview_hash}:{normalized_input_hash}"
       toggle_reaction:
-        action_class: reversible.write
+        minimum_action_class: reversible.write
+        allowed_commands:
+          - act/click
+          - act/scroll
+          - act/scroll_to
+          - navigate/url
+          - observe/accessibility
+          - observe/element
+          - observe/find
+          - observe/screenshot
+          - observe/visible_text
+          - tabs/manage
+          - wait/condition
         allowed_tools:
           - browser.snapshot
           - browser.get_text
@@ -148,8 +209,7 @@ execution:
             - target
             - reaction
             - enabled
-        semantic_key:
-          template: "xiaohongshu:reaction:{target}:{reaction}:{enabled}"
+        semantic_key_template: "{provider}:{operation_id}:{preview_hash}:{normalized_input_hash}"
 license: Apache-2.0
 metadata:
   author: acedatacloud

--- a/skills/xiaohongshu/tests/test_browser_contract.py
+++ b/skills/xiaohongshu/tests/test_browser_contract.py
@@ -100,9 +100,24 @@ def _operation_block(frontmatter: str, operation: str) -> str:
     return match.group(1)
 
 
+def _operation_names(frontmatter: str) -> set[str]:
+    match = re.search(r"^    operations:\n(.*?)(?=^license:)", frontmatter, re.MULTILINE | re.DOTALL)
+    assert match, "missing execution.browser.operations"
+    return set(re.findall(r"^      ([a-z][a-z_]+):$", match.group(1), re.MULTILINE))
+
+
 def _operation_tools(block: str) -> set[str]:
     match = re.search(r"^        allowed_tools:\n((?:          - .+\n)+)", block, re.MULTILINE)
     assert match, "missing operation allowed_tools"
+    return {
+        line.removeprefix("          - ").strip()
+        for line in match.group(1).splitlines()
+    }
+
+
+def _operation_commands(block: str) -> set[str]:
+    match = re.search(r"^        allowed_commands:\n((?:          - .+\n)+)", block, re.MULTILINE)
+    assert match, "missing operation allowed_commands"
     return {
         line.removeprefix("          - ").strip()
         for line in match.group(1).splitlines()
@@ -119,8 +134,9 @@ def test_browser_execution_frontmatter_contract() -> None:
         re.MULTILINE,
     )
     assert "  Operate Xiaohongshu / RED through the user's paired browser device:" in frontmatter
-    assert re.search(r"^skill_revision: 4\.1\.0$", frontmatter, re.MULTILINE)
+    assert re.search(r"^skill_revision: 4\.2\.0$", frontmatter, re.MULTILINE)
     assert re.search(r"^execution:\n  browser:\n", frontmatter, re.MULTILINE)
+    assert re.search(r"^    skill_revision: 4\.2\.0$", frontmatter, re.MULTILINE)
     assert re.search(r"^    provider: xiaohongshu/xiaohongshu$", frontmatter, re.MULTILINE)
     assert _nested_list(frontmatter, "origins") == EXPECTED_ORIGINS
     assert _nested_list(frontmatter, "capabilities") == EXPECTED_CAPABILITIES
@@ -152,12 +168,16 @@ def test_compact_manifest_matches_final_generated_profile() -> None:
 
 
 def test_operation_descriptors_define_exact_tool_union() -> None:
-    frontmatter = _frontmatter(SKILL.read_text(encoding="utf-8"))
+    skill_text = SKILL.read_text(encoding="utf-8")
+    frontmatter = _frontmatter(skill_text)
+    operation_names = _operation_names(frontmatter)
+    assert operation_names == {"read_content", "publish_note", "comment_or_reply", "toggle_reaction"}
     operations = {
         name: _operation_block(frontmatter, name)
-        for name in ("read_content", "publish_note", "comment_or_reply", "toggle_reaction")
+        for name in operation_names
     }
     operation_tools = {name: _operation_tools(block) for name, block in operations.items()}
+    operation_commands = {name: _operation_commands(block) for name, block in operations.items()}
 
     assert set().union(*operation_tools.values()) == _top_level_list(frontmatter, "allowed_tools")
     assert set().union(*operation_tools.values()) == EXPECTED_FACADES
@@ -165,14 +185,31 @@ def test_operation_descriptors_define_exact_tool_union() -> None:
     for tools in operation_tools.values():
         assert tools <= DEPLOYED_BROWSER_TOOLS
 
+    for name, tools in operation_tools.items():
+        expected_commands = {
+            f"{MANIFEST_DATA['facades'][tool]['family']}/{MANIFEST_DATA['facades'][tool]['kind']}"
+            for tool in tools
+        }
+        assert operation_commands[name] == expected_commands
+
     publish = operations["publish_note"]
-    assert re.search(r"^        action_class: protected\.publish$", publish, re.MULTILINE)
+    assert re.search(r"^        minimum_action_class: protected\.publish$", publish, re.MULTILINE)
     for field in ("title", "content_hash", "media_hashes", "visibility"):
         assert re.search(rf"^            - {field}$", publish, re.MULTILINE)
-    assert re.search(r'^          template: "xiaohongshu:publish:\{account\}:\{content_hash\}"$', publish, re.MULTILINE)
-    assert re.search(r"^        action_class: protected\.interaction$", operations["comment_or_reply"], re.MULTILINE)
-    assert re.search(r"^        action_class: reversible\.write$", operations["toggle_reaction"], re.MULTILINE)
-    assert re.search(r"^        action_class: read$", operations["read_content"], re.MULTILINE)
+    assert re.search(
+        r'^        semantic_key_template: "\{provider\}:\{operation_id\}:\{preview_hash\}:\{normalized_input_hash\}"$',
+        publish,
+        re.MULTILINE,
+    )
+    assert re.search(r"^        minimum_action_class: protected\.interaction$", operations["comment_or_reply"], re.MULTILINE)
+    assert re.search(r"^        minimum_action_class: reversible\.write$", operations["toggle_reaction"], re.MULTILINE)
+    assert re.search(r"^        minimum_action_class: read$", operations["read_content"], re.MULTILINE)
+    for block in operations.values():
+        template = re.search(r'^        semantic_key_template: "([^"]+)"$', block, re.MULTILINE)
+        assert template
+        fields = set(re.findall(r"\{([^}]+)\}", template.group(1)))
+        assert {"provider", "operation_id"} <= fields
+        assert fields <= {"provider", "operation_id", "preview_hash", "normalized_input_hash"}
 
 
 def test_generic_manifest_contains_no_site_specific_logic() -> None:


### PR DESCRIPTION
## Summary
- align Xiaohongshu Browser operation descriptors with AuthBackend's production authority schema
- derive exact wire command allowlists from the generated Browser manifest
- validate every declared operation dynamically to prevent future sync regressions

## Production failure
`sync_skills --namespace acedatacloud` failed only for `acedatacloud/xiaohongshu` with `descriptor_invalid`, leaving the Skill hidden. The Xiaohongshu Browser Connector then failed closed with `required_skills_unavailable`.

## Validation
- `python3 -m pytest skills/xiaohongshu/tests/test_browser_contract.py skills/xiaohongshu/tests/test_contract_script.py -q` (25 passed)
- YAML parse + all-operation descriptor assertions
- `git diff --check`

## 🤖 对抗评审 (reviewer: GPT-5.3-Codex, 2 rounds)
- RISK: Auth parser unavailable to reviewer → 未采纳；已直接读取 `AuthBackend origin/main:app/services/browser_authority.py` 并逐字段对照，source SHA-256 `21634ae1e96283019390741adc8b0e2fec7de56bd96c5dc7c1ae3c3f821d2b2d`
- RISK: tests only enumerated four operations → 已修；YAML解析全部operation键并锁定预期集合，每个operation都验证Auth descriptor字段与manifest command映射
- Round 2: `VERDICT: CLEAN`
