### PR TITLE
docs(youtube): 补齐 URL→上传路径，并让失败原因可见

### DIFF
--- a/skills/youtube/SKILL.md
+++ b/skills/youtube/SKILL.md
@@ -110,8 +110,39 @@ curl -sS -H "Authorization: Bearer $GOOGLE_YOUTUBE_TOKEN" \
 file you're about to upload. Uploads are a two-step *resumable* flow:
 init with metadata → PUT the bytes.
 
+### If the source is a URL, fetch it first
+
+Videos produced by a generation API (Maestro, Seedance, Veo, …) come back as a
+CDN URL, not a local file. Download it and verify you actually got a video
+before starting the upload:
+
 ```bash
-FILE="/path/to/video.mp4"
+SRC="https://example.cdn.acedata.cloud/path/video.mp4"
+FILE=$(mktemp)   # plain mktemp — `mktemp /tmp/x-XXXXXX.mp4` is not portable
+
+# -f: fail on 4xx/5xx instead of saving the error page. -L: follow CDN redirects.
+curl -fsSL -o "$FILE" -w 'http=%{http_code} size=%{size_download}\n' "$SRC"
+
+# Two distinct failures, two distinct messages — a 404/DNS error is a bad URL,
+# not a bad video, and saying so saves the next step from misdiagnosing it.
+[ -s "$FILE" ] \
+  || { echo "download failed (see http= above) — nothing to upload"; rm -f "$FILE"; exit 1; }
+
+# A 200 can still be an HTML interstitial or an expired-link page. Reject that
+# rather than allow-listing one container, so WebM/MOV/AVI still pass. `grep -a`
+# is required — without it grep treats a binary header as "no match".
+head -c 512 "$FILE" | grep -qai '<html\|<!doctype' \
+  && { echo "got an HTML page, not a video"; rm -f "$FILE"; exit 1; }
+```
+
+`--upload-file` ignores the filename; YouTube keys off the
+`Content-Type: video/*` header, so the extensionless temp file is fine.
+
+### The upload itself
+
+```bash
+# Falls back to the placeholder only if the fetch step above didn't set FILE.
+FILE="${FILE:-/path/to/video.mp4}"
 TITLE="My title"
 DESC="My description"
 # privacyStatus: public | unlisted | private
@@ -129,11 +160,18 @@ UPLOAD_URL=$(curl -sS -D - -o /dev/null \
   -d "$META" | tr -d '\r' | awk '/^[Ll]ocation:/{print $2}')
 
 # 2. Upload the bytes -> returns the created video resource (has .id).
-curl -sS -H "Authorization: Bearer $GOOGLE_YOUTUBE_TOKEN" \
+RESULT=$(curl -sS -H "Authorization: Bearer $GOOGLE_YOUTUBE_TOKEN" \
   -H "Content-Type: video/*" \
-  -X PUT --upload-file "$FILE" "$UPLOAD_URL" \
-  | jq '{id: .id, url: ("https://www.youtube.com/watch?v=" + .id), privacy: .status.privacyStatus}'
+  -X PUT --upload-file "$FILE" "$UPLOAD_URL")
+echo "$RESULT" | jq -e .id >/dev/null 2>&1 \
+  || { echo "upload failed: $(echo "$RESULT" | jq -r '.error.message' 2>/dev/null || echo "$RESULT")"; exit 1; }
+echo "$RESULT" | jq '{id: .id, url: ("https://www.youtube.com/watch?v=" + .id), privacy: .status.privacyStatus}'
 ```
+
+Delete a downloaded temp file only **after** you've confirmed an id came back
+(`echo "$RESULT" | jq -e .id >/dev/null && rm -f "$FILE"`). On a 401/403 or a
+dropped connection the download is still good and re-uploading beats re-fetching
+a few hundred MB.
 
 `categoryId` `22` = "People & Blogs" (a safe default). To set a custom
 thumbnail (needs the file to be processed first), call


### PR DESCRIPTION
## 问题

`skills/youtube/SKILL.md` 的上传示例写死：

```bash
FILE="/path/to/video.mp4"
```

