### PR TITLE
fix(bilibili): publish 返回真实文章 URL + 修复分类永远是「生活」

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -42,6 +42,8 @@ python3 "$BILI" whoami                     # who is logged in (mid, name)
 python3 "$BILI" articles --limit 20        # my 专栏 articles + stats
 python3 "$BILI" article <cvid>             # one article's stats (cv id)
 python3 "$BILI" drafts --limit 50          # list saved drafts (aid + title)
+python3 "$BILI" status --limit 10          # review state of recent submissions
+python3 "$BILI" categories                 # 分类 names accepted by --category
 ```
 
 Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (评论),
@@ -69,12 +71,41 @@ BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxde
 python3 "$BILI" publish --title "标题" --content-file a.html                       # dry-run
 python3 "$BILI" publish --title "标题" --content-file a.html --draft-only --confirm   # save a draft
 python3 "$BILI" publish --title "标题" --content-file a.html --confirm                # save draft + submit (publish)
+python3 "$BILI" publish --title "标题" --content-file a.html --category 数码 --confirm  # pick the 分类
 ```
 
 - `--draft-only` saves a draft (no submit) — safe; finish/publish in the editor.
+  Prefer it when the user has not clearly asked to go public: a submitted
+  article enters a review queue this CLI cannot withdraw it from.
 - The **submit** (go public) step is frequently rate-limited by Bilibili
   risk-control (HTTP 412). When that happens the CLI reports the saved draft +
-  edit URL so the user can publish from the web editor. Default to `--draft-only`.
+  edit URL so the user can publish from the web editor.
+- `--category` picks the 分类 (default **数码**, which suits technical posts).
+  Run `categories` for the accepted names. The result echoes the 分类 actually
+  used as `category` / `category_id` — report it when it wasn't the user's pick.
+
+### Publishing is not instant — it enters a review queue
+
+A successful `submit` returns `state: -2` (**待审核**) and `pending_review: true`.
+The returned `url` **404s for everyone until Bilibili approves it** (usually
+minutes to hours). Tell the user it is pending; do not claim it is live, and do
+not re-submit. Check later with `status`, which is the only view that shows
+pending/rejected articles (the public list omits them):
+
+```sh
+python3 "$BILI" status --limit 5    # state_desc: 待审核 / 已发布 / 未通过 (+ reason)
+```
+
+Other states are **not** pending and will never go live on their own — the CLI
+returns them with `ok: false` and `published: false` (`-1` 未通过 rejected, `-3`
+锁定, `-4` 已删除). Read `state_desc`, tell the user plainly, and check `status`
+for the `reason` rather than re-submitting.
+
+The `id` in the publish result is the **article id** (use `cv<id>`), which is a
+different number from `draft_aid`. Only ever share the `url` field. If Bilibili
+returned no article id, `url` and `id` are `null` and `id_unverified: true` is
+set — there is nothing shareable yet, so find the article with `status` instead
+of constructing a link from `draft_aid`.
 
 ## Managing drafts (the 999-draft cap)
 
@@ -108,8 +139,8 @@ skips this.
 - **This is the user's real Bilibili account.** Confirm before any publish.
 - **submit may 412** (anti-bot) even when the draft saved fine — the draft is the
   reliable result; don't loop-retry submit.
-- A wrong cover layout (`tid`) / category returns `-17`; the CLI auto-retries
-  common `tid` values.
+- A 分类 the account can't post to returns `-17`; without `--category` the CLI
+  auto-retries the fallback list.
 - **Never print `BILIBILI_COOKIES`** — it is full account access.
 - **ToS**: acts only on the user's own account with their own captured cookie.
 
