### PR TITLE
fix(toutiao): 修复 <img> 偏移错位与丢失的兜底检查

### DIFF
--- a/skills/toutiao/scripts/toutiao.py
+++ b/skills/toutiao/scripts/toutiao.py
@@ -334,17 +334,23 @@ class _ImgFinder(_HTMLParser):
         text = self.get_starttag_text() or ""
         line, col = self.getpos()
         start = self._line_starts[line - 1] + col
+        # If the computed offset doesn't land on the tag we were handed, the
+        # line mapping is wrong and splicing would corrupt the article. Refuse
+        # rather than write a mangled body.
+        if self._html[start:start + len(text)] != text:
+            raise ValueError(f"offset mismatch at line {line} col {col}")
         self.spans.append((start, start + len(text), attrs))
 
     handle_starttag = _record
     handle_startendtag = _record
 
     def find(self, html):
-        # getpos() is (line, col); precompute line offsets to map to an index.
-        self._line_starts, pos = [0], 0
-        for ln in html.splitlines(keepends=True):
-            pos += len(ln)
-            self._line_starts.append(pos)
+        # getpos() is (line, col); map that to an index. HTMLParser counts
+        # lines with rawdata.count("\n"), so index on "\n" ONLY — str.splitlines
+        # also breaks on \r, \v, \f, \x1c-\x1e, \x85,  ,  , and every
+        # such character would shift every subsequent offset.
+        self._html = html
+        self._line_starts = [0] + [mt.end() for mt in re.finditer("\n", html)]
         self.feed(html)
         self.close()
         return self.spans
@@ -490,6 +496,22 @@ def rehost_images(jar, html, drop_failed=False):
             failures.append(f"{src[:80]} ({e})")
     out.append(html[cursor:])
     result = "".join(out)
