### PR TITLE
docs(ai-chat): add claude-opus-5 to Claude model list

### DIFF
--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -58,7 +58,7 @@ models include:
 |--------|------------------|
 | OpenAI / reasoning | `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o3`, `o4-mini` |
 | OpenAI free-tier chat-completions | `gpt-5.5:free`, `gpt-5:free`, `gpt-4.1:free`, `gpt-4o:free`, `gpt-4o-mini:free`, `gpt-oss:free` |
-| Claude | `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
+| Claude | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
 | Gemini | `gemini-3.5-flash`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
 | Grok | `grok-4.5`, `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
 | DeepSeek | `deepseek-r1`, `deepseek-r1-0528`, `deepseek-v3`, `deepseek-v3-250324`, `deepseek-v3.2-exp`, `deepseek-v4-flash` |


### PR DESCRIPTION
## What
Add `claude-opus-5` to the Claude model table in the ai-chat skill (new flagship-tier Opus, listed after the fable-5 flagship). Discovery/docs only.

## 🤖 对抗评审

独立评审（Claude general-purpose subagent；Codex 本轮触发 usage limit 已回退）逐条 hunt，结论 **无计费/结构缺陷**，仅两条流程项：

- **[low] 16 个非中文 locale 的 `claudeOpus5Description` 为英文占位** — 这是 `/i18n-backfill` 的既定行为（从 `en` 播种、Nexior 禁止 `yarn translate`），与既有 backfill 一致。**接受，不改**。
- **[med] 跨仓部署顺序** — PS 的 `VISIBLE_MODELS` 若先于 Mongo 能力上线，`/v1/models` 会列出 opus-5 但调用 500。**修复=排序**：PB 计费规则 merge+sync → 插入 Mongo 能力 → 再 merge PS。计费关键路径不受影响。

已确认：5 个 service cost、2 个 api visible_models、`_chat_models.json`、4 个 openapi enum、`config/models.json`、worker VISIBLE_MODELS、Skills/APIs/MCP、Nexior(常量+对象+类型+分组+数组+i18n×18) 全部与 opus-4-8 对齐；计费为 opus-4-8 字节级克隆；`[1m]` 陷阱各处均用裸 id 规避；`pytest tests/api_cost` 963 passed。
