### PR TITLE
fix(google-ads): pin API version to v25 (v18 is sunset)

### DIFF
--- a/skills/google-ads/SKILL.md
+++ b/skills/google-ads/SKILL.md
@@ -5,8 +5,8 @@ when_to_use: |
   Trigger when the user wants Google Ads reporting — list accessible
   customers, campaign / ad-group / keyword performance, spend and
   conversions. Read via GAQL. Needs the OAuth token PLUS a platform
-  developer token and a login-customer-id; if those env vars are
-  absent the connector isn't fully provisioned yet — tell the user.
+  developer token; if the developer token is absent the connector
+  isn't fully provisioned yet — tell the user.
 connections: [google/ads]
 allowed_tools: [Bash]
 license: Apache-2.0
@@ -15,26 +15,31 @@ metadata:
   version: "1.0"
 ---
 
-Query the **Google Ads API** via `curl + jq`. Three credentials are needed:
+Query the **Google Ads API** via `curl + jq`. Two credentials plus one context
+header:
 
 - `$GOOGLE_ADS_TOKEN` — the user's OAuth bearer (`adwords` scope) →
   `Authorization: Bearer $GOOGLE_ADS_TOKEN`
 - `$GOOGLE_ADS_DEVELOPER_TOKEN` — the platform's developer token (injected
   server-side) → header `developer-token: $GOOGLE_ADS_DEVELOPER_TOKEN`
-- `login-customer-id` — the manager (MCC) id under which calls are made; use the
-  target customer id, or `$GOOGLE_ADS_LOGIN_CUSTOMER_ID` if set (digits only, no
-  dashes).
+- `login-customer-id` — **only for manager (MCC) scoped calls**: the manager id
+  the request runs under, or `$GOOGLE_ADS_LOGIN_CUSTOMER_ID` if set (digits
+  only, no dashes). Not needed by `customers:listAccessibleCustomers`.
 
 > **API version:** the base is `https://googleads.googleapis.com/<vNN>`. Google
-> ships a new `vNN` every ~4 months and retires old ones — set `VER` to the
-> **current** supported version (check developers.google.com/google-ads/api
-> release notes); the example uses `v18`.
+> ships a new `vNN` every ~4 months and retires old ones, so a hardcoded version
+> eventually stops working. The example uses `v25` (supported as of 2026-07). If
+> **every** call 404s, the version is unavailable — either retired or not yet
+> released. Probe `customers:listAccessibleCustomers`: a supported version
+> answers 401/200, an unavailable one 404. Step **down** one version at a time
+> from the example, and check Google's supported-versions table before assuming
+> a newer `vNN` exists.
 
 If `$GOOGLE_ADS_DEVELOPER_TOKEN` is empty, the connector isn't fully provisioned —
 say so rather than calling the API (it would 401/DEVELOPER_TOKEN_NOT_APPROVED).
 
 ```bash
-VER="v18"; BASE="https://googleads.googleapis.com/$VER"
+VER="v25"; BASE="https://googleads.googleapis.com/$VER"
 AUTH="Authorization: Bearer $GOOGLE_ADS_TOKEN"; DEV="developer-token: $GOOGLE_ADS_DEVELOPER_TOKEN"
 # Customers the OAuth user can access (ids are returned as customers/<id>)
 curl -sS -H "$AUTH" -H "$DEV" "$BASE/customers:listAccessibleCustomers" | jq '.resourceNames'
@@ -44,7 +49,10 @@ curl -sS -H "$AUTH" -H "$DEV" "$BASE/customers:listAccessibleCustomers" | jq '.r
 
 ```bash
 CID="1234567890"   # target customer id, digits only
-curl -sS -H "$AUTH" -H "$DEV" -H "login-customer-id: ${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$CID}" \
+# Manager (MCC) access → send login-customer-id; direct access → drop the header.
+# Array, not a plain string: the header value contains a space and would split.
+LOGIN=(); [ -n "$GOOGLE_ADS_LOGIN_CUSTOMER_ID" ] && LOGIN=(-H "login-customer-id: $GOOGLE_ADS_LOGIN_CUSTOMER_ID")
+curl -sS -H "$AUTH" -H "$DEV" "${LOGIN[@]}" \
   -H "Content-Type: application/json" -d '{
   "query":"SELECT campaign.name, metrics.cost_micros, metrics.clicks, metrics.conversions FROM campaign WHERE segments.date DURING LAST_30_DAYS ORDER BY metrics.cost_micros DESC"
 }' "$BASE/customers/$CID/googleAds:searchStream" \
@@ -56,8 +64,14 @@ GAQL resources: `campaign`, `ad_group`, `ad_group_criterion` (keywords),
 
 ## Gotchas
 
