### PR TITLE
fix(wordpress): harden skill for SEO + unattended publishing

### DIFF
--- a/skills/wordpress/SKILL.md
+++ b/skills/wordpress/SKILL.md
@@ -9,11 +9,11 @@ when_to_use: |
   This skill is for self-hosted WordPress (Application Password auth),
   not WordPress.com.
 connections: [wordpress]
-allowed_tools: [Bash]
+allowed_tools: [Bash, publish_artifact]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 Drive the **WordPress REST API** (`/wp-json/wp/v2`) with `curl + jq`.
@@ -36,27 +36,54 @@ API="$SITE/wp-json/wp/v2"
 WP=(curl -sS --fail-with-body -u "$WORDPRESS_USERNAME:$WORDPRESS_APP_PASSWORD")
 ```
 
+> **Don't add `-L`/`--location` to these calls.** A redirect usually means the
+> site URL is wrong. curl strips the `Authorization` header when a redirect
+> crosses host or scheme (e.g. `http`→`https`, apex→`www`) — exactly the cases
+> that occur here — so the followed request runs **unauthenticated** and can
+> return the site's HTML page with HTTP 200: it looks like success but wrote
+> nothing. Fix the URL instead (see the `/wp-json` gotcha below).
+
+
 Errors come back as `{"code": "...", "message": "...", "data": {"status": 401}}` —
 show `message` verbatim. Common codes:
 
 | HTTP | Meaning | What to tell the user |
 |------|---------|-----------------------|
 | 401 | `incorrect_password` / bad Basic auth | Application Password wrong or revoked → regenerate it and reconnect the WordPress connector |
+| 401 | `rest_not_logged_in` on a plain-`http://` site | Application Passwords are disabled without HTTPS → the user must enable HTTPS |
 | 403 | `rest_cannot_create` / insufficient role | The user's role can't publish; needs Author/Editor/Admin, or Application Passwords are disabled on the site |
 | 404 | `rest_no_route` | REST API disabled or a security plugin blocks `/wp-json` → the user must re-enable it |
 | 400 | `rest_invalid_param` | Bad field (e.g. unknown category id) → fix and retry |
+| 500 | `rest_upload_sideload_error` | `wp-content/uploads` isn't writable by the web server → the user must fix directory permissions |
 
-> **`content` is HTML, not Markdown.** Convert Markdown to HTML first
-> (`pandoc -f markdown -t html`, or a simple converter). Raw Markdown renders literally.
+> **`content` is HTML, not Markdown.** Raw Markdown renders literally. `pandoc` is
+> **not installed** — convert with Python's `markdown` package (preinstalled in the
+> sandbox). If the import ever fails, `pip install markdown` first, then:
+>
+> ```bash
+> HTML=$(python3 -c "
+> import sys, markdown
+> print(markdown.markdown(sys.stdin.read(), extensions=['fenced_code','tables']))
+> " <<'MD'
+> ## 标题
+>
+> 正文 **粗体**
+> MD
+> )
+> ```
+
 
 ## Step 0 — verify the connection first
 
 ```bash
-"${WP[@]}" "$API/users/me" | jq '{id, name, slug, roles: (.roles // [])}'
+"${WP[@]}" "$API/users/me?context=edit" | jq '{id, name, slug, roles}'
 ```
 
-A 200 with your user object confirms the site URL, username, and Application
-Password all work. If this fails, stop and surface the error — don't attempt writes.
+`context=edit` is required — without it WP omits `roles`/`capabilities` entirely,
+so you cannot tell whether the account may publish. A 200 with `roles` containing
+`administrator`, `editor` or `author` confirms the site URL, username, Application
+Password **and** publish permission. If this fails, stop and surface the error —
+don't attempt writes.
 
 ## Publish or draft a post
 
@@ -87,6 +114,62 @@ jq -n --arg t "标题" --arg c "<p>正文</p>" --arg e "一句话摘要" \
 - Update a post: `POST $API/posts/<id>` with any subset of fields (WP REST uses
   POST, not PUT, for updates).
 - Delete (trash) a post: `"${WP[@]}" -X DELETE "$API/posts/<id>"`.