+    # Backstop: the tokenizer silently sees nothing inside an unterminated tag
+    # or an unterminated <script>/<style>/<textarea>/<title>, so an external
+    # <img> there would ship verbatim and 头条 rejects the whole article (7115).
+    # Our own rewrites all carry web_uri=, so any other <img left in the output
+    # is one we never processed. Fatal even under drop_failed — a tag the
+    # parser cannot see is also one we cannot remove.
+    unseen = [seg[:120] for seg in re.split(r"(?i)(?=<img\b)", result)[1:]
+              if 'web_uri="' not in seg.split(">", 1)[0][:2000]]
+    if unseen:
+        die("the article contains an <img> tag this skill could not parse, so "
+            "it can neither be uploaded to 头条 nor safely removed — and 头条 "
+            "rejects any article with an external image. Nothing was "
+            "published:\n  - " + "\n  - ".join(unseen)
+            + "\nUsually an unterminated tag, or an unclosed <script>/<style> "
+              "earlier in the body hiding it from the parser. "
+              "--drop-failed-images does NOT bypass this.")
     if failures and not drop_failed:
         die("could not upload these images to 头条, and 头条 rejects any article "
             "with an external image, so nothing was published:\n  - "


### PR DESCRIPTION
接 #716 合并后的第 7 轮对抗评审，发现两个真实缺陷。两个都会导致**静默的数据破坏或外链图残留**。

## 缺陷 1：偏移错位破坏正文（我在 #716 引入的）

`_line_starts` 用 `str.splitlines()` 构建，而它会在 **8 个 `HTMLParser` 不算作换行的分隔符**上切分：`\r`、`\v`、`\f`、`\x1c`–`\x1e`、`\x85`、U+2028、U+2029。

`HTMLParser.updatepos` 用的是 `rawdata.count("\n")`。两者不一致 ⇒ `<img>` 之前只要出现任意一个这种字符，**之后所有偏移全部错位**，拼接就切在错误位置：

- **删掉正文**
- **同时把外链 `<img>` 原样留下** → 头条 7115 拒整篇

孤立 `\r` 并不罕见：一个包含 CR 行尾示例输出的代码块就会产生，直通 HTML 里也可能带。

实测复现（markdown 路径）：

```python
md = "```\nline1\rline2\r...\rline6\n```\n\n![pic](http://evil.example/x.png)\n\nOutro"
```
→ 真实 `<img>` 起点 60，算出来的 span 是 `(17, 64)`，输出变成：
```
<pre><code>line1\r<img src="CDN"...> src="http://evil.example/x.png" alt="pic">\n<p>Outro</p>
```
代码块被摧毁，**外链 URL 原样幸存**。另一形态（直通 HTML + 孤立 CR）直接删掉整个 `<p>KEEPME</p>`。

**修法**：只按 `\n` 建索引，与 `HTMLParser.updatepos` 完全一致；另加一道断言 —— 算出的偏移必须真的落在解析器交给我们的那个标签上，不一致就 `die()`。错位是静默的，此前没有任何检查能发现它。

## 缺陷 2：随正则一起删掉的兜底检查

#716 用 `HTMLParser` 替换正则时，把旧的 `residue` 兜底也一并删了。但 tokenizer 对下面两种输入**完全看不见**：

| 输入 | 后果 |
|---|---|
| `<p>a</p><img src="http://evil/x.png"` （未闭合，截断粘贴） | `spans == []`，原样返回，外链 URL 进入头条 `content` |
| 未闭合的 `<script>`/`<style>`/`<textarea>`/`<title>` | **它之后的所有 `<img>` 全部隐形**，多张外链图一次性发出去 |

html5lib 交叉验证**不能**排除这一类 —— 我们的不变量是「发布出去的字节串里不能有外链图 URL」，而不是「外链图不会被渲染」。头条的 7115 检查是在字符串上跑的。

**修法**：拼接后做一次廉价扫描。我们自己重写的标签一定带 `web_uri=`，所以输出里任何其它 `<img` 都是没处理过的 → `die()`。即使加了 `--drop-failed-images` 也不放行（解析器看不见的标签同样删不干净）。

## 验证

- 四种形态修复前全部复现、修复后全部消除
- **正常路径零误伤**：正常文章 / skip-list 已托管图 / 多图 / CRLF / 中文 emoji / 无图正文
- **3 万例差分 fuzz**，随机注入全部 8 种分隔符字符，用 html5lib（严格 HTML5 tokenizer）解析比对：
  - 可见正文丢失 **0**
  - 输出中 src 非头条域的 `<img>` 标签 **0**

> 关于 fuzz 断言：我第一版断言用裸子串匹配 `'e.com' in result`，报了 59 例"残留"。查证后是**误报** —— 那些字节按 HTML5 规范是纯文本（在未闭合属性内部），不是图片标签，头条不会当图片处理。改成解析后检查每个 `<img>` 标签的 `src` 才是正确的不变量。

## 🤖 对抗评审

第 7 轮评审员（Claude subagent）复核 #716 的 HTMLParser 改写，本 PR 即是对其两条 `RISK` 的修复。它同时**确认无缺陷**的部分：

- CRLF、CJK/emoji/星平面字符的偏移精确；`<img>` 位于文首/文尾均正确
- `<script>`/`<style>`/`<textarea>`/`<title>`/注释/CDATA 在**正常闭合**时被跳过是正确的（浏览器同样不渲染其中的 `<img>`）
- 首个 `src` 优先与浏览器一致；`srcset`/`data-src` 无回归
- alt 转义往返双向正确，既不双重转义也不转义不足（`AT&T`、`&copy;`、`&#39;` 等均验证）
- 与 `nonfatal` 传播、`_resolve_url`、`--drop-failed-images` 无相互作用问题
- `HTMLParser` 在畸形输入上不抛异常（退化为不产出），`try/except → die()` 的取舍合理

累计 7 轮评审、2 个模型、18 个真实缺陷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)