### PR TITLE
fix(reddit): a created comment must never be reported as an unknown outcome

### DIFF
--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -52,7 +52,11 @@ R="${SKILL_DIR:-}/scripts/reddit.py"; [ -f "$R" ] || R=$(find /tmp -maxdepth 8 -
 [ -f "$R" ] || { echo "reddit script not found (SKILL_DIR=$SKILL_DIR)" >&2; exit 1; }
 python3 "$R" whoami
 python3 "$R" submissions --limit 10
+python3 "$R" comments --limit 10
 ```
+
+If a `comment` write ever reports an unknown outcome, run `comments` to check
+whether it actually landed **before** considering any retry.
 
 ## Find threads and check the rules
 

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -474,6 +474,26 @@ class RedditClient:
         return {"ok": True, "posted": True, "id": post.get("id"), "name": post.get("name"), "url": post_url}
 
 
+    def comments(self, limit: int) -> list[dict]:
+        """List my own recent comments — used to verify an ambiguous write."""
+        username = self.username or str(self.me().get("name") or "")
+        suffix = ".json" if self.mode == "cookie" else ""
+        payload = self.request(
+            "GET",
+            f"/user/{urllib.parse.quote(username, safe='')}/comments{suffix}",
+            query={"limit": limit, "raw_json": 1},
+        )
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), dict):
+            die("Reddit returned a malformed comments response; authenticated response content was omitted.")
+        children = payload["data"].get("children")
+        # Fail closed: a silently-empty list reads as "the write did not land"
+        # and invites the duplicate reply this command exists to prevent.
+        if not isinstance(children, list) or any(
+            not isinstance(child, dict) or not valid_comment_data(child.get("data")) for child in children
+        ):
+            die("Reddit returned a malformed comments response; authenticated response content was omitted.")
+        return [child["data"] for child in children]
+
     def search(self, *, query: str, subreddit: str = "", sort: str = "relevance", limit: int = 10, time_filter: str = "month") -> list[dict]:
         suffix = ".json" if self.mode == "cookie" else ""
         path = f"/r/{subreddit}/search{suffix}" if subreddit else f"/search{suffix}"
@@ -540,11 +560,37 @@ class RedditClient:
         created = things[0].get("data")
         if not isinstance(created, dict):
             die_unknown_comment_response()
+        comment_name = created.get("name")
+        comment_id = created.get("id")
+        if not isinstance(comment_id, str) or not comment_id:
+            # `name` is the fullname (t1_<id>), so it carries the id too.
+            comment_id = comment_name[3:] if isinstance(comment_name, str) and comment_name.startswith("t1_") else ""
+
+        # A permalink alone proves creation — accept it even without an id.
         permalink = created.get("permalink")
-        comment_url = WEB_BASE + permalink if isinstance(permalink, str) and permalink.startswith("/") else ""
-        if not comment_url:
+        if isinstance(permalink, str) and permalink.startswith("/"):
+            return {"ok": True, "commented": True, "id": comment_id or None, "name": comment_name, "url": WEB_BASE + permalink}
+
+        if not comment_id:
             die_unknown_comment_response()
-        return {"ok": True, "commented": True, "id": created.get("id"), "name": created.get("name"), "url": comment_url}
+
+        # link_id is the thread even when replying to a comment (t1_ parent).
+        link_id = created.get("link_id")
+        thread = link_id[3:] if isinstance(link_id, str) and link_id.startswith("t3_") else ""
+        if not thread and parent.startswith("t3_"):
+            thread = parent[3:]
+        if not thread:
+            # Created for sure (we hold its id) but the thread is unknown; never
+            # report this as a failed write — that is what invites a duplicate.
+            return {
+                "ok": True,
+                "commented": True,
+                "id": comment_id,
+                "name": comment_name,
+                "url": None,
+                "note": "Reddit did not return a permalink. Run `comments` to locate it; do not resend.",
+            }
+        return {"ok": True, "commented": True, "id": comment_id, "name": comment_name, "url": derive_comment_url(thread, comment_id)}
 
 
 def format_profile(data: dict, mode: str) -> dict:
@@ -584,8 +630,39 @@ def die_unknown_post_response() -> None:
     die_unknown_write_outcome("Reddit returned a malformed write response")
 
 
+COMMENT_ID_RE = re.compile(r"^[A-Za-z0-9]{2,16}$")
+
+
+def derive_comment_url(thread_id: str, comment_id: str) -> str:
+    """Build Reddit's slug-less permalink when the write response omits one."""
+    if not COMMENT_ID_RE.fullmatch(thread_id) or not COMMENT_ID_RE.fullmatch(comment_id):
+        die_unknown_comment_response()
+    return f"{WEB_BASE}/comments/{thread_id}/_/{comment_id}/"
+
+
+def valid_comment_data(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if not isinstance(item.get("id"), str) or not item["id"]:
+        return False
+    return isinstance(item.get("body"), str) and isinstance(item.get("permalink"), (str, type(None)))
+
+
 def die_unknown_comment_response() -> None:
     die_unknown_write_outcome("Reddit returned a malformed comment response", kind="comment")
+
+
+def format_comment(item: dict) -> dict:
+    permalink = item.get("permalink")
+    return {
+        "id": item.get("id"),
+        "body": str(item.get("body") or "")[:300],
+        "link_title": item.get("link_title"),
+        "subreddit": item.get("subreddit"),
+        "url": WEB_BASE + permalink if isinstance(permalink, str) and permalink.startswith("/") else None,
+        "score": item.get("score"),
+        "created_utc": item.get("created_utc"),
+    }
 
 
 def format_search_hit(item: dict) -> dict:
@@ -674,6 +751,9 @@ def build_parser() -> argparse.ArgumentParser:
     link_post.add_argument("--title", required=True)
     link_post.add_argument("--url", required=True)
 
+    my_comments = commands.add_parser("comments", help="list my recent comments (verify an ambiguous write)")
+    my_comments.add_argument("--limit", type=positive_limit, default=10)
+
     search = commands.add_parser("search", help="search public posts to find threads worth replying to")
     search.add_argument("--query", "-q", required=True)
     search.add_argument("--subreddit", "-r", default="")
@@ -708,6 +788,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.command == "submissions":
         items = client.submissions(args.limit)
         output({"auth_mode": client.mode, "count": len(items), "submissions": [format_submission(item) for item in items]})
+        return
+    if args.command == "comments":
+        items = client.comments(args.limit)
+        output({"auth_mode": client.mode, "count": len(items), "comments": [format_comment(item) for item in items]})
         return
     if args.command == "search":
         hits = client.search(

--- a/skills/reddit/tests/test_reddit.py
+++ b/skills/reddit/tests/test_reddit.py
@@ -468,7 +468,8 @@ class RedditSkillTests(unittest.TestCase):
             {"json": {"errors": [["RATELIMIT", "you are doing that too much csrf-secret", None]]}},
             {"json": {"errors": []}},
             {"json": {"errors": [], "data": {"things": []}}},
-            {"json": {"errors": [], "data": {"things": [{"data": {"id": "c1"}}]}}},
+            # No id at all -> genuinely unknown outcome.
+            {"json": {"errors": [], "data": {"things": [{"data": {"body": "x"}}]}}},
         ]
         for payload in payloads:
             stream = io.StringIO()
@@ -477,6 +478,136 @@ class RedditSkillTests(unittest.TestCase):
             ), self.assertRaises(SystemExit), redirect_stdout(stream):
                 client.comment(parent="t3_post1", body="Body")
             self.assertNotIn("csrf-secret", stream.getvalue())
+
+    def test_comment_without_permalink_is_a_success_not_an_unknown_outcome(self):
+        """Cookie mode often omits permalink; an id means Reddit created the comment."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        payload = {
+            "json": {"errors": [], "data": {"things": [{"data": {"id": "nabc123", "name": "t1_nabc123"}}]}}
+        }
+        with patch.object(client, "request", return_value=payload):
+            result = client.comment(parent="t3_1v711cj", body="Looks good")
+
+        self.assertTrue(result["commented"])
+        self.assertEqual("nabc123", result["id"])
+        self.assertEqual("https://www.reddit.com/comments/1v711cj/_/nabc123/", result["url"])
+
+    def test_comments_fails_closed_on_drifted_shape(self):
+        """A silently-empty list would read as 'the write did not land' -> duplicate reply."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.username = "tester"
+        drifted = {"data": {"children": [{"kind": "t1", "comment": {"id": "c1", "body": "x"}}]}}
+        stream = io.StringIO()
+        with patch.object(client, "request", return_value=drifted), self.assertRaises(
+            SystemExit
+        ), redirect_stdout(stream):
+            client.comments(10)
+        self.assertIn("malformed comments response", stream.getvalue())
+
+    def test_comments_accepts_documented_shape_and_survives_odd_body(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.username = "tester"
+        payload = {
+            "data": {
+                "children": [
+                    {
+                        "kind": "t1",
+                        "data": {
+                            "id": "c1",
+                            "body": "Looks good",
+                            "permalink": "/r/test/comments/p1/t/c1/",
+                            "link_title": "Test",
+                            "subreddit": "test",
+                        },
+                    }
+                ]
+            }
+        }
+        with patch.object(client, "request", return_value=payload):
+            items = client.comments(10)
+        self.assertEqual(1, len(items))
+        formatted = reddit.format_comment(items[0])
+        self.assertEqual("Looks good", formatted["body"])
+        self.assertEqual("https://www.reddit.com/r/test/comments/p1/t/c1/", formatted["url"])
+
+    def test_reply_to_a_comment_derives_a_real_permalink_from_link_id(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        payload = {
+            "json": {
+                "errors": [],
+                "data": {"things": [{"data": {"id": "nc2", "name": "t1_nc2", "link_id": "t3_1v711cj"}}]},
+            }
+        }
+        with patch.object(client, "request", return_value=payload):
+            result = client.comment(parent="t1_parent1", body="Reply")
+        self.assertEqual("https://www.reddit.com/comments/1v711cj/_/nc2/", result["url"])
+
+    def test_derive_comment_url_rejects_ids_that_could_escape_reddit(self):
+        for thread, comment_id in [
+            ("abc123", "x/../../../@evil.example.com"),
+            ("../../evil", "c1"),
+            ("abc123", ""),
+        ]:
+            stream = io.StringIO()
+            with self.subTest(thread=thread, comment_id=comment_id), self.assertRaises(
+                SystemExit
+            ), redirect_stdout(stream):
+                reddit.derive_comment_url(thread, comment_id)
+
+    def test_comment_accepts_permalink_only_and_name_only_responses(self):
+        """Proof of creation in any form must never be reported as unknown."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+
+        # permalink but no id
+        payload = {"json": {"errors": [], "data": {"things": [
+            {"data": {"name": "t1_nabc12", "permalink": "/r/test/comments/1v711cj/slug/nabc12/"}}]}}}
+        with patch.object(client, "request", return_value=payload):
+            result = client.comment(parent="t3_1v711cj", body="B")
+        self.assertTrue(result["commented"])
+        self.assertEqual("https://www.reddit.com/r/test/comments/1v711cj/slug/nabc12/", result["url"])
+
+        # name but no id and no permalink
+        payload = {"json": {"errors": [], "data": {"things": [
+            {"data": {"name": "t1_nabc12", "link_id": "t3_1v711cj"}}]}}}
+        with patch.object(client, "request", return_value=payload):
+            result = client.comment(parent="t1_x1", body="B")
+        self.assertTrue(result["commented"])
+        self.assertEqual("https://www.reddit.com/comments/1v711cj/_/nabc12/", result["url"])
+
+    def test_comment_with_unknown_thread_still_reports_success(self):
+        """We hold the id, so it was created; a 'failure' here would invite a duplicate."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        payload = {"json": {"errors": [], "data": {"things": [{"data": {"id": "nc9", "name": "t1_nc9"}}]}}}
+        with patch.object(client, "request", return_value=payload):
+            result = client.comment(parent="t1_parent1", body="Reply")
+        self.assertTrue(result["commented"])
+        self.assertEqual("nc9", result["id"])
+        self.assertIsNone(result["url"])
+        self.assertIn("do not resend", result["note"])
+
+    def test_valid_comment_data_rejects_bad_types_but_allows_null_permalink(self):
+        self.assertTrue(reddit.valid_comment_data({"id": "c1", "body": "x", "permalink": None}))
+        self.assertTrue(reddit.valid_comment_data({"id": "c1", "body": "[deleted]"}))
+        self.assertFalse(reddit.valid_comment_data({"id": "c1", "body": {"nested": 1}}))
+        self.assertFalse(reddit.valid_comment_data({"id": "c1", "body": 123}))
+        self.assertFalse(reddit.valid_comment_data({"id": "", "body": "x"}))
+        self.assertFalse(reddit.valid_comment_data({"body": "x"}))
+
+    def test_comments_listing_survives_a_null_permalink_sibling(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.username = "tester"
+        payload = {"data": {"children": [
+            {"data": {"id": "c1", "body": "Looks good", "permalink": "/r/test/comments/p1/t/c1/"}},
+            {"data": {"id": "c2", "body": "older", "permalink": None}},
+        ]}}
+        with patch.object(client, "request", return_value=payload):
+            items = client.comments(10)
+        self.assertEqual(2, len(items))
+        self.assertIsNone(reddit.format_comment(items[1])["url"])
 
     def test_comment_body_limits_are_enforced(self):
         for body in ["", "   ", "x" * 10_001]:


### PR DESCRIPTION
## 起因：一次真实写入失败

在 `r/test` 实发一条评论时，脚本返回：

```json
{"error": "Reddit returned a malformed comment response; ... the comment outcome is unknown.
Open the parent thread and look for your reply before taking any further action and do not replay automatically."}
```

离线复现后确认**这是本 skill 的 bug，不是 Reddit 的问题**：cookie 模式下 `/api/comment` 返回了 `id` + `name`（评论**确实已创建**），但**没有 `permalink` 字段**，而 `comment()` 把「没有 permalink」当成了畸形响应。

这是这个命令最坏的失败模式 —— 它会诱导人去手动重试，而重试正好制造重复评论，也就是 Reddit 判定垃圾的特征。

## 改动

**1. 有创建证据就算成功。** 拿到 `permalink` 直接用；只有 `id`/`name` 时，从响应的 `link_id` 解析出所在帖子，拼出 Reddit 规范的 slug-less 永久链接 `/comments/<thread>/_/<comment_id>/`。连帖子都无法确定时，仍然返回 `commented: true` 但 `url: null` 并附一句「用 `comments` 找它，不要重发」—— **绝不把一次成功的写入报成失败**。

**2. 新增 `comments` 只读命令。** 此前根本无法验证一次结果未知的写入 —— `submissions` 只列帖子不列评论。现在可以先查再决定。SKILL.md 同步写明：写入报未知时，先跑 `comments` 确认，再考虑是否重试。

## 测试

`30 → 38`。并用变异测试验证新断言非空跑（此前 3 个变异体能在 34 个测试下存活，现已全部被捕获）。

## 🤖 对抗评审

**Codex 用量耗尽（限制到 8/2），本轮由 Claude general-purpose subagent 承担，两轮收敛，共 8 条 RISK 全部修复。**

**Round 1（4 条）**
| RISK | 修复 |
|---|---|
| `comments()` **fail-open**：drifted 响应被静默丢弃 → `count: 0` 看着像"没发出去" → 正好触发重复重试 | 改为 fail-closed，新增 `valid_comment_data()`，对齐既有 `submissions()` 的严格度 |
| `format_comment()` 遇非字符串 `body` 抛 TypeError，裸 traceback 逃逸出 JSON 契约 | 校验器强制 `body` 为 str + `str()` 防御 |
| `derive_comment_url()` 的 `t1_` 分支返回 `/api/info?id=` —— 那是 JSON 接口不是可点链接，却会被 `publish_artifact` 当作交付物 URL 记进 My Outputs | 改为从 `link_id` 解析真实帖子，两个分支统一产出规范永久链接 |
| URL 插值无字符校验，畸变 id 可逃逸到站外（`x/../../../@evil.example.com`） | 新增 `COMMENT_ID_RE` 同时校验 thread id 与 comment id |

**Round 2（4 条，其中 1 条是我自己引入的回归）**
| RISK | 修复 |
|---|---|
| **⚠️ 回归**：把 `id` 检查提到 permalink 分支之前，导致「有 permalink 但无 id」的响应**从成功变成了未知** —— 正是本 PR 要消灭的那类 bug | permalink 分支优先返回成功；`id` 缺失时从 `name`（即 `t1_<id>`）回退取出 |
| `t1_` 回复若无 permalink 且无 `link_id` 直接判死，而同形状的 `t3_` 却成功 | 改为返回 `commented: true` + `url: null` + 提示，不再报失败 |
| `valid_comment_data` 拒绝显式 `"permalink": null`，且 fail-closed 是全有全无 —— **一条无关的旧评论就能让整个验证列表报错**，等于从反方向重新制造"无法验证 → 重试 → 重复" | 允许 `permalink` 为 `None`（`format_comment` 本就能处理） |
| body/id 类型校验**零测试覆盖**（3 个变异体存活） | 补 4 组测试，变异测试复验全部捕获 |

评审同时确认：**不存在任何可产出非 reddit.com 域名 URL 的路径**（三处 URL 构造均以 `WEB_BASE` + `/` 开头的字符串拼接，`urlsplit` 验证 hostname 恒为 `www.reddit.com`）。

## 待办（不阻塞本 PR）

OAuth 模式下 `/user/<name>/comments` 可能需要 `history` scope，而 SKILL.md 记录的是 `identity read submit`。当前生产 OAuth 未配置，走的是 cookie 路径，因此不影响；若将来启用 OAuth 需实测确认。
