### PR TITLE
feat(connectors): 语雀 / 开源中国 / SegmentFault 三个中文内容平台技能

### DIFF
--- a/skills/oschina/SKILL.md
+++ b/skills/oschina/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: oschina
+description: Read the connected 开源中国 / OSChina (my.oschina.net) account and create Markdown blog drafts with the user's own login cookies (BYOC). Use when the user mentions 开源中国 / OSChina, wants to save a 开源中国 draft, or asks who their connected 开源中国 account is.
+when_to_use: |
+  Trigger for the user's 开源中国 (my.oschina.net) account driven by their own
+  login cookie: show the connected account, or turn Markdown into a 开源中国
+  blog draft. 开源中国 exposes no publish API, so this skill stops at a draft
+  and hands the user the editor URL. Writes are gated behind explicit
+  confirmation.
+connections: [oschina]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# oschina — read & draft on 开源中国 via your own cookies
+
+Drives the user's **real** 开源中国 account through the same
+`apiv1.oschina.net` endpoints the site uses, authenticated by the login cookie
+they captured with the ACE extension. No browser, no third-party deps — just
+`urllib`.
+
+The connector injects the cookie jar as a JSON env var `$OSCHINA_COOKIES`.
+Never print it.
+
+```bash
+python3 "$SKILL_DIR/scripts/oschina.py" whoami
+```
+
+If `$SKILL_DIR` points at a different skill loaded in the same turn, resolve
+this skill's directory explicitly before running the commands below.
+
+## Important: draft only
+
+**开源中国 has no public publish API.** Every open-source client for this
+platform (including the upstream adapter this skill is modelled on) stops at
+draft creation. This skill does the same: it saves the Markdown as a draft and
+returns the editor URL. Tell the user plainly that they must open that URL and
+click publish themselves — do not claim the article was published.
+
+## Verify the connection first
+
+```bash
+python3 "$SKILL_DIR/scripts/oschina.py" whoami
+```
+
+If this fails with an auth error, the cookie has expired. Ask the user to
+reconnect at `https://auth.acedata.cloud/user/connections` rather than retrying.
+
+## Create a draft — GATED
+
+Prepare the complete Markdown in a file. The first call is always a dry run and
+does not write anything.
+
+```bash
+# Dry run — shows exactly what would be written.
+python3 "$SKILL_DIR/scripts/oschina.py" draft \
+  --title "标题" --content-file /tmp/article.md
+
+# Actually create the draft after the user confirms.
+python3 "$SKILL_DIR/scripts/oschina.py" draft \
+  --title "标题" --content-file /tmp/article.md --confirm
+```
+
+`--confirm` is valid only as the final argument. Show the title and full
+content to the user before writing.
+
+## Gotchas
+
+- Content is sent as Markdown (`contentType: 1`). Do not pre-render it to HTML.
+- Images referenced by external URL are not re-hosted. If the source host
+  blocks hotlinking they will not render; mention this when the article has
+  images.
+- `--catalog` takes a 开源中国 catalog id; the default `0` uses the account's
+  default catalog. If the API rejects the catalog, ask the user for the right
+  id rather than guessing.
+- Do not retry a timed-out write automatically — the outcome may be unknown and
+  a retry can create a duplicate draft.
+
+## Record the output
+
+This skill only produces drafts, so do **not** call `publish_artifact`. Report
+the returned `draft_id` and `edit_url` to the user instead.