@@ -123,6 +154,14 @@ After you successfully publish and obtain the live result URL, call the built-in
 publish_artifact(kind="article", channel="bilibili", title="<title>", url="<the REAL returned URL>", status="delivered")
 ```
 
-Use the real returned URL — never fabricate one. Call it once per published item,
-only after delivery is confirmed; skip it (or use `status="failed"`) if publishing failed.
+Use the real returned URL — never fabricate one. That is the `url` field of the
+publish result (built from the article `id`, **not** `draft_aid`). Call it once
+per published item, only after delivery is confirmed.
+
+- `state: 0` or `1` (已发布, live) → `status="delivered"`.
+- `pending_review: true` (待审核) → `status="draft"`; the URL is not live yet.
+  Re-record as delivered later if the user asks you to re-check with `status`.
+- rejected/locked states, a 412-blocked submit, `id_unverified: true`, or
+  `state_unknown: true` → `status="failed"` (or skip it).
+
 See `_shared/artifacts.md`.

--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -277,8 +277,30 @@ def cmd_article(jar, args):
     })
 
 
-# tid = cover layout; a wrong one returns code -17 / "分类". Try common ones.
-_TID_CANDIDATES = ["4", "3", "6", "7", "2", "17", "28", "41"]
+# The article's 分类 (from /x/article/categories). This is the `category` form
+# field — `tid` alone does NOT set it (a hardcoded category=0 always lands in
+# 生活 regardless of tid). Sub-category ids only; a parent id is rejected.
+_CATEGORIES = {
+    "数码": "26", "科技": "26", "tech": "26",
+    "学习": "34", "人文历史": "25", "自然": "33", "汽车": "27",
+    "日常": "15", "生活": "15", "美食": "13", "时尚": "14", "运动": "22", "萌宠": "21",
+    "绘画": "23", "手工": "24", "摄影": "38", "音乐舞蹈": "39", "模型手办": "11",
+    "动漫杂谈": "4", "动漫资讯": "5", "动画技术": "31",
+    "单机游戏": "6", "电子竞技": "7", "手机游戏": "8", "网络游戏": "9", "桌游棋牌": "10",
+    "电影": "12", "电视剧": "35", "纪录片": "36", "综艺": "37",
+    "原创连载": "18", "同人连载": "19", "短篇小说": "32", "小说杂谈": "20",
+}
+# Fallback order when --category is not given: 数码 first (most of our content
+# is technical), then broad ones. A category the account can't post to → -17.
+_TID_CANDIDATES = ["26", "34", "15", "4", "6", "12", "23"]
+
+# A creative article's `state` (what 投稿管理 shows). Only 0/1 are actually live.
+_STATES = {0: "已发布", 1: "已发布", -1: "未通过", -2: "待审核", -3: "锁定", -4: "已删除"}
+
+# id → canonical display name (first alias wins; 数码/科技/tech all map to 26).
+_CATEGORY_NAMES = {}
+for _name, _cid in _CATEGORIES.items():
+    _CATEGORY_NAMES.setdefault(_cid, _name)
 
 
 # ── image upload (Bilibili hotlink-blocks external imgs; re-host via
@@ -545,6 +567,19 @@ def md_to_html(src):
     return "\n".join(out)
 
 
+def _resolve_categories(raw):
+    """--category → the single 分类 id to use, or the fallback list if unset."""
+    if not raw:
+        return _TID_CANDIDATES, None
+    name = raw.strip()
+    cid = _CATEGORIES.get(name)
+    if not cid:
+        if not name.isdigit():
+            die(f"unknown --category {raw!r}; known: " + ", ".join(sorted(_CATEGORIES)))
+        cid = name
+    return [cid], cid  # explicit choice: don't silently fall back to another 分类
+
+
 def cmd_publish(jar, args):
     if not args.title:
         die("--title is required")
@@ -562,14 +597,22 @@ def cmd_publish(jar, args):
     if not csrf:
         die("no bili_jct cookie (CSRF token) — reconnect Bilibili.")
 
+    # Resolve before the dry-run so a typo'd 分类 is caught in the preview,
+    # and before rehost_images so a bad one can't burn uploads then abort.
+    cids, explicit = _resolve_categories(args.category)
+
     if not CONFIRM:
         out({
             "dry_run": True, "command": "publish", "platform": "bilibili",
             "title": args.title, "draft_only": args.draft_only,
+            "category": (_CATEGORY_NAMES.get(explicit, explicit) if explicit
+                         else "(auto: 数码)"),
             "content_bytes": len(content),
             "note": "Bilibili 专栏 content is HTML. Re-run with --confirm as the "
-                    "LAST argument to write. The submit step is often 412-limited; "
-                    "the saved draft is the reliable result.",
+                    "LAST argument to write. Published articles enter Bilibili's "
+                    "review queue (state -2) before going public; the submit step "
+                    "is also often 412-limited, in which case the saved draft is "
+                    "the reliable result.",
         })
         return
 
@@ -585,13 +628,15 @@ def cmd_publish(jar, args):
     ref = "https://member.bilibili.com/"
     base = {
         "title": args.title, "content": content, "csrf": csrf,
-        "category": "0", "list_id": "0", "reprint": "0", "original": "1",
+        "list_id": "0", "reprint": "0", "original": "1",
         "media_id": "0", "spoiler": "0", "save": "0", "pgc_id": "0",
     }
-    # 1. save draft, retrying tid until the category is accepted
-    aid, last = None, None
-    for tid in _TID_CANDIDATES:
-        body = dict(base, tid=tid)
+    # 1. save draft, retrying the 分类 until one is accepted
+    aid, chosen, last = None, None, None
+    for cid in cids:
+        # `category` is what actually sets 分类; `tid` must match or the article
+        # silently lands in 生活.
+        body = dict(base, tid=cid, category=cid)
         status, text = request("POST", f"{API}/x/article/creative/draft/addupdate",
                                jar, referer=ref, form=body)
         try:
@@ -601,21 +646,22 @@ def cmd_publish(jar, args):
             continue
         if r.get("code") == 0:
             aid = (r.get("data") or {}).get("aid")
-            chosen_tid = tid
+            chosen = cid
             break
         last = f"code={r.get('code')} {r.get('message')}"
         if "分类" not in str(r.get("message", "")) and r.get("code") != -17:
-            break  # a non-category error won't be fixed by another tid
+            break  # a non-category error won't be fixed by another one
     if not aid:
         die(f"save-draft failed: {last}")
 
     if args.draft_only:
         out({"ok": True, "draft_only": True, "aid": str(aid),
+             "category_id": chosen, "category": _CATEGORY_NAMES.get(chosen, chosen),
              "edit_url": f"https://member.bilibili.com/article-text/home?aid={aid}"})
         return
 
     # 2. submit (publish) — may be 412 risk-controlled; report draft if so
-    body = dict(base, tid=chosen_tid, aid=aid)
+    body = dict(base, tid=chosen, category=chosen, aid=aid)
     status, text = request("POST", f"{API}/x/article/creative/article/submit",
                            jar, referer=ref, form=body)
     try:
@@ -623,8 +669,64 @@ def cmd_publish(jar, args):
     except json.JSONDecodeError:
         r = None
     if r and r.get("code") == 0:
-        out({"ok": True, "published": True, "aid": str(aid),
-             "url": f"https://www.bilibili.com/read/cv{aid}"})
+        # The published article gets a NEW id — the draft aid is not a cv id, so
+        # cv<draft_aid> 404s. Only trust an id the submit response actually gave.
+        data = r.get("data") or {}
+        try:
+            cvid = int(data.get("aid"))
+        except (TypeError, ValueError):
+            cvid = None
+        if cvid is not None and cvid <= 0:
+            cvid = None  # article ids are positive; 0 means "not returned"
+        res = {"ok": True, "published": True,
+               "id": str(cvid) if cvid is not None else None,
+               "url": (f"https://www.bilibili.com/read/cv{cvid}"
+                       if cvid is not None else None),
+               "draft_aid": str(aid),
+               "category_id": chosen,
+               "category": _CATEGORY_NAMES.get(chosen, chosen)}
+        notes = []
+        if cvid is None:
+            # Never hand back a draft-aid URL dressed up as the published one.
+            res["id_unverified"] = True
+            notes.append("submit succeeded but returned no article id — there is "
+                         f"no shareable URL yet (draft aid {aid} is NOT a cv id). "
+                         "Find the article with `status`.")
+        raw_state = data.get("state")
+        if isinstance(raw_state, bool):
+            state = None
+        else:
+            try:
+                state = int(raw_state)
+            except (TypeError, ValueError):
+                state = None
+        if state is None and raw_state is not None:
+            res["state_unknown"] = True
+            notes.append(f"submit returned an unreadable state ({raw_state!r}); "
+                         "confirm with `status` before reporting this as live.")
+        if state is not None and state not in (0, 1):
+            res["state"] = state
+            res["state_desc"] = _STATES.get(state, str(state))
+            if state == -2:
+                # 待审核: the url 404s for everyone until Bilibili approves it.
+                res["pending_review"] = True
+                notes.append("submitted, now in Bilibili's review queue — the URL "
+                             "goes live once approved (usually minutes to hours). "
+                             "Re-check with `status`; do not re-submit.")
+            elif state < 0:
+                # -1 未通过 / -3 锁定 / -4 已删除 — NOT pending, will never go live.
+                res["ok"] = False
+                res["published"] = False
+                notes.append(f"submit returned state {state} "
+                             f"({_STATES.get(state, 'unknown')}) — the article is "
+                             "not live and is not queued. Check `status` for the "
+                             "reason; do not report this as published.")
+        elif state in (0, 1):
+            res["state"] = state
+            res["state_desc"] = _STATES[state]
+        if notes:
+            res["note"] = " ".join(notes)
+        out(res)
     else:
         out({"ok": False, "published": False, "draft_saved": True, "aid": str(aid),
              "edit_url": f"https://member.bilibili.com/article-text/home?aid={aid}",
@@ -635,6 +737,41 @@ def cmd_publish(jar, args):
 def _drafts_of(d: dict) -> list:
     al = (d.get("data") or {}).get("artlist") or d.get("artlist") or {}
     return al.get("drafts") or []
+
+
+def cmd_categories(jar, args):
+    by_id = {}
+    for name, cid in _CATEGORIES.items():
+        by_id.setdefault(cid, []).append(name)
+    cats = [{"id": cid, "names": names} for cid, names in by_id.items()]
+    out({"count": len(cats), "categories": cats,
+         "note": "pass any of the names (or the raw id) to `publish --category`; "
+                 "the default is 数码."})
+
+
+def cmd_status(jar, args):
+    # The creative list is the ONLY view that shows pending/rejected articles —
+    # the public space list omits anything not yet approved.
+    d = get_json(f"{API}/x/article/creative/article/list?pn=1&ps={args.limit}",
+                 jar, referer="https://member.bilibili.com/")
+    if d.get("code"):
+        die(f"status error (code={d.get('code')}): {d.get('message')} — cookie expired?")
+    al = (d.get("data") or {}).get("artlist") or d.get("artlist") or {}
+    rows = []
+    for a in (al.get("articles") or [])[: args.limit]:
+        st = a.get("state")
+        cvid = a.get("id")
+        rows.append({
+            "id": str(cvid) if cvid else None,
+            "title": a.get("title"),
+            "state": st,
+            "state_desc": _STATES.get(st, str(st)) if isinstance(st, int) else None,
+            "live": isinstance(st, int) and st >= 0,
+            "reason": a.get("reason") or None,
+            "category": (a.get("category") or {}).get("name"),
+            "url": f"https://www.bilibili.com/read/cv{cvid}" if cvid else None,
+        })
+    out({"count": len(rows), "articles": rows})
 
 
 def cmd_drafts(jar, args):
@@ -686,6 +823,8 @@ COMMANDS = {
     "publish": cmd_publish,
     "drafts": cmd_drafts,
     "delete-draft": cmd_delete_draft,
+    "categories": cmd_categories,
+    "status": cmd_status,
 }
 
 
@@ -702,8 +841,13 @@ def main() -> None:
     sp.add_argument("--content", help="HTML content inline")
     sp.add_argument("--content-file", help="path to an HTML file")
     sp.add_argument("--draft-only", action="store_true", help="save a draft; do NOT submit")
+    sp.add_argument("--category", help="分类 name (e.g. 数码, 学习, 日常) or a raw tid; "
+                                       "default tries 数码 first")
     sp.add_argument("--no-rehost-images", action="store_true",
                     help="keep external image URLs as-is (skip Bilibili CDN re-host)")
+    sp = sub.add_parser("categories", help="list the 分类 names accepted by --category")
+    sp = sub.add_parser("status", help="review state of the user's recent submissions")
+    sp.add_argument("--limit", type=int, default=10)
     sp = sub.add_parser("drafts", help="list 专栏 drafts (id+title); use to prune the 999-draft cap")
     sp.add_argument("--limit", type=int, default=50)
     sp.add_argument("--page", type=int, default=1)

--- a/tests/test_bilibili_publish.py
+++ b/tests/test_bilibili_publish.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).parents[1] / "skills" / "bilibili" / "scripts" / "bilibili.py"
+SPEC = importlib.util.spec_from_file_location("bilibili_skill", SCRIPT)
+assert SPEC and SPEC.loader
+bili = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bili)
+
+JAR = [{"name": "bili_jct", "value": "csrf-token", "domain": ".bilibili.com"},
+       {"name": "SESSDATA", "value": "sess", "domain": ".bilibili.com"}]
+
+DRAFT_AID = 373282
+ARTICLE_ID = 51827685
+
+
+def args(**kw) -> SimpleNamespace:
+    base = dict(title="T", content="<p>hi</p>", content_file=None, draft_only=False,
+                category=None, no_rehost_images=True)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class Recorder:
+    """Stands in for bilibili.request, capturing the form each call posted."""
+
+    def __init__(self, submit_data=None, draft_code=0):
+        self.calls: list[tuple[str, dict]] = []
+        self.submit_data = submit_data if submit_data is not None else {
+            "aid": ARTICLE_ID, "state": -2,
+        }
+        self.draft_code = draft_code
+
+    def __call__(self, method, url, jar, referer=None, form=None):
+        self.calls.append((url, form or {}))
+        if url.endswith("draft/addupdate"):
+            if self.draft_code:
+                return 200, json.dumps({"code": self.draft_code, "message": "分类错误"})
+            return 200, json.dumps({"code": 0, "data": {"aid": DRAFT_AID}})
+        if url.endswith("article/submit"):
+            return 200, json.dumps({"code": 0, "data": self.submit_data})
+        raise AssertionError(f"unexpected url {url}")
+
+    def form_for(self, suffix: str) -> dict:
+        for url, form in self.calls:
+            if url.endswith(suffix):
+                return form
+        raise AssertionError(f"no call to {suffix}")
+
+
+def publish(monkey_request, publish_args) -> dict:
+    original_request, original_confirm = bili.request, bili.CONFIRM
+    bili.request, bili.CONFIRM = monkey_request, True
+    try:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bili.cmd_publish(JAR, publish_args)
+        return json.loads(buf.getvalue())
+    finally:
+        bili.request, bili.CONFIRM = original_request, original_confirm
+
+
+class PublishIdTest(unittest.TestCase):
+    def test_url_uses_submit_article_id_not_draft_aid(self):
+        # The published article gets a NEW id; cv<draft_aid> 404s.
+        rec = Recorder()
+        res = publish(rec, args())
+        self.assertEqual(res["id"], str(ARTICLE_ID))
+        self.assertEqual(res["url"], f"https://www.bilibili.com/read/cv{ARTICLE_ID}")
+        self.assertEqual(res["draft_aid"], str(DRAFT_AID))
+        self.assertNotIn(str(DRAFT_AID), res["url"])
+
+    def test_pending_review_state_is_surfaced(self):
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": -2}), args())
+        self.assertTrue(res["pending_review"])
+        self.assertEqual(res["state"], -2)
+        self.assertTrue(res["ok"])
+
+    def test_approved_state_has_no_pending_flag(self):
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": 0}), args())
+        self.assertNotIn("pending_review", res)
+        self.assertTrue(res["ok"])
+
+    def test_rejected_state_is_not_reported_as_pending(self):
+        # -1 未通过 will NEVER go live; calling it "pending" makes the agent
+        # record a permanently-404 URL as delivered.
+        for state in (-1, -3, -4):
+            res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": state}),
+                          args())
+            self.assertNotIn("pending_review", res, f"state {state}")
+            self.assertFalse(res["ok"], f"state {state}")
+            self.assertFalse(res["published"], f"state {state}")
+            self.assertEqual(res["state_desc"], bili._STATES[state])
+
+    def test_non_int_state_does_not_crash_after_the_write(self):
+        # The article is already submitted here — a TypeError would destroy the
+        # only copy of the returned id.
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": "-2"}), args())
+        self.assertEqual(res["id"], str(ARTICLE_ID))
+
+    def test_coercible_string_state_still_warns(self):
+        # "-2" must not silently downgrade to "fully published".
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": "-2"}), args())
+        self.assertTrue(res["pending_review"])
+        self.assertEqual(res["state"], -2)
+
+    def test_unreadable_state_is_flagged_not_swallowed(self):
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": "weird"}),
+                      args())
+        self.assertTrue(res["state_unknown"])
+        self.assertIn("unreadable state", res["note"])
+        self.assertNotIn("state", res)
+
+    def test_state_one_is_live_not_abnormal(self):
+        # _STATES maps both 0 and 1 to 已发布.
+        res = publish(Recorder(submit_data={"aid": ARTICLE_ID, "state": 1}), args())
+        self.assertTrue(res["ok"])
+        self.assertNotIn("pending_review", res)
+        self.assertEqual(res["state_desc"], "已发布")
+
+    def test_missing_article_id_yields_no_url_at_all(self):
+        # Falling back to a draft-aid URL is the exact 404 bug being fixed.
+        for data in ({}, {"aid": 0}, {"aid": None}, {"aid": "not-a-number"}):
+            res = publish(Recorder(submit_data=data), args())
+            self.assertTrue(res["id_unverified"], data)
+            self.assertIsNone(res["url"], data)
+            self.assertIsNone(res["id"], data)
+            self.assertNotIn(str(DRAFT_AID), json.dumps(res.get("url") or ""), data)
+
+    def test_unverified_id_warning_survives_pending_review(self):
+        # Ground truth: submit always returns -2, so this pairing is the norm.
+        res = publish(Recorder(submit_data={"state": -2}), args())
+        self.assertTrue(res["id_unverified"])
+        self.assertTrue(res["pending_review"])
+        self.assertIn("no shareable URL", res["note"])
+        self.assertIn("review queue", res["note"])
+
+    def test_publish_reports_the_category_it_used(self):
+        res = publish(Recorder(), args())
+        self.assertEqual(res["category_id"], "26")
+        self.assertEqual(res["category"], "数码")
+
+
+class CategoryTest(unittest.TestCase):
+    def test_category_field_is_sent_not_just_tid(self):
+        # A hardcoded category=0 silently lands every article in 生活.
+        rec = Recorder()
+        publish(rec, args(category="数码"))
+        for suffix in ("draft/addupdate", "article/submit"):
+            form = rec.form_for(suffix)
+            self.assertEqual(form["category"], "26", suffix)
+            self.assertEqual(form["tid"], "26", suffix)
+
+    def test_default_category_is_shuma(self):
+        rec = Recorder()
+        publish(rec, args())
+        self.assertEqual(rec.form_for("draft/addupdate")["category"], "26")
+
+    def test_explicit_category_does_not_fall_back(self):
+        # -17 on an explicit choice must fail, not silently pick another 分类.
+        rec = Recorder(draft_code=-17)
+        original_request, original_confirm = bili.request, bili.CONFIRM
+        bili.request, bili.CONFIRM = rec, True
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf), self.assertRaises(SystemExit):
+                bili.cmd_publish(JAR, args(category="数码"))
+        finally:
+            bili.request, bili.CONFIRM = original_request, original_confirm
+        self.assertEqual(len(rec.calls), 1)
+
+    def test_unknown_category_name_is_rejected(self):
+        buf = io.StringIO()
+        original_confirm = bili.CONFIRM
+        bili.CONFIRM = True
+        try:
+            with redirect_stdout(buf), self.assertRaises(SystemExit):
+                bili.cmd_publish(JAR, args(category="不存在的分类"))
+        finally:
+            bili.CONFIRM = original_confirm
+        self.assertIn("unknown --category", json.loads(buf.getvalue())["error"])
+
+    def test_bad_category_is_caught_in_the_dry_run(self):
+        # Must fail in the preview, not after --confirm has uploaded images.
+        buf = io.StringIO()
+        original_confirm = bili.CONFIRM
+        bili.CONFIRM = False
+        try:
+            with redirect_stdout(buf), self.assertRaises(SystemExit):
+                bili.cmd_publish(JAR, args(category="不存在的分类"))
+        finally:
+            bili.CONFIRM = original_confirm
+        self.assertIn("unknown --category", json.loads(buf.getvalue())["error"])
+
+    def test_bad_category_aborts_before_image_upload(self):
+        uploads = []
+        original = bili.rehost_images
+        bili.rehost_images = lambda *a, **k: uploads.append(1) or ""
+        original_confirm, bili.CONFIRM = bili.CONFIRM, True
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf), self.assertRaises(SystemExit):
+                bili.cmd_publish(JAR, args(category="不存在的分类",
+                                           no_rehost_images=False))
+        finally:
+            bili.rehost_images, bili.CONFIRM = original, original_confirm
+        self.assertEqual(uploads, [])
+
+    def test_numeric_category_passes_through(self):
+        rec = Recorder()
+        publish(rec, args(category="34"))
+        self.assertEqual(rec.form_for("draft/addupdate")["category"], "34")
+
+    def test_all_category_ids_are_subcategories(self):
+        # Parent ids (e.g. 17 科技) are rejected by submit.
+        parents = {"1", "2", "3", "16", "17", "28", "29", "41", "43"}
+        self.assertFalse(parents & set(bili._CATEGORIES.values()))
+        self.assertFalse(parents & set(bili._TID_CANDIDATES))
+
+
+class StatusTest(unittest.TestCase):
+    # Live-verified: the creative list puts `artlist` at the TOP level.
+    ENVELOPE = {
+        "code": 0, "message": "OK",
+        "artlist": {"articles": [
+            {"id": 51827685, "title": "pending one", "state": -2, "reason": "",
+             "category": {"id": 26, "name": "数码"}},
+            {"id": 51826510, "title": "live one", "state": 0, "reason": "",
+             "category": {"id": 15, "name": "生活"}},
+            {"id": 51820000, "title": "rejected one", "state": -1,
+             "reason": "含违规内容", "category": {"id": 26, "name": "数码"}},
+        ]},
+    }
+
+    def run_status(self, envelope, limit=10) -> dict:
+        original = bili.get_json
+        bili.get_json = lambda *a, **k: envelope
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bili.cmd_status(JAR, SimpleNamespace(limit=limit))
+            return json.loads(buf.getvalue())
+        finally:
+            bili.get_json = original
+
+    def test_parses_top_level_artlist(self):
+        res = self.run_status(self.ENVELOPE)
+        self.assertEqual(res["count"], 3)
+        self.assertEqual(res["articles"][0]["title"], "pending one")
+
+    def test_live_flag_and_state_desc(self):
+        rows = self.run_status(self.ENVELOPE)["articles"]
+        self.assertEqual([r["live"] for r in rows], [False, True, False])
+        self.assertEqual([r["state_desc"] for r in rows],
+                         ["待审核", "已发布", "未通过"])
+        self.assertEqual(rows[2]["reason"], "含违规内容")
+
+    def test_no_cvnone_url_when_id_missing(self):
+        res = self.run_status({"artlist": {"articles": [
+            {"title": "no id yet", "state": -2}]}})
+        row = res["articles"][0]
+        self.assertIsNone(row["url"])
+        self.assertIsNone(row["id"])
+
+    def test_no_literal_none_state_desc(self):
+        row = self.run_status({"artlist": {"articles": [
+            {"id": 51, "title": "no state"}]}})["articles"][0]
+        self.assertIsNone(row["state_desc"])
+        self.assertFalse(row["live"])
+
+    def test_limit_is_respected(self):
+        self.assertEqual(self.run_status(self.ENVELOPE, limit=2)["count"], 2)
+
+    def test_api_error_exits(self):
+        with self.assertRaises(SystemExit), redirect_stdout(io.StringIO()):
+            self.run_status({"code": -101, "message": "账号未登录"})
+
+
+class CategoriesCommandTest(unittest.TestCase):
+    def run_categories(self) -> dict:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            bili.cmd_categories(JAR, SimpleNamespace())
+        return json.loads(buf.getvalue())
+
+    def test_every_accepted_name_is_listed(self):
+        # De-duping by id used to hide aliases like 生活 and 科技, so an agent
+        # reading this output would think they were unavailable.
+        listed = {n for c in self.run_categories()["categories"] for n in c["names"]}
+        self.assertEqual(listed, set(bili._CATEGORIES))
+
+    def test_ids_match_the_lookup_table(self):
+        for cat in self.run_categories()["categories"]:
+            for name in cat["names"]:
+                self.assertEqual(bili._CATEGORIES[name], cat["id"])
+
+
+class DryRunTest(unittest.TestCase):
+    def test_dry_run_writes_nothing(self):
+        rec = Recorder()
+        original_request, original_confirm = bili.request, bili.CONFIRM
+        bili.request, bili.CONFIRM = rec, False
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bili.cmd_publish(JAR, args())
+            res = json.loads(buf.getvalue())
+        finally:
+            bili.request, bili.CONFIRM = original_request, original_confirm
+        self.assertTrue(res["dry_run"])
+        self.assertEqual(rec.calls, [])
+
+    def test_dry_run_echoes_the_category_name_the_user_typed(self):
+        # "26" is not checkable by a human against the 分类 they asked for.
+        original_confirm, bili.CONFIRM = bili.CONFIRM, False
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                bili.cmd_publish(JAR, args(category="数码"))
+            self.assertEqual(json.loads(buf.getvalue())["category"], "数码")
+        finally:
+            bili.CONFIRM = original_confirm
+
+
+class MarkdownTest(unittest.TestCase):
+    def test_code_block_renders_to_pre_code(self):
+        html = bili.md_to_html('# T\n\n```json\n{"a": 1}\n```\n')
+        self.assertIn("<pre><code>", html)
+        self.assertIn("&quot;a&quot;", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

用户在 studio 里让 agent 把一篇文档发到 B站专栏。文章确实发出去了，图片、Markdown→HTML 转换都正常，但返回的链接是 404，分类也错了。排查发现三个真 bug。

### 1. 返回的 URL 是草稿 id，不是文章 id（每个链接都 404）

`publish` 成功后返回 `https://www.bilibili.com/read/cv{draft_aid}`。但 `draft_aid`（如 `373282`）和已发布文章 id（如 `51827685`）是两个完全不同的号。