+- Schedule a post: `{"status":"future","date_gmt":"2030-01-01T00:00:00"}` (UTC,
+  no trailing `Z`).
+
+## SEO fields that actually matter
+
+WordPress core emits `<link rel="canonical">` on its own but ships **no meta
+description tag at all** — that only appears if the site runs an SEO plugin
+(Yoast, Rank Math, SEOPress) or a theme that renders one. Those consume the
+post's `excerpt`, so setting `excerpt` is what makes a good description possible;
+it does nothing on a bare core install. For an SEO post always set:
+
+| Field | Why |
+|---|---|
+| `slug` | The permalink. Set it explicitly to a short ASCII keyword phrase — otherwise a CJK title becomes a percent-encoded URL. |
+| `excerpt` | Source for the SEO plugin's meta description and for list-page summaries. One sentence. |
+| `categories` / `tags` | Internal linking + topic clustering. |
+| `featured_media` | Social/OG card image. |
+| media `alt_text` | Image SEO + accessibility. Set it on the media object (below). |
+
+
+```bash
+jq -n --arg s "claude-api-guide" --argjson c 3 --argjson m 9 \
+  '{title:"如何稳定调用 Claude API：完整对接指南",
+    slug:$s,
+    content:"<h2>小标题</h2><p>正文</p>",
+    excerpt:"一句话摘要，用于 meta description。",
+    status:"publish", categories:[$c], featured_media:$m}' \
+| "${WP[@]}" -X POST "$API/posts" -H "Content-Type: application/json" -d @- \
+| jq '{id, status, slug, link}'
+```
+
+## Before publishing: check for a duplicate
+
+**WordPress will NOT reject a duplicate slug — it silently appends `-2`,** so an
+unattended/scheduled run that reposts the same article creates an endless trail of
+near-identical URLs that compete with each other in search. Always pre-check:
+
+```bash
+SLUG="claude-api-guide"
+# Fail CLOSED at BOTH steps: a failed request, or a 200 that isn't a JSON array
+# (HTML from a redirect/permalink issue, or an error object), must abort — never
+# fall through and create the duplicate this check exists to prevent.
+if ! LOOKUP=$("${WP[@]}" "$API/posts?slug=$SLUG&status=publish,draft,future&_fields=id,link"); then
+  echo "duplicate check failed (request error) — aborting" >&2; exit 1
+fi
+if ! EXISTING=$(printf '%s' "$LOOKUP" | jq -er 'if type=="array" then (.[0].id // "") else error("not a JSON array") end'); then
+  echo "duplicate check failed (unexpected response) — aborting" >&2; exit 1
+fi
+if [ -n "$EXISTING" ]; then
+  echo "already exists as post $EXISTING — update it instead of creating a new one"
+  # update:  "${WP[@]}" -X POST "$API/posts/$EXISTING" ...
+fi
+```
+
+Prefer **updating** the existing post over creating a near-duplicate. This matters
+most in Scheduled Tasks, where nobody is watching the output.
 
 ## List / read posts
 
@@ -125,22 +208,40 @@ MEDIA_ID=$("${WP[@]}" -X POST "$API/media" \
   -H "Content-Type: image/png" \
   --data-binary @"$FILE" | jq -r '.id')
 echo "media id=$MEDIA_ID"