-- **Three headers, not one.** Missing `developer-token` or `login-customer-id`
-  is the #1 cause of 401/403 here.
+- **A 404 on *every* endpoint points at `VER`, not at credentials** — the
+  version is retired or unreleased. A 404 on a *single* call is about that call:
+  a missing resource (bad customer id) or a wrong path. Sanity-check the version
+  with `customers:listAccessibleCustomers` before debugging auth.
+- **Two credentials plus a context header.** `developer-token` is required on
+  every call; `login-customer-id` is only needed when acting under a manager
+  (MCC) account — `customers:listAccessibleCustomers` works without it. Omitting
+  it on a manager-scoped call is the #1 cause of 401/403 here.
 - Customer ids are **digits only** in URLs/headers (strip the dashes from
   `123-456-7890`).
 - `searchStream` returns an array of chunks each with `.results[]` — flatten with


### PR DESCRIPTION
## 问题

`google-ads` skill 的示例硬编码了 `VER="v18"`，而 Google 已下线该版本 —— 该版本下**所有**端点返回 404。这个 skill 一旦点亮就会全军覆没。

从集群 pod 实测（未认证探测，401 = 版本存活，404 = 不可用）：

```
v17 -> 404 (retired)      v22 -> 401 (alive)
v18 -> 404 (retired)      v23 -> 401 (alive)
v19 -> 404 (retired)      v24 -> 401 (alive)
v20 -> 401 (alive)        v25 -> 401 (alive)
v21 -> 401 (alive)        v26 -> 404 (unreleased)
```

## 改动

1. **示例升到 `v25`**（当前最新存活版本）。
2. **版本说明改为可执行的排查步骤** —— 满盘 404 说明版本不可用（已下线**或**未发布），用 `customers:listAccessibleCustomers` 探测，并且**向下**回退。原来写的「往上加版本」在 v25 上是死路：v26 未发布，agent 会从一个 404 走进另一个 404。
3. **修正 `login-customer-id` 的定位** —— 它是管理账号（MCC）的上下文 header，不是第三个凭据。`listAccessibleCustomers` 只需 OAuth + `developer-token`。GAQL 示例改为按需拼接该 header。

## 验证

- 版本存活性：集群 pod 内对 v17–v26 逐个探测（见上表）
- 条件 header 的 shell 正确性：未设置时展开为 0 个参数，设置时为 2 个参数且 header 值完整（未拆词）

不涉及审核 —— 这是纯粹的失效修复，独立于 `google/ads` connector 的 developer token 与 `hidden` 翻转。

## 🤖 对抗评审

评审者：**Codex** (`codex exec --sandbox read-only`)，3 轮收敛。

**第 1 轮 — 4 个 RISK，全部接受并修复：**

| RISK | 处理 |
|---|---|
| 「404 就往上加版本」在 v25 上误导（v26 未发布） | ✅ 修复 —— 改为向下回退 + 查官方支持版本表。这是我引入的真实缺陷 |
| 「满盘 404 = 已下线」太绝对（也可能是未发布 / URL 畸形） | ✅ 修复 —— 改为「不可用：已下线或未发布」 |
| 「404 不是资源缺失」对单个资源调用是错的 | ✅ 修复 —— 区分「每个端点都 404」与「单个调用 404」 |
| `login-customer-id` 被列为必需凭据 | ✅ 修复 —— 改为管理账号上下文 header，并同步修正 frontmatter 的 `when_to_use`（否则与正文矛盾） |

**第 2 轮 — 2 个 RISK，均由第 1 轮修复引入，全部接受并修复：**

| RISK | 处理 |
|---|---|
| 正文说 header 仅 MCC 需要，但示例仍无条件发送 —— 自相矛盾 | ✅ 修复 —— 改为条件拼接 |
| 「单个 404 = 资源缺失」仍太绝对 | ✅ 修复 —— 补上「或路径错误」 |

**自查发现（评审未提）：** 第 2 轮的条件 header 修复用了未加引号的字符串变量，`login-customer-id: 1234567890` 会被按空格拆成两个参数，curl 收到坏 header。改用 bash 数组并实测验证。

**第 3 轮：`VERDICT: CLEAN`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)