submit 响应**本来就带真 id**，只是没读：

```json
{"code":0,"data":{"aid":51827612,"state":-2,"view_url":"...","dyn_id":"..."}}
```

SKILL.md 让 agent 把返回的 `url` 记进 `publish_artifact`，所以每条产出记录都是坏链接。

### 2. 分类永远是「生活」

`category` 表单字段被硬编码成 `"0"`，`tid` 才是被当成分类传的 —— 但实际控制分类的是 `category`。实测：

| 请求 | 结果分类 |
|---|---|
| `tid=17` + `category=0`（原代码） | 生活 |
| `tid=26` + `category=26` | 科技 / 数码 |

技术教程全被归到「生活」。现在加了 `--category`（默认 **数码**）和 `categories` 命令，`category` + `tid` 一起传。

### 3. submit 不等于发布 —— 会进审核队列

submit 返回 `state: -2`（待审核），URL 对所有人 404 直到审核通过。原代码直接报 `published: true`，agent 会告诉用户「已发布」并给出一个当时还是 404 的链接。现在只有 `-2` 标记 `pending_review`；`-1` 未通过 / `-3` 锁定 / `-4` 已删除 返回 `ok: false`，不会被记成已交付。新增 `status` 命令 —— 创作中心列表是唯一能看到待审/被拒文章的接口。