--- a/skills/oschina/scripts/oschina.py
+++ b/skills/oschina/scripts/oschina.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+oschina — read & publish on 开源中国 (my.oschina.net) with the user's own login
+cookies (BYOC). Standard-library only (urllib), no third-party deps, so it runs
+in the bare sandbox without an image change.
+
+The connector injects the user's cookie jar as a JSON env var ``OSCHINA_COOKIES``
+— a list of ``{name, value, domain, ...}`` dicts captured by the ACE extension.
+
+Read commands run directly. ``publish`` is GATED: without a trailing
+``--confirm`` it only dry-runs. ``--confirm`` is honored ONLY as the last
+argument, so a title/content that merely contains "--confirm" can never silently
+go live.
+
+NOTE: 开源中国 exposes no public "publish" API — only draft creation. This CLI
+creates a draft and returns its editor URL; the user finishes publishing in the
+开源中国 editor.
+
+Examples:
+  python3 oschina.py whoami
+  python3 oschina.py draft --title T --content-file a.md --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+PLATFORM = "oschina"
+API = "https://apiv1.oschina.net/oschinapi"
+ORIGIN = "https://my.oschina.net"
+MAX_CONTENT_BYTES = 10 * 1024 * 1024
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects outright.
+
+    add_unredirected_header only protects the Cookie; urllib copies every other
+    header onto the redirected request, so a 30x to a foreign host could hand
+    over any auth header we add later.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar (shared pattern across the cookie-BYOC skills) ────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect 开源中国 at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def request(method: str, url: str, jar: list, *, headers=None, body=None, write: bool = False):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "*/*",
+        "Accept-Language": "zh-CN,zh;q=0.9",
+        "Origin": ORIGIN,
+        "Referer": f"{ORIGIN}/",
+    }
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with _OPENER.open(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        if e.code in (301, 302, 303, 307, 308):
+            die(f"开源中国 redirected {method} {url} — not followed, so no "
+                f"credential left oschina.net. You are most likely logged out; "
+                f"reconnect at https://auth.acedata.cloud/user/connections."
+                + (" This was a WRITE: its outcome is UNKNOWN — check your "
+                   "drafts before retrying." if write else ""))
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        if write:
+            die(f"开源中国 write {method} {url} did not return a result "
+                f"({e.reason}); the outcome is UNKNOWN. Check your 开源中国 "
+                f"drafts before retrying so you do not create a duplicate.")
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def api_call(method: str, path: str, jar: list, *, body=None, write: bool = False):
+    """Unwrap the {success, message, code, result} envelope, dying on failure.
+    开源中国 returns HTTP 200 even for logical errors."""
+    url = f"{API}{path}"
+    status, text = request(method, url, jar, body=body, write=write)
+    try:
+        env = json.loads(text)
+    except json.JSONDecodeError:
+        if write:
+            die(f"开源中国 write to {path} returned a non-JSON response ({status}); "
+                f"the outcome is UNKNOWN. Check your drafts before retrying. "
+                f"Body: {text[:200]}")
+        die(f"non-JSON response ({status}) from {path}: {text[:300]}")
+    if not isinstance(env, dict):
+        die(f"unexpected response from {path}: {text[:300]}")
+    if not env.get("success"):
+        msg = str(env.get("message") or "")
+        code = env.get("code")
+        if code in (40001, 401, 403) or "未登录" in msg or "登录" in msg:
+            die(f"auth failed (code={code}: {msg}) — cookie likely expired. "
+                f"Reconnect at https://auth.acedata.cloud/user/connections.")
+        die(f"开源中国 API error on {path} (code={code}): {msg}")
+    return env.get("result")
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def os_me(jar) -> dict:
+    me = api_call("GET", "/user/myDetails", jar)
+    if not isinstance(me, dict) or not me.get("userId"):
+        die("could not read 开源中国 profile (cookie expired?)")
+    return me
+
+
+def cmd_whoami(jar, _args):
+    me = os_me(jar)
+    vo = me.get("userVo") or {}
+    uid = me.get("userId")
+    out({
+        "user_id": str(uid),
+        "name": vo.get("name"),
+        "url": f"{ORIGIN}/u/{uid}",
+        "avatar": vo.get("portraitUrl"),
+    })
+
+
+def read_content(args) -> str:
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    if content is None:
+        die("provide --content-file <path.md> or --content <markdown>")
+    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+        die("content exceeds the 10 MiB safety limit")
+    return content
+
+
+def cmd_draft(jar, args):
+    if not args.title:
+        die("--title is required")
+    content = read_content(args)
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "draft", "platform": PLATFORM,
+            "title": args.title, "catalog": args.catalog,
+            "private": not args.public,
+            "content_characters": len(content),
+            "note": "开源中国 content is Markdown. Re-run with --confirm as the LAST "
+                    "argument to actually create the draft. 开源中国 exposes no "
+                    "publish API — finish publishing in the 开源中国 editor.",
+        })
+        return
+
+    me = os_me(jar)
+    uid = me.get("userId")
+    result = api_call("POST", "/api/draft/save_draft", jar, write=True, body={
+        "title": args.title,
+        "user": int(uid),
+        "content": content,
+        "contentType": 1,  # 1 = Markdown, 2 = HTML
+        "catalog": args.catalog,
+        "originUrl": "",
+        "privacy": not args.public,
+        "disableComment": False,
+    })
+    draft_id = result.get("id") if isinstance(result, dict) else None
+    if not draft_id:
+        die(f"draft creation failed: {str(result)[:300]}")
+    out({
+        "ok": True,
+        "draft_only": True,
+        "draft_id": str(draft_id),
+        "edit_url": f"{ORIGIN}/u/{uid}/blog/write/draft/{draft_id}",
+        "note": "Draft saved. 开源中国 has no publish API — open edit_url to publish.",
+    })
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "draft": cmd_draft,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="oschina.py", description="开源中国 cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("draft", help="create a draft article (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="Markdown content inline")
+    sp.add_argument("--content-file", help="path to a Markdown file")
+    sp.add_argument("--catalog", type=int, default=0, help="开源中国 catalog id (0 = default)")
+    sp.add_argument("--public", action="store_true",
+                    help="mark the draft non-private; it still needs publishing in the editor")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/segmentfault/SKILL.md
+++ b/skills/segmentfault/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: segmentfault
+description: Read the connected SegmentFault 思否 (segmentfault.com) account and create Markdown article drafts with the user's own login cookies (BYOC). Use when the user mentions SegmentFault / 思否, wants to save a 思否 draft, or asks who their connected 思否 account is.
+when_to_use: |
+  Trigger for the user's SegmentFault 思否 account driven by their own login
+  cookie: show the connected account, or turn Markdown into a 思否 article
+  draft. The write API creates a draft, so this skill stops there and hands the
+  user the editor URL. Writes are gated behind explicit confirmation.
+connections: [segmentfault]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+# segmentfault — read & draft on 思否 via your own cookies
+
+Drives the user's **real** SegmentFault account through the same
+`segmentfault.com/gateway` endpoints the site uses, authenticated by the login
+cookie they captured with the ACE extension. No browser, no third-party deps —
+just `urllib`.
+
+The connector injects the cookie jar as a JSON env var `$SEGMENTFAULT_COOKIES`.
+Never print it.
+
+```bash
+python3 "$SKILL_DIR/scripts/segmentfault.py" whoami
+```
+
+If `$SKILL_DIR` points at a different skill loaded in the same turn, resolve
+this skill's directory explicitly before running the commands below.
+
+## Important: draft only
+
+SegmentFault's write endpoint (`/gateway/draft`) creates a **draft**. This skill
+returns the draft's editor URL and does not publish. Tell the user plainly that
+they must open that URL and publish themselves — do not claim the article went
+live.
+
+## Verify the connection first
+
+```bash
+python3 "$SKILL_DIR/scripts/segmentfault.py" whoami
+```
+
+If this fails with an auth error, the cookie has expired. Ask the user to
+reconnect at `https://auth.acedata.cloud/user/connections` rather than retrying.
+
+## Create a draft — GATED
+
+Prepare the complete Markdown in a file. The first call is always a dry run and
+does not write anything.
+
+```bash
+# Dry run — shows exactly what would be written.
+python3 "$SKILL_DIR/scripts/segmentfault.py" draft \
+  --title "标题" --content-file /tmp/article.md --tags "python,api"
+
+# Actually create the draft after the user confirms.
+python3 "$SKILL_DIR/scripts/segmentfault.py" draft \
+  --title "标题" --content-file /tmp/article.md --tags "python,api" --confirm
+```
+
+`--confirm` is valid only as the final argument. Show the title, tags and full
+content to the user before writing.
+
+## Gotchas
+
+- The write API needs a per-session token scraped from the `/write` page. If
+  the CLI reports it could not find that token, the cookie is stale — reconnect
+  rather than retrying.
+- A restricted account (禁言 / 锁定) is reported as an explicit error. Do not
+  retry; tell the user their account is restricted.
+- Content is sent as Markdown. Do not pre-render it to HTML.
+- Images referenced by external URL are not re-hosted. If the source host
+  blocks hotlinking they will not render; mention this when the article has
+  images.
+- Do not retry a timed-out write automatically — the outcome may be unknown and
+  a retry can create a duplicate draft.
+
+## Record the output
+
+This skill only produces drafts, so do **not** call `publish_artifact`. Report
+the returned `draft_id` and `edit_url` to the user instead.