+
+# Set alt text (image SEO + accessibility) — a separate call on the media object.
+jq -n --arg a "Claude API 架构图" '{alt_text:$a}' \
+| "${WP[@]}" -X POST "$API/media/$MEDIA_ID" \
+    -H "Content-Type: application/json" -d @- | jq '{id, alt_text}'
+
 # Attach as the post's featured image:
 #   add  "featured_media": <MEDIA_ID>  to the post body.
 ```
 
 ## Gotchas
 
-- **HTTPS + Application Passwords are required.** On plain `http://`, WordPress
-  disables Application Passwords → every call 401s. Tell the user to enable HTTPS.
+- **HTTPS is effectively required for Application Passwords.** WP gates them on
+  `wp_is_application_passwords_available()`, which is false on a plain-`http://`
+  production site → authenticated calls fail with `rest_not_logged_in` (401). (The
+  gate is filterable and is bypassed when `WP_ENVIRONMENT_TYPE` is `local`, so a
+  dev box may still work — but any real site the user connects must serve HTTPS.)
+- **`$WORDPRESS_SITE_URL` must exactly match the site's configured address.** If
+  it differs (missing/extra `www`, `http` vs `https`), WP answers `/wp-json/...`
+  with a **301** to the canonical host. Fix the stored site URL in the connector
+  rather than papering over it with `-L`.
+
 - **A security plugin / host may block `/wp-json`** (Wordfence, "disable REST
   API" plugins, some managed hosts). Symptom: 404 `rest_no_route` or an HTML
   login page instead of JSON. The user must allow REST API access.
+- **Pretty permalinks may be off.** If `/wp-json/wp/v2/...` returns the site's
+  HTML instead of JSON, the site is on plain permalinks — use the always-available
+  query form instead: `$SITE/?rest_route=/wp/v2/posts`.
 - **The Application Password contains spaces** (e.g. `abcd efgh ijkl mnop`).
   Keep them — `curl -u` handles the spaces fine; don't strip them.
 - **Never publish silently.** Even if the user says "post it", prefer creating a
   draft and returning the `wp-admin` edit link unless they explicitly asked to
-  go live.
+  go live. (In an unattended Scheduled Task the user has pre-authorized the run,
+  so publishing directly is expected there — but still run the duplicate check.)
 
 
 ## Record the output


### PR DESCRIPTION
## 背景

要把 WordPress 当作「自有 SEO 内容站」跑无人值守定时发文，先对 `wordpress` skill 做了一次**真实环境**验证——本地起 WordPress 6.9.4 容器（Docker + MariaDB + wp-cli，Application Password 认证），把 SKILL.md 里每条命令**逐条真跑**，而不是看代码判断。

## 修复的 Bug（都是实测出来的）

| 问题 | 实测证据 |
|---|---|
| `allowed_tools: [Bash]` 缺 `publish_artifact`，但正文要求模型调用它 → 永远调不通 | 对照 `ghost` / `hashnode` / `x` 均已包含 |
| Step 0 用 `/users/me` 不带 `context=edit`，WP 不返回 `roles` → 无法确认有无发布权限 | 实测 `{"roles": null}`；加 `?context=edit` 后返回 `["administrator"]` |
| Markdown→HTML 指示用 `pandoc`，但沙箱镜像里**没有** pandoc | `PlatformService/sandbox/worker/Dockerfile` 无 pandoc；已改用 Python `markdown`（`requirements.txt:55` 固定 `markdown==3.7`），并在同版本容器里验证输出 |

## 补齐的能力（SEO 内容站必需）

- **SEO 字段**：`slug`（中文标题不显式设 slug 会生成百分号编码的永久链接）、`excerpt`、分类/标签、`featured_media`、媒体 `alt_text`（实测 `alt_text` 需对 media 对象单独 POST）。
- **重复发布防护（最关键）**：实测 WP **不会**拒绝重复 slug，而是**静默追加 `-2`**——无人值守定时任务会持续堆积互相竞争的近重复 URL。新增**fail-closed** 预检查。
- 定时发布 `status=future`、纯永久链接站的 `?rest_route=` 回退、错误表补 `rest_upload_sideload_error`（uploads 目录不可写，实测 500）。
- 警告 `-L`：跨 host/scheme 跳转时 curl 会剥离 `Authorization`，跟随后可能返回 HTML 200——**看着像成功其实什么都没写**。

## 验证

所有新代码块均按**原文逐字**在真实 WP 上跑通：连接校验、草稿、完整 SEO 发布、媒体上传 + 特色图 + alt text、分类 `term_exists` 复用、定时发布、重复检测。发布页实测可访问，`<link rel="canonical">` 正常。

去重逻辑穷举 5 种输入：正常数组含重复→走更新；空数组→允许创建；错误对象 / HTML / 空 body→**全部 abort**。并在真实服务器上用错误口令、不可达主机验证 fail-closed。

CI：`validate.yml` 校验通过（258 行 < 500），`python3 -m unittest discover -s tests` 47 项全过。

## 🤖 对抗评审

Codex（`codex exec --sandbox read-only`），3 轮收敛。

**Round 1 — 4 个 RISK，全部实测复核后修复：**
1. `RISK HIGH` 去重检查 fail-open：curl/jq 失败时 `EXISTING` 为空，会继续创建它本该阻止的重复。→ **确认真实**（实测 jq exit=5 后仍走创建路径），改为 fail-closed。
2. `RISK MEDIUM` HTTPS 断言过于绝对。→ **确认真实**：实测 `WP_ENVIRONMENT_TYPE=local` 时 `wp_is_application_passwords_available()` 返回 **true**，纯 HTTP 也可用。已改为说明该 gate 可被 filter 覆盖、local 环境例外。
3. `RISK MEDIUM` curl 重定向丢 auth 的说法过宽。→ **确认真实**：实测**同 host** 跳转 curl **保留**了 auth（返回 200 JSON）。已改为「跨 host/scheme 时剥离」。
4. `RISK MEDIUM` meta description 说法不准。→ **确认真实**：WP core 实测**根本不输出** meta description，仅输出 canonical。已改为「core 不产出，需 SEO 插件/主题消费 `excerpt`」。

**Round 2 — 1 个 RISK，已修复：**
- 去重检查在 HTTP 200 但返回体为 HTML / 非数组对象时**仍会 fail-open**（jq 类型守卫对 object 返回空且 exit 0）。→ **确认真实**，改用 `jq -er ... else error(...)` 并检查退出码；穷举 5 种输入重测通过。

**Round 3 — 1 个 RISK，已举证反驳（rebut）：**
- 评审称 Python `markdown` 未安装（`ModuleNotFoundError`）。→ **不成立**：评审在**我的 macOS 主机**上测试，而 skill 的 Bash 运行在**沙箱镜像**（`aichat2/worker/src/tools/builtin/bash.ts:144` → `SANDBOX_URL/execute`），该镜像 `requirements.txt:55` 固定 `markdown==3.7`；已在同版本容器中验证片段输出正确。仍顺手加了一句 `pip install markdown` 兜底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)