它默认文件已在本地。但真实场景里视频几乎都来自生成类 API（Maestro / Seedance / Veo）返回的 **CDN URL**。文档没有"URL → 本地文件"这一步，模型只能自行推演——[实跑一次上传](https://www.youtube.com/watch?v=Cw52yA8VpV0)时它就误判了一次失败原因（以为沙箱不保留文件，实际保留）。

## 改动

在上传示例**之前**新增一节 `### If the source is a URL, fetch it first`，并顺带修掉一个既有缺陷。

每一行都是实测得出的，不是照着经验写的：

| 写法 | 为什么必须这样 |
|---|---|
| `FILE=$(mktemp)` | 带后缀的 `mktemp /tmp/x-XXXXXX.mp4` **不可移植**：macOS 上创建的是**字面名** `upload-XXXXXX.mp4`，第二次调用 `mkstemp failed: File exists` |
| `curl -fsSL` | 无 `-f` 时 404 **退出码为 0**，还把 449 字节的 XML 错误页存成 `.mp4`；无 `-L` 时 301 只拿到 162 字节的跳转壳子 |
| 先 `[ -s ]` 再查内容 | 两类失败给两种提示：404 / DNS 失败 → `download failed`，HTML 200 → `got an HTML page`。混为一谈会把"URL 坏了"误报成"格式不对" |
| 否定式检查（拒 HTML）而非白名单（只放行 MP4） | 白名单会**误拒 YouTube 支持的 WebM / MOV / AVI**——等于把误诊换个地方 |
| `grep -qa` 的 `-a` | 没有 `-a` 时 grep 把二进制头判为"不匹配"。**BSD grep 返回 rc=1，GNU/busybox 返回 rc=0**——只在 macOS 上炸，最难查的那类 |
| `FILE="${FILE:-...}"` | 原先两个代码块都赋值 `FILE`，按文档顺序执行会把下载好的路径覆盖成不存在的占位符 |
| `rm` 移出代码块、以 `jq -e .id` 为条件 | `curl \| jq` 遇到错误响应**仍退出 0**，无条件 `rm` 会在 403 时删掉几百 MB 的源文件 |

**顺带修掉的既有缺陷**（非本次引入，但我的改动让它更显眼）：上传失败时展示用的 jq 只取 `.id`，把上游错误吞掉，只显示 `{"id": null, "url": "https://www.youtube.com/watch?v=", "privacy": null}`。这与本 skill 开头「show that error verbatim」以及它自己记录的 `403 insufficientPermissions` → 重新授权流程直接矛盾；在文件被正确保留之后，用户反而无从知道为何失败。

## 验证

全部路径实跑，非推演：

```
真 mp4 (9,740,913 B)   → ACCEPTED
WebM / MOV / AVI       → ACCEPTED   ← 白名单版本会误拒
404                    → download failed   (传输)
DNS 失败 (http=000)    → download failed   (传输)
HTTP 200 HTML (559 B)  → got an HTML page  (内容)
重定向                 → -L 跟随至 200，正确判定
403 上传失败           → 源文件保留，且打印 "insufficientPermissions: ..."
非 JSON / 空响应       → 原样回显，不再是空信息
成功                   → 清理临时文件
```

CI 校验本地通过：frontmatter 完好、47 个 python 测试 OK、无上游信息泄漏。

## 🤖 对抗评审

评审方：Claude `general-purpose` subagent（codex 当日用量超限，按 `.claude/commands/auto-review.md` 回退）。**3 轮收敛**，共 10 条 RISK。

**第 1 轮 — 6 条，5 条实修、1 条判定不适用**
- `mktemp` 后缀不可移植 → 实修（复现了 macOS 字面名 + 二次失败）
- `[ -s ]` 拦不住 HTML → 实修（example.com 200 / 559 B 确实放行）
- 缺 `-L` → 实修（301 拿到 162 B 壳子且 rc=0）
- 「会上传成功再处理失败」这句无法证实 → **删除**该断言，而非软化
- `FILE=` 重复赋值 / 取用先于定义 → 实修
- 无临时文件清理 → 实修
- （`exit 1` 是否会杀掉 agent 会话 → 查证为仓库既有惯例，25+ 处，只结束单次调用子 shell，不适用）

> ⚠️ 评审建议的 `head -c 12 | grep -q ftyp` **我实测后发现是错的**：它把真的 9.7MB 视频拒了（grep 对二进制默认判为不匹配）。若照抄，会引入比原 bug 更糟的问题。改用 `grep -qa` 并已在 macOS/Linux 双平台确认。

**第 2 轮 — 4 条，全部实修**（均为我第 1 轮修复引入的新问题）
- `ftyp` 白名单误拒 WebM/AVI → 改为否定式检查
- 所有失败统一报 "not an mp4" → 拆成传输/内容两种提示
- 无条件 `rm -f` 在 403 时删源文件 → 改为 `jq -e .id` 条件清理
- 重排只解决了阅读顺序，执行顺序仍覆盖 → 改用 `${FILE:-...}`

**第 3 轮 — `VERDICT: CLEAN`**，并额外指出一条既有缺陷（jq 吞掉 API 错误）。评审认为可留作后续，但因其仅需两行、且与本次「文件保留后无从判因」直接相关，**本 PR 一并修掉**（含非 JSON / 空响应两个边界）。

关于体积/时长上限：评审同意暂不写入——文档目前未对上限作任何声明，保持沉默是准确的，而写一个猜测的数字是错的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)