### PR TITLE
chore(browser): sync 100MB resource contract

### DIFF
--- a/skills/xiaohongshu/contracts/browser-manifest.compact.json
+++ b/skills/xiaohongshu/contracts/browser-manifest.compact.json
@@ -1,8 +1,8 @@
 {
   "_generated": {
     "generator": "aichat2/worker/scripts/generate-browser-manifest.ts",
-    "source_commit": "a78269d3844a1f9cf39f16c86e72b601fda96dd3",
-    "wire_contract_digest": "sha256:ed4adfdd4ce9457637b0c1b4c201a50edff0929fb1047b7b305af944d381b30b",
+    "source_commit": "36734db68935dce5fb74e8b38730c9b6ebc2e7d2",
+    "wire_contract_digest": "sha256:e7b8c17c86ca467557535acb28373282c2b55f3bb3d7e214b846bf7ff6b971a4",
     "facade_catalog_digest": "sha256:756005f4ef222efcdf06dd559e403b3cdd3c0e16a2e05cadaabb594809434f3e"
   },
   "facades": {

--- a/skills/xiaohongshu/contracts/browser-manifest.compact.json
+++ b/skills/xiaohongshu/contracts/browser-manifest.compact.json
@@ -1,7 +1,7 @@
 {
   "_generated": {
     "generator": "aichat2/worker/scripts/generate-browser-manifest.ts",
-    "source_commit": "5e4ed46bd693bb95e378cdb73810d4fb592ab1c3",
+    "source_commit": "a78269d3844a1f9cf39f16c86e72b601fda96dd3",
     "wire_contract_digest": "sha256:ed4adfdd4ce9457637b0c1b4c201a50edff0929fb1047b7b305af944d381b30b",
     "facade_catalog_digest": "sha256:756005f4ef222efcdf06dd559e403b3cdd3c0e16a2e05cadaabb594809434f3e"
   },

--- a/skills/xiaohongshu/contracts/browser-manifest.compact.json
+++ b/skills/xiaohongshu/contracts/browser-manifest.compact.json
@@ -1,8 +1,8 @@
 {
   "_generated": {
     "generator": "aichat2/worker/scripts/generate-browser-manifest.ts",
-    "source_commit": "38f585523b137950352dbcb00b6666fc8e0217eb",
-    "wire_contract_digest": "sha256:c6bba645acd73ab44d4866f7062813556bd9c5ee166c7acf7f12bbc2d878cda8",
+    "source_commit": "5e4ed46bd693bb95e378cdb73810d4fb592ab1c3",
+    "wire_contract_digest": "sha256:ed4adfdd4ce9457637b0c1b4c201a50edff0929fb1047b7b305af944d381b30b",
     "facade_catalog_digest": "sha256:756005f4ef222efcdf06dd559e403b3cdd3c0e16a2e05cadaabb594809434f3e"
   },
   "facades": {


### PR DESCRIPTION
## Summary
- sync the Xiaohongshu compact Browser manifest to the final 100MB contract
- preserve the unchanged facade catalog and operation descriptors

Source commit: `36734db68935dce5fb74e8b38730c9b6ebc2e7d2`

Final wire digest: `sha256:e7b8c17c86ca467557535acb28373282c2b55f3bb3d7e214b846bf7ff6b971a4`

## Validation
- compact manifest JSON validation passed
- CI Validate Skills passed

## Rollout
Merge before enabling the matching aichat2/Relay producer. Facade catalog digest remains unchanged.

## Adversarial review (claude-subagent, 2 rounds)
- final provenance and digest were regenerated from the canonical source
- final digest parity was verified across all six consumers
- deployable-branch risk was fixed by committing and pushing the final compact manifest