### PR TITLE
fix(reddit): default search to relevance sort

### DIFF
--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -65,9 +65,14 @@ R="${SKILL_DIR:-}/scripts/reddit.py"; [ -f "$R" ] || R=$(find /tmp -maxdepth 8 -
 [ -f "$R" ] || { echo "reddit script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 
 python3 "$R" search --query "suno api" --time week --limit 10
-python3 "$R" search --query "image generation api" --subreddit SideProject --sort new
+python3 "$R" search --query "image generation api" --subreddit SideProject
 python3 "$R" subreddit-info --subreddit SideProject
 ```
+
+`--sort` defaults to `relevance`. **Reddit's `new` sort ignores keyword relevance**
+— it returns recent posts that often do not contain the query terms at all. Use
+`--sort new` only to scan a specific subreddit's recent activity, never to find
+threads by keyword.
 
 ## Reply to a thread — GATED
 

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -474,7 +474,7 @@ class RedditClient:
         return {"ok": True, "posted": True, "id": post.get("id"), "name": post.get("name"), "url": post_url}
 
 
-    def search(self, *, query: str, subreddit: str = "", sort: str = "new", limit: int = 10, time_filter: str = "week") -> list[dict]:
+    def search(self, *, query: str, subreddit: str = "", sort: str = "relevance", limit: int = 10, time_filter: str = "month") -> list[dict]:
         suffix = ".json" if self.mode == "cookie" else ""
         path = f"/r/{subreddit}/search{suffix}" if subreddit else f"/search{suffix}"
         params = {"q": query, "sort": sort, "limit": limit, "t": time_filter, "raw_json": 1, "type": "link"}
@@ -677,8 +677,8 @@ def build_parser() -> argparse.ArgumentParser:
     search = commands.add_parser("search", help="search public posts to find threads worth replying to")
     search.add_argument("--query", "-q", required=True)
     search.add_argument("--subreddit", "-r", default="")
-    search.add_argument("--sort", choices=["new", "relevance", "top", "comments"], default="new")
-    search.add_argument("--time", dest="time_filter", choices=["hour", "day", "week", "month", "year", "all"], default="week")
+    search.add_argument("--sort", choices=["relevance", "new", "top", "comments"], default="relevance")
+    search.add_argument("--time", dest="time_filter", choices=["hour", "day", "week", "month", "year", "all"], default="month")
     search.add_argument("--limit", type=positive_limit, default=10)
 
     about = commands.add_parser("subreddit-info", help="read a subreddit's rules and posting requirements")

--- a/skills/reddit/tests/test_reddit.py
+++ b/skills/reddit/tests/test_reddit.py
@@ -512,6 +512,20 @@ class RedditSkillTests(unittest.TestCase):
         self.assertEqual("https://www.reddit.com/r/SunoAI/comments/p1/looking/", formatted["url"])
         self.assertEqual(500, len(formatted["selftext_excerpt"]))
 
+    def test_search_defaults_to_relevance_because_new_ignores_keywords(self):
+        """Reddit's `new` sort returns recent posts that need not match the query."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        with patch.object(client, "request", return_value={"data": {"children": []}}) as request:
+            client.search(query="suno api")
+        self.assertEqual("relevance", request.call_args.kwargs["query"]["sort"])
+
+        stream = io.StringIO()
+        with patch.dict(os.environ, {"REDDIT_COOKIES": COOKIE_JAR}, clear=True), patch.object(
+            reddit.RedditClient, "search", return_value=[]
+        ) as search, redirect_stdout(stream):
+            reddit.main(["search", "--query", "suno api"])
+        self.assertEqual("relevance", search.call_args.kwargs["sort"])
+
     def test_search_is_a_read_and_rejects_malformed_shape(self):
         client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
         stream = io.StringIO()


### PR DESCRIPTION
## 问题

上一个 PR（#718）引入的 `search` 命令把 `--sort` 默认设成了 `new`。**线上实测发现这让 search 基本不可用。**

同一个 query（`suno api`），两种 sort 的实测对比：

| `--sort new --time month` | `--sort relevance --time year` |
|---|---|
| Moderation is back (sorry for the hiatus) — r/newretrowave | AI Music Showcase - Ep.58: **Suno API** — r/aimusicalliance |
| Built and shipped my first iPhone game — r/SideProject | Open **suno** alternative — r/StableDiffusion |
| I shipped my first iPhone game — r/ClaudeCode | Nano Banana **API**, Midjourney **API**, **Suno API** — r/SaaS |
| Wifey in a Raid Inspired Fight Scene — r/generativeAI | Is there a **Suno** Playlist **API**? — r/SunoAI |
| Wifey in a Raid Inspired Fight Scene — r/Seedance_AI | A radio station using the **Suno API** — r/SunoAI |
| **0/5 标题含关键词** | **5/5 标题含关键词** |

Reddit 的 `new` 排序**不做关键词相关性过滤** —— 它返回的是近期帖子，跟你搜什么基本无关。而 search 命令的用途正是「按关键词找到值得回复的帖子」，默认 `new` 直接让这个用途失效（真正相关的 "Is there a Suno Playlist API?" 反而搜不到）。

## 改动

- `--sort` 默认 `new` → `relevance`（choices 顺序也调整，relevance 排首位）
- `--time` 默认 `week` → `month`（week 窗口太窄，配合 relevance 才有足够样本）
- CLI parser 默认值与 `search()` 方法签名默认值同步修改，保持一致
- SKILL.md 增加说明：`new` 忽略关键词相关性，只应用于扫某个 sub 的近期动态，不要用来按关键词找帖

## 测试

`28 → 29`，新增 1 个测试同时钉住两层默认值（方法层 + CLI 层），避免只改一处造成不一致：

```
python3 -m pytest skills/reddit/tests/test_reddit.py -q
29 passed
```

## 验证方式

线上真实环境（api.acedata.cloud aichat2 沙箱 + 已连接的 Reddit cookie 账号）实跑 search 对比两种 sort，非 mock 推断。

## 🤖 对抗评审

评审方：**Codex**（`codex exec --sandbox read-only`，跨模型）。

针对本次改动复核了 4 点：CLI 默认值与方法签名默认值是否一致、新增测试是否真正钉住行为（而非空断言）、是否影响其他命令、SKILL.md 说明是否准确。

前序 PR #718 的两轮评审已收敛（详见该 PR）：
- Round 1：评论写入失败复用发帖文案，会误导人重试造成重复评论 → 已修 + 回归测试
- Round 2：`t2_`/`t5_` 等不可评论类型未被本地拦截 → 正则收紧为 `^t[13]_`