## 验证

在真实账号上端到端跑通（发布 → 查状态 → 清理）。测试用例覆盖每个修复，**逐个 revert 后对应测试都会失败**（mutation-tested）。全量 79 passed，ruff clean。

代码块渲染经核实**没有问题** —— B站完整保留了 `<pre><code>` 和行内 `<code>`（在真实已发布文章上验证）。

## 🤖 对抗评审

Codex 额度用尽（`You've hit your usage limit`），按协议回退到 Claude `general-purpose` 子代理。**两轮，共 16 条 RISK，全部修复，无一驳回。**

### 第一轮（10 条）

| # | 发现 | 处理 |
|---|---|---|
| 1 | 所有负数 state 都报成「待审核」，包括 `-1` 未通过 —— 被拒文章会被记成 delivered，链接永久 404 | 已修：仅 `-2` 是 pending，其余 `ok:false` |
| 2 | 非 int state 触发 TypeError，**且发生在写入之后** —— 崩溃会丢掉刚发布文章的唯一 id | 已修 |
| 3 | `cvid = data.get("aid") or aid` 悄悄重新引入本 PR 要修的 404 bug，**且有测试把它固化成正确行为** | 已修：`id_unverified` 标记 |
| 4 | `--category` 校验太晚 —— dry-run 跳过校验，且 `--confirm` 时在 `rehost_images` **之后**才报错，拼错分类会白白往账号上传一批图再中止 | 已修：提到 dry-run 前 |
| 5 | `status` 对无 id 的行输出 `cvNone` 链接 | 已修 |
| 6 | SKILL.md 让 agent 报告自动选中的分类，但 CLI 从不返回它 | 已修：返回 `category` + `category_id` |
| 7 | SKILL.md 自相矛盾：既说「不是 live」又让记成 `delivered` | 已修：pending → `draft` |
| 8 | 新增的 `status` / `categories` 零测试覆盖 | 已修：+7 个测试 |
| 9 | `categories` 按 id 去重，把 `生活`/`科技`/`tech` 这些别名吞了 | 已修 |
| 10 | 删掉了「Default to `--draft-only`」这条护栏 | 已修：恢复并强化理由 |

### 第二轮（6 条，都是第一轮修复引入的新问题）

| # | 发现 | 处理 |
|---|---|---|
| 11 | `pending_review` 的 note 覆盖掉 `id_unverified` 的警告 —— 而 submit **总是**返回 `-2`，这个组合是必然发生的 | 已修：note 改为累加 |
| 12 | `id`/`url` 仍然回落到 draft aid，与同一 commit 修好的 `cmd_status` 行为不一致 | 已修：`url: null` |
| 13 | 非 int state 被静默吞掉 → 待审文章报成完全发布（正是修复 #1 要消灭的失效模式），且测试固化了它 | 已修：`int()` 强转 + `state_unknown` |
| 14 | `state != 0` 把 `1`（也是已发布）当异常 | 已修：`not in (0, 1)` |
| 15 | dry-run 显示 `26` 而非 `数码` —— 而 dry-run 正是用户批准写操作前看的那一屏 | 已修 |
| 16 | `state_desc` 对缺失 state 输出字面量 `"None"` | 已修 |

评审员另确认无误：cookie 作用域未改动、表单 `urlencode` 无注入面、`chosen_tid`→`chosen` 重命名三处一致、`.agents/` 与 `.github/` 镜像同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