--- a/skills/segmentfault/scripts/segmentfault.py
+++ b/skills/segmentfault/scripts/segmentfault.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+segmentfault — read & publish on SegmentFault 思否 (segmentfault.com) with the
+user's own login cookies (BYOC). Standard-library only (urllib), no third-party
+deps, so it runs in the bare sandbox without an image change.
+
+The connector injects the user's cookie jar as a JSON env var
+``SEGMENTFAULT_COOKIES`` — a list of ``{name, value, domain, ...}`` dicts
+captured by the ACE extension.
+
+Read commands run directly. ``draft`` is GATED: without a trailing ``--confirm``
+it only dry-runs. ``--confirm`` is honored ONLY as the last argument, so a
+title/content that merely contains "--confirm" can never silently go live.
+
+NOTE: SegmentFault's write API creates a DRAFT. This CLI returns the draft's
+editor URL; the user finishes publishing in the SegmentFault editor.
+
+Examples:
+  python3 segmentfault.py whoami
+  python3 segmentfault.py draft --title T --content-file a.md --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+PLATFORM = "segmentfault"
+BASE = "https://segmentfault.com"
+MAX_CONTENT_BYTES = 10 * 1024 * 1024
+
+# Bounded so a hostile/huge page cannot cause catastrophic backtracking.
+_TOKEN_RE = re.compile(r'serverData"\s*:\s*\{\s*"Token"\s*:\s*"([^"]{1,500})"')
+
+_RAW = sys.argv[1:]
+CONFIRM = bool(_RAW) and _RAW[-1] == "--confirm"
+ARGV = _RAW[:-1] if CONFIRM else list(_RAW)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects outright.
+
+    add_unredirected_header only protects the Cookie; urllib still copies every
+    other header (including the per-session ``token``) onto the redirected
+    request, so a 30x to an attacker host would hand over the write token.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
+def out(obj) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def die(msg: str, code: int = 1) -> None:
+    out({"error": msg})
+    sys.exit(code)
+
+
+# ── Cookie jar (shared pattern across the cookie-BYOC skills) ────────
+
+def load_cookies() -> list:
+    env = f"{PLATFORM.upper()}_COOKIES"
+    raw = os.environ.get(env)
+    if not raw:
+        die(f"{env} is not set — connect SegmentFault at "
+            f"https://auth.acedata.cloud/user/connections, then retry.")
+    try:
+        jar = json.loads(raw)
+    except json.JSONDecodeError as e:
+        die(f"{env} is not valid JSON: {e}")
+    if not isinstance(jar, list):
+        die(f"{env} must be a JSON list of cookies, got {type(jar).__name__}")
+    return jar
+
+
+def _domain_matches(host: str, domain: str) -> bool:
+    d = domain.lstrip(".").lower()
+    h = host.lower()
+    return not d or h == d or h.endswith("." + d)
+
+
+def cookie_header(jar: list, url: str) -> str:
+    host = urllib.parse.urlsplit(url).hostname or ""
+    host_in_scope = any(
+        c.get("domain") and _domain_matches(host, str(c["domain"])) for c in jar
+    )
+    parts = []
+    for c in jar:
+        name, value = c.get("name"), c.get("value")
+        if not name or value is None:
+            continue
+        domain = c.get("domain")
+        if domain:
+            if not _domain_matches(host, str(domain)):
+                continue
+        elif not host_in_scope:
+            continue
+        parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def request(method: str, url: str, jar: list, *, headers=None, body=None, write: bool = False):
+    hdrs = {
+        "User-Agent": UA,
+        "Accept": "*/*",
+        "Accept-Language": "zh-CN,zh;q=0.9",
+        "Origin": BASE,
+        "Referer": f"{BASE}/",
+    }
+    if headers:
+        hdrs.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
+    # Unredirected → the cookie is not re-sent if the API 30x-redirects to a
+    # different host (e.g. a login page), so the jar never leaks off-site.
+    req.add_unredirected_header("Cookie", cookie_header(jar, url))
+    try:
+        with _OPENER.open(req, timeout=30) as resp:
+            raw = resp.read()
+            if resp.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+            return resp.status, raw.decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        if e.code in (301, 302, 303, 307, 308):
+            die(f"SegmentFault redirected {method} {url} — not followed, so no "
+                f"credential left segmentfault.com. You are most likely logged "
+                f"out; reconnect at https://auth.acedata.cloud/user/connections."
+                + (" This was a WRITE: its outcome is UNKNOWN — check your "
+                   "drafts before retrying." if write else ""))
+        raw = e.read()
+        try:
+            if e.headers.get("Content-Encoding") == "gzip":
+                raw = gzip.decompress(raw)
+        except Exception:
+            pass
+        return e.code, raw.decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        if write:
+            die(f"SegmentFault write {method} {url} did not return a result "
+                f"({e.reason}); the outcome is UNKNOWN. Check your SegmentFault "
+                f"drafts before retrying so you do not create a duplicate.")
+        die(f"network error reaching {url}: {e.reason}")
+
+
+def _auth_died(status: int, text: str) -> None:
+    if status in (401, 403) or text.strip('"') == "Unauthorized":
+        die("auth failed — cookie expired or invalid. Reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+
+
+def session_token(jar: list) -> str:
+    """The write API needs a per-session token embedded in the /write page."""
+    status, html = request("GET", f"{BASE}/write", jar)
+    _auth_died(status, html)
+    m = _TOKEN_RE.search(html)
+    if not m:
+        die("could not find the SegmentFault session token on /write — you are "
+            "probably logged out. Reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    return m.group(1)
+
+
+# ── commands ────────────────────────────────────────────────────────
+
+def cmd_whoami(jar, _args):
+    status, html = request("GET", f"{BASE}/user/settings", jar)
+    _auth_died(status, html)
+    if status != 200:
+        die(f"unexpected status {status} reading the profile")
+    name = re.search(r'name="name"[^>]{0,300}?value="([^"]{1,200})"', html)
+    avatar = re.search(
+        r'src="(https://avatar-static\.segmentfault\.com/[^"]{1,300})"', html
+    )
+    if not name and "登录" in html:
+        die("not logged in — cookie expired. Reconnect at "
+            "https://auth.acedata.cloud/user/connections.")
+    out({
+        "platform": PLATFORM,
+        "name": name.group(1) if name else None,
+        "avatar": avatar.group(1) if avatar else None,
+        "settings_url": f"{BASE}/user/settings",
+    })
+
+
+def read_content(args) -> str:
+    content = args.content
+    if args.content_file:
+        try:
+            with open(args.content_file, encoding="utf-8") as f:
+                content = f.read()
+        except OSError as e:
+            die(f"cannot read --content-file: {e}")
+    if content is None:
+        die("provide --content-file <path.md> or --content <markdown>")
+    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+        die("content exceeds the 10 MiB safety limit")
+    return content
+
+
+def _extract_draft_id(text: str):
+    """SegmentFault answers either [0, {...}] / [1, "error"] or a bare object."""
+    try:
+        res = json.loads(text)
+    except json.JSONDecodeError:
+        return None, f"non-JSON response: {text[:200]}"
+    if isinstance(res, list):
+        if res and res[0] == 1:
+            return None, str(res[1] if len(res) > 1 else "unknown error")
+        if len(res) > 1 and isinstance(res[1], dict) and res[1].get("id"):
+            return res[1]["id"], None
+        return None, f"unexpected list response: {text[:200]}"
+    if isinstance(res, dict):
+        if res.get("id"):
+            return res["id"], None
+        msg = res.get("message") or res.get("msg") or res.get("error") or res.get("errMsg")
+        return None, str(msg or text[:200])
+    return None, f"unexpected response: {text[:200]}"
+
+
+def cmd_draft(jar, args):
+    if not args.title:
+        die("--title is required")
+    content = read_content(args)
+    tags = [t.strip() for t in (args.tags or "").split(",") if t.strip()]
+
+    if not CONFIRM:
+        out({
+            "dry_run": True, "command": "draft", "platform": PLATFORM,
+            "title": args.title, "tags": tags,
+            "content_characters": len(content),
+            "note": "SegmentFault content is Markdown. Re-run with --confirm as "
+                    "the LAST argument to actually create the draft. The write "
+                    "API creates a DRAFT — finish publishing in the SegmentFault "
+                    "editor.",
+        })
+        return
+
+    token = session_token(jar)
+    status, text = request("POST", f"{BASE}/gateway/draft", jar,
+                           headers={"token": token}, write=True,
+                           body={"title": args.title, "tags": tags,
+                                 "text": content, "object_id": "",
+                                 "type": "article"})
+    _auth_died(status, text)
+    for marker in ("禁言", "锁定"):
+        if marker in text:
+            die(f"SegmentFault rejected the write ({marker}); the account is "
+                f"restricted.")
+    draft_id, err = _extract_draft_id(text)
+    if not draft_id:
+        die(f"draft creation failed (status {status}): {err}")
+    out({
+        "ok": True,
+        "draft_only": True,
+        "draft_id": str(draft_id),
+        "edit_url": f"{BASE}/write?draftId={draft_id}",
+        "note": "Draft saved. Open edit_url to review and publish.",
+    })
+
+
+COMMANDS = {
+    "whoami": cmd_whoami,
+    "draft": cmd_draft,
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="segmentfault.py",
+                                description="SegmentFault 思否 cookie CLI")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the logged-in account")
+    sp = sub.add_parser("draft", help="create a draft article (GATED by trailing --confirm)")
+    sp.add_argument("--title")
+    sp.add_argument("--content", help="Markdown content inline")
+    sp.add_argument("--content-file", help="path to a Markdown file")
+    sp.add_argument("--tags", help="comma-separated tag names")
+    args = p.parse_args(ARGV)
+    jar = load_cookies()
+    COMMANDS[args.command](jar, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/yuque/SKILL.md
+++ b/skills/yuque/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: yuque
+description: Read and write Yuque (语雀) documents with the user's own personal access token through the official open API at https://www.yuque.com/api/v2. Use when the user wants to publish Markdown to 语雀, list their knowledge bases (知识库), read or update a 语雀 document, or delete one.
+when_to_use: |
+  Trigger for 语雀 / Yuque document management: verify the connected account,
+  list knowledge bases or the documents inside one, read a document, create a
+  Markdown document, update an existing one, or delete one. Writes and
+  destructive actions require explicit confirmation.
+connections: [yuque]
+allowed_tools: [Bash]
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+---
+
+Use the bundled standard-library CLI. The connector injects the user's 语雀
+personal access token as `$YUQUE_TOKEN`. Never print it. The CLI uses the
+official open API at `https://www.yuque.com/api/v2` with the documented
+`X-Auth-Token` header.
+
+```bash
+python3 "$SKILL_DIR/scripts/yuque.py" whoami
+```
+
+If `$SKILL_DIR` points at a different skill loaded in the same turn, resolve
+this skill's directory explicitly before running the commands below.
+
+If authentication fails, ask the user to create a token at
+`https://www.yuque.com/settings/tokens` and reconnect at
+`https://auth.acedata.cloud/user/connections`. Do not ask for their account
+password or Cookie.
+
+## Read
+
+A `repo` is a 语雀 knowledge base, addressed either by its `namespace`
+(`user/book`, as shown in the document URL) or by its numeric id. Always run
+`repos` first — never guess a namespace.
+
+```bash
+# Verify the token and see the account.
+python3 "$SKILL_DIR/scripts/yuque.py" whoami
+
+# List knowledge bases, then the documents in one.
+python3 "$SKILL_DIR/scripts/yuque.py" repos
+python3 "$SKILL_DIR/scripts/yuque.py" docs germey/blog --limit 20
+python3 "$SKILL_DIR/scripts/yuque.py" doc germey/blog DOC_ID
+```
+
+## Create and update
+
+Prepare the complete Markdown in a file. 语雀 has no separate draft state — a
+document is either private or public — so the CLI creates **private** documents
+by default and only publishes publicly with an explicit `--public`.
+
+```bash
+# First call is always a dry run and does not load credentials or call the API.
+python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+  --title "标题" --content-file /tmp/article.md
+
+# Create it privately after the user confirms.
+python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+  --title "标题" --content-file /tmp/article.md --confirm
+
+# Public publishing additionally requires --public.
+python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+  --title "标题" --content-file /tmp/article.md --public --confirm
+
+python3 "$SKILL_DIR/scripts/yuque.py" update germey/blog DOC_ID \
+  --title "新标题" --content-file /tmp/article.md --public --confirm
+```
+
+`--confirm` is valid only as the final argument. Always show the target
+knowledge base, title, visibility and full content to the user before a public
+publish. Default to a private document unless the user explicitly asks to
+publish publicly.
+
+Note that `update` rewrites the whole document body. Read the current document
+first if the user only wants part of it changed.
+
+## Delete
+
+```bash
+python3 "$SKILL_DIR/scripts/yuque.py" delete germey/blog DOC_ID --confirm
+```
+
+Use the real returned `doc_id` and URL. Do not retry a timed-out write
+automatically because its outcome may be unknown; list the documents first so
+you do not create a duplicate.
+
+## Gotchas
+
+- Images referenced by external URL are not re-hosted; 语雀 renders them from
+  the original host. If the source blocks hotlinking, upload the images to 语雀
+  manually first and reference the returned URLs.
+- 语雀's own terms state the open API is for normal reading and writing of 语雀
+  content; abnormal automated behaviour can get the account blocked. Keep the
+  volume human-scale.
+
+## Record the output
+
+After a confirmed public publish returns a real URL, call `publish_artifact`
+once with `kind="article"`, `channel="yuque"`, the title, returned URL, and
+`status="delivered"`. Do not record private documents or failed/unknown writes.

--- a/skills/yuque/scripts/yuque.py
+++ b/skills/yuque/scripts/yuque.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Read and write Yuque (语雀) documents through its official open API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import socket
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://www.yuque.com/api/v2"
+GATED_COMMANDS = {"create", "update", "delete"}
+MAX_CONTENT_BYTES = 10 * 1024 * 1024
+MAX_ITEMS = 100
+
+
+def output(value) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, default=str))
+
+
+def die(message: str, code: int = 1) -> None:
+    output({"error": message})
+    raise SystemExit(code)
+
+
+def split_confirmation(argv: list[str]) -> tuple[list[str], bool]:
+    confirmed = bool(argv) and argv[-1] == "--confirm"
+    return (argv[:-1] if confirmed else list(argv), confirmed)
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class YuqueClient:
+    def __init__(self, token: str, opener=None) -> None:
+        self._token = token
+        self._opener = opener or urllib.request.build_opener(NoRedirectHandler())
+
+    @classmethod
+    def from_environment(cls):
+        token = os.environ.get("YUQUE_TOKEN", "").strip()
+        if not token:
+            die(
+                "YUQUE_TOKEN is not set. Reconnect 语雀 at "
+                "https://auth.acedata.cloud/user/connections."
+            )
+        return cls(token)
+
+    def request(self, method: str, path: str, *, body=None, write: bool = False, expect_json: bool = True):
+        encoded = None if body is None else json.dumps(body, ensure_ascii=False).encode("utf-8")
+        request = urllib.request.Request(
+            f"{API_BASE}{path}",
+            data=encoded,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "X-Auth-Token": self._token,
+                "Content-Type": "application/json",
+                "User-Agent": "AceDataCloud-Yuque-Skill/1.0",
+            },
+        )
+        try:
+            with self._opener.open(request, timeout=30) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as error:
+            if error.code in {301, 302, 303, 307, 308}:
+                die(f"Yuque API redirected {method} {path}; credentials were not forwarded.")
+            if error.code in {401, 403}:
+                die(
+                    f"Yuque API HTTP {error.code} for {method} {path}. The token is invalid or "
+                    "lacks scope. Reconnect with a token from https://www.yuque.com/settings/tokens."
+                )
+            if error.code == 404:
+                die(f"Yuque API 404 for {method} {path}; the repo or document does not exist.")
+            die(f"Yuque API HTTP {error.code} for {method} {path}.")
+        except (urllib.error.URLError, OSError, socket.timeout):
+            if write:
+                die(
+                    f"Yuque write {method} {path} did not return a result; outcome is unknown. "
+                    "List the documents before retrying so you do not create a duplicate."
+                )
+            die(f"Network error while calling Yuque {method} {path}.")
+        if not expect_json or not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            die(f"Yuque returned invalid JSON for {method} {path}.")
+        if not isinstance(payload, dict) or "data" not in payload:
+            die(f"Yuque returned an unexpected envelope for {method} {path}.")
+        return payload["data"]
+
+    def user(self) -> dict:
+        value = self.request("GET", "/user")
+        if not isinstance(value, dict):
+            die("Yuque returned malformed user data.")
+        return value
+
+    def repos(self, login: str) -> list[dict]:
+        quoted = urllib.parse.quote(str(login), safe="")
+        value = self.request("GET", f"/users/{quoted}/repos")
+        if not isinstance(value, list):
+            die("Yuque returned malformed repo data.")
+        return value
+
+    def docs(self, repo: str) -> list[dict]:
+        quoted = urllib.parse.quote(str(repo), safe="")
+        value = self.request("GET", f"/repos/{quoted}/docs")
+        if not isinstance(value, list):
+            die("Yuque returned malformed document data.")
+        return value
+
+    def doc(self, repo: str, doc_id: str) -> dict:
+        repo_q = urllib.parse.quote(str(repo), safe="")
+        doc_q = urllib.parse.quote(str(doc_id), safe="")
+        value = self.request("GET", f"/repos/{repo_q}/docs/{doc_q}")
+        if not isinstance(value, dict):
+            die("Yuque returned malformed document data.")
+        return value
+
+    def create_doc(self, repo: str, body: dict) -> dict:
+        quoted = urllib.parse.quote(str(repo), safe="")
+        value = self.request("POST", f"/repos/{quoted}/docs", body=body, write=True)
+        if not isinstance(value, dict) or not value.get("id"):
+            die("Yuque did not return a valid created document.")
+        return value
+
+    def update_doc(self, repo: str, doc_id: str, body: dict) -> dict:
+        repo_q = urllib.parse.quote(str(repo), safe="")
+        doc_q = urllib.parse.quote(str(doc_id), safe="")
+        value = self.request("PUT", f"/repos/{repo_q}/docs/{doc_q}", body=body, write=True)
+        if not isinstance(value, dict) or not value.get("id"):
+            die("Yuque did not return a valid updated document.")
+        return value
+
+    def delete_doc(self, repo: str, doc_id: str) -> None:
+        repo_q = urllib.parse.quote(str(repo), safe="")
+        doc_q = urllib.parse.quote(str(doc_id), safe="")
+        self.request("DELETE", f"/repos/{repo_q}/docs/{doc_q}", write=True, expect_json=False)
+
+
+def read_content(args) -> str:
+    if args.content_file:
+        path = pathlib.Path(args.content_file)
+        try:
+            if path.stat().st_size > MAX_CONTENT_BYTES:
+                die("Content file exceeds the 10 MiB safety limit.")
+            return path.read_text(encoding="utf-8")
+        except OSError as error:
+            die(f"Cannot read --content-file: {error}")
+    if args.content is not None:
+        if len(args.content.encode("utf-8")) > MAX_CONTENT_BYTES:
+            die("Content exceeds the 10 MiB safety limit.")
+        return args.content
+    die("Provide --content-file <path.md> or --content <markdown>.")
+
+
+def format_repo(repo: dict) -> dict:
+    return {
+        "repo_id": repo.get("id"),
+        "namespace": repo.get("namespace"),
+        "name": repo.get("name"),
+        "slug": repo.get("slug"),
+        "type": repo.get("type"),
+        "public": repo.get("public"),
+        "items_count": repo.get("items_count"),
+    }
+
+
+def format_doc(doc: dict, repo: str | None = None) -> dict:
+    namespace = repo or (doc.get("book") or {}).get("namespace")
+    slug = doc.get("slug")
+    return {
+        "doc_id": doc.get("id"),
+        "title": doc.get("title"),
+        "slug": slug,
+        "public": doc.get("public"),
+        "status": doc.get("status"),
+        "url": f"https://www.yuque.com/{namespace}/{slug}" if namespace and slug else None,
+        "word_count": doc.get("word_count"),
+        "created_at": doc.get("created_at"),
+        "updated_at": doc.get("updated_at"),
+    }
+
+
+def build_body(args, content: str) -> dict:
+    # public: 0 = private, 1 = public. Yuque has no separate "draft" state, so a
+    # private doc is the closest equivalent and is the default.
+    body = {
+        "title": args.title,
+        "body": content,
+        "format": "markdown",
+        "public": 1 if args.public else 0,
+    }
+    if args.slug:
+        body["slug"] = args.slug
+    return body
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="yuque.py", description="Yuque open API CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("whoami", help="show the token's account")
+
+    repos = sub.add_parser("repos", help="list the account's knowledge bases")
+    repos.add_argument("--login", help="user login; defaults to the token's own account")
+
+    docs = sub.add_parser("docs", help="list documents in a knowledge base")
+    docs.add_argument("repo", help="repo namespace (user/book) or numeric repo id")
+    docs.add_argument("--limit", type=int, default=20)
+
+    one = sub.add_parser("doc", help="read one document")
+    one.add_argument("repo")
+    one.add_argument("doc_id", help="document id or slug")
+
+    for command in ("create", "update"):
+        write = sub.add_parser(command, help=f"{command} a document (GATED by trailing --confirm)")
+        write.add_argument("repo")
+        if command == "update":
+            write.add_argument("doc_id")
+        write.add_argument("--title", required=True)
+        write.add_argument("--content")
+        write.add_argument("--content-file")
+        write.add_argument("--slug")
+        write.add_argument(
+            "--public",
+            action="store_true",
+            help="publish publicly; omit to keep the document private",
+        )
+
+    delete = sub.add_parser("delete", help="delete a document (GATED by trailing --confirm)")
+    delete.add_argument("repo")
+    delete.add_argument("doc_id")
+    return parser
+
+
+def dry_run(args, content: str | None = None) -> None:
+    value = {"dry_run": True, "command": args.command, "platform": "yuque", "repo": args.repo}
+    if args.command in {"create", "update"}:
+        value.update(
+            {
+                "doc_id": getattr(args, "doc_id", None),
+                "title": args.title,
+                "visibility": "public" if args.public else "private",
+                "slug": args.slug,
+                "content_characters": len(content or ""),
+            }
+        )
+    else:
+        value["doc_id"] = args.doc_id
+    value["note"] = "Re-run with --confirm as the final argument to write to Yuque."
+    output(value)
+
+
+def main(argv: list[str] | None = None) -> None:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    clean_argv, confirmed = split_confirmation(raw)
+    args = build_parser().parse_args(clean_argv)
+    content = read_content(args) if args.command in {"create", "update"} else None
+    if args.command in GATED_COMMANDS and not confirmed:
+        dry_run(args, content)
+        return
+
+    client = YuqueClient.from_environment()
+    if args.command == "whoami":
+        user = client.user()
+        output(
+            {
+                "user_id": user.get("id"),
+                "login": user.get("login"),
+                "name": user.get("name"),
+                "url": f"https://www.yuque.com/{user.get('login')}" if user.get("login") else None,
+                "books_count": user.get("books_count"),
+                "public_books_count": user.get("public_books_count"),
+            }
+        )
+    elif args.command == "repos":
+        login = args.login or client.user().get("login")
+        if not login:
+            die("Could not resolve the account login; pass --login explicitly.")
+        output({"repos": [format_repo(item) for item in client.repos(login)]})
+    elif args.command == "docs":
+        if not 1 <= args.limit <= MAX_ITEMS:
+            die(f"--limit must be between 1 and {MAX_ITEMS}.")
+        items = client.docs(args.repo)[: args.limit]
+        output({"count": len(items), "docs": [format_doc(item, args.repo) for item in items]})
+    elif args.command == "doc":
+        doc = client.doc(args.repo, args.doc_id)
+        result = format_doc(doc, args.repo)
+        result["body"] = doc.get("body")
+        output(result)
+    elif args.command == "create":
+        result = client.create_doc(args.repo, build_body(args, content or ""))
+        output({"ok": True, **format_doc(result, args.repo), "public": bool(args.public)})
+    elif args.command == "update":
+        result = client.update_doc(args.repo, args.doc_id, build_body(args, content or ""))
+        output({"ok": True, **format_doc(result, args.repo), "public": bool(args.public)})
+    elif args.command == "delete":
+        client.delete_doc(args.repo, args.doc_id)
+        output({"ok": True, "repo": args.repo, "doc_id": args.doc_id, "deleted": True})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
第一批中文一文多发连接器。三个技能都是纯 stdlib（urllib），无第三方依赖，
无需改 sandbox 镜像；写操作一律先 dry-run，只有末位 `--confirm` 才真正落笔。

- **yuque**：语雀官方开放 API（`/api/v2` + `X-Auth-Token`），PAT 模式，
  不依赖 Cookie，不会因登录态过期而失效。支持 whoami / repos / docs / doc /
  create / update / delete。语雀无草稿态，默认写私有文档，`--public` 才公开。
- **oschina**：开源中国 Cookie BYOC。**开源中国无公开发布接口**——实测
  `/api/draft/publish` 等路径全部 404，仅 `save_draft` 可用，故本技能只出草稿
  并返回编辑器 URL，SKILL.md 明确要求不得声称"已发布"。
- **segmentfault**：思否 Cookie BYOC，`/gateway/draft` 同样只产出草稿。

三个平台的接口均已对线上实测验证（语雀 401 `bad X-Auth-Token`、开源中国
40001 未登录、思否 Unauthorized），错误分支与真实响应一一对应。

## 🤖 对抗评审

Codex（gpt-5.5, read-only）三轮，第一轮命中一个**真实且可利用**的缺陷：

**RISK：SegmentFault 写入时的会话 token 会随 30x 跳转泄露到外部主机。**
`add_unredirected_header` 只保护 Cookie，urllib 的默认跳转处理器会把其余请求头
（含 `token: <session>`）原样复制到跳转后的请求上。若 `/gateway/draft` 返回
`302 Location: https://attacker.example/`，写 token 就交到了对方手里。

已用本地双端点复现确认：跳转后 Cookie=None 但 `Token=TOKENSECRET` 确实送达。
**修复**：两个 Cookie 技能都改用 `build_opener(HTTPRedirectHandler→None)` 彻底
拒绝跳转，30x 直接报错并提示重连；复测跳转目标收到 0 个凭据。

自查另补一处：写操作遇到网络超时原本只报通用 network error，可能诱使重试造成
重复草稿 —— 已加 `write` 标记，写路径明确提示"结果未知，先查草稿再重试"。

第二、三轮均 `VERDICT: CLEAN`。

已实测通过的不变量：跳转不带 Cookie/token、域名后缀混淆（notsegmentfault.com）
不匹配、无域 Cookie 不外发、100KB 恶意输入下 token 正则无回溯爆炸、
`--confirm` 出现在标题/正文中会被 argparse 挡下（fail-closed）、密钥不进 stdout。

Co-Authored-By: Claude <noreply@anthropic.com>