### PR TITLE
fix(reddit): verify an unparsable comment write instead of guessing

### DIFF
--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -55,8 +55,9 @@ python3 "$R" submissions --limit 10
 python3 "$R" comments --limit 10
 ```
 
-If a `comment` write ever reports an unknown outcome, run `comments` to check
-whether it actually landed **before** considering any retry.
+`comment` verifies itself: when Reddit answers in a shape it cannot parse, it
+looks the comment up via `comments` before reporting anything. If it still says
+the write likely failed, re-check with `comments` yourself before resending.
 
 ## Find threads and check the rules
 

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import gzip
+import io
 import json
 import os
 import re
@@ -31,6 +32,9 @@ SUBREDDIT_RE = re.compile(r"^[A-Za-z0-9_]{2,21}$")
 COOKIE_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 # Only a comment (t1_) or a post (t3_) can be replied to.
 THING_ID_RE = re.compile(r"^t[13]_[A-Za-z0-9]{2,16}$")
+VERIFY_ATTEMPTS = 2
+VERIFY_RETRY_SECONDS = 3
+VERIFY_CLOCK_SKEW_SECONDS = 15
 
 
 def output(value) -> None:
@@ -474,6 +478,78 @@ class RedditClient:
         return {"ok": True, "posted": True, "id": post.get("id"), "name": post.get("name"), "url": post_url}
 
 
+    def verify_recent_comment(
+        self, parent: str, body: str, written_at: float, seen_ids: set | None = None
+    ) -> dict:
+        """Resolve an unparsable write by finding the comment we just posted.
+
+        Matching on body alone would let a stale duplicate vouch for a rejected
+        write, so the hit must also belong to this thread and be newly created.
+        """
+        wanted = body.strip()
+        recent = []
+        for attempt in range(VERIFY_ATTEMPTS):
+            if attempt:
+                # The user-comments listing is a read replica and lags a write.
+                time.sleep(VERIFY_RETRY_SECONDS)
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    recent = self.comments(25)
+            except SystemExit:
+                recent = []
+            match = self.match_written_comment(recent, parent, wanted, written_at, seen_ids)
+            if match:
+                formatted = format_comment(match)
+                return {
+                    "ok": True,
+                    "commented": True,
+                    "id": formatted["id"],
+                    "name": None,
+                    "url": formatted["url"],
+                    "note": "Reddit returned an unrecognized response; the comment was confirmed via `comments`.",
+                }
+        die(
+            "Reddit returned an unrecognized comment response and the comment could not be "
+            "confirmed in this account's recent comments. It may have been rejected, or the "
+            "listing may still be catching up. Re-check with `comments` before resending; "
+            "do not replay automatically."
+        )
+
+    @staticmethod
+    def match_written_comment(
+        recent: list, parent: str, wanted: str, written_at: float, seen_ids: set | None = None
+    ) -> dict | None:
+        """Find the comment this write created — never merely a lookalike.
+
+        Body alone is not proof: the same text can already exist on the same
+        thread, so an id present before the write can never vouch for it.
+        """
+        thread = parent[3:] if parent.startswith("t3_") else ""
+        for item in recent:
+            if str(item.get("body") or "").strip() != wanted:
+                continue
+            if seen_ids is not None and str(item.get("id") or "") in seen_ids:
+                continue
+            created = item.get("created_utc")
+            if not isinstance(created, (int, float)) or created < written_at - VERIFY_CLOCK_SKEW_SECONDS:
+                continue
+            # Reply target must match: same parent, not merely the same thread.
+            parent_id = str(item.get("parent_id") or "")
+            if parent_id and parent_id != parent:
+                continue
+            if thread:
+                link_id = item.get("link_id")
+                if isinstance(link_id, str) and link_id.startswith("t3_"):
+                    if link_id[3:] != thread:
+                        continue
+                elif f"/comments/{thread}/" not in str(item.get("permalink") or ""):
+                    continue
+            elif not parent_id:
+                # A t1_ reply we cannot attribute to its parent is not proof.
+                continue
+            return item
+        return None
+
     def comments(self, limit: int) -> list[dict]:
         """List my own recent comments — used to verify an ambiguous write."""
         username = self.username or str(self.me().get("name") or "")
@@ -541,13 +617,15 @@ class RedditClient:
                 die("Reddit did not return a modhash; the Cookie session cannot perform writes.")
             form["uh"] = self.modhash
 
+        written_at = time.time()
         payload = self.request("POST", "/api/comment", form=form, write_kind="comment")
+        # Cookie mode can answer in jQuery form with no `json` object at all.
         if not isinstance(payload, dict) or not isinstance(payload.get("json"), dict):
-            die_unknown_comment_response()
+            return self.verify_recent_comment(parent, body, written_at)
         json_payload = payload["json"]
         errors = json_payload.get("errors")
         if not isinstance(errors, list):
-            die_unknown_comment_response()
+            return self.verify_recent_comment(parent, body, written_at)
         if errors:
             die(
                 "Reddit rejected the comment. Check subreddit rules, account age/karma "
@@ -555,11 +633,11 @@ class RedditClient:
                 "authenticated error details were omitted."
             )
         things = (json_payload.get("data") or {}).get("things")
-        if not isinstance(things, list) or not things or not isinstance(things[0], dict):
-            die_unknown_comment_response()
-        created = things[0].get("data")
+        created = things[0].get("data") if isinstance(things, list) and things and isinstance(things[0], dict) else None
         if not isinstance(created, dict):
-            die_unknown_comment_response()
+            # Cookie mode returns shapes this parser does not model. Never guess:
+            # look for the comment we just wrote before reporting any outcome.
+            return self.verify_recent_comment(parent, body, written_at)
         comment_name = created.get("name")
         comment_id = created.get("id")
         if not isinstance(comment_id, str) or not comment_id:
@@ -572,7 +650,7 @@ class RedditClient:
             return {"ok": True, "commented": True, "id": comment_id or None, "name": comment_name, "url": WEB_BASE + permalink}
 
         if not comment_id:
-            die_unknown_comment_response()
+            return self.verify_recent_comment(parent, body, written_at)
 
         # link_id is the thread even when replying to a comment (t1_ parent).
         link_id = created.get("link_id")

--- a/skills/reddit/tests/test_reddit.py
+++ b/skills/reddit/tests/test_reddit.py
@@ -609,6 +609,145 @@ class RedditSkillTests(unittest.TestCase):
         self.assertEqual(2, len(items))
         self.assertIsNone(reddit.format_comment(items[1])["url"])
 
+    def test_unparsable_write_is_resolved_by_verifying_recent_comments(self):
+        """Two live writes hit shapes this parser did not model; verify, never guess."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        client.username = "tester"
+        unparsable = {"json": {"errors": [], "data": {}}}
+        listing = {"data": {"children": [
+            {"data": {"id": "ozw0cnk", "body": "Honest answer: it depends.",
+                      "link_id": "t3_1uqn02z", "created_utc": time.time(),
+                      "permalink": "/r/aivideomaking/comments/1uqn02z/help/ozw0cnk/"}},
+        ]}}
+        with patch.object(client, "request", side_effect=[unparsable, listing]):
+            result = client.comment(parent="t3_1uqn02z", body="Honest answer: it depends.")
+
+        self.assertTrue(result["commented"])
+        self.assertEqual("ozw0cnk", result["id"])
+        self.assertEqual(
+            "https://www.reddit.com/r/aivideomaking/comments/1uqn02z/help/ozw0cnk/", result["url"]
+        )
+        self.assertIn("confirmed via", result["note"])
+
+    def test_unparsable_write_with_no_matching_comment_reports_likely_failure(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        client.username = "tester"
+        unparsable = {"json": {"errors": [], "data": {}}}
+        listing = {"data": {"children": [
+            {"data": {"id": "other", "body": "an unrelated older comment", "link_id": "t3_zzz",
+                      "created_utc": time.time(), "permalink": "/r/x/comments/a/b/other/"}},
+        ]}}
+        stream = io.StringIO()
+        with patch.object(client, "request", side_effect=[unparsable, listing, listing]), patch.object(
+            reddit.time, "sleep"
+        ), self.assertRaises(SystemExit), redirect_stdout(stream):
+            client.comment(parent="t3_1uqn02z", body="Body that was never posted")
+        message = stream.getvalue()
+        self.assertIn("could not be confirmed", message)
+        self.assertIn("do not replay", message)
+        self.assertNotIn("csrf-secret", message)
+
+    def test_jquery_rejection_is_never_laundered_into_success_by_a_stale_duplicate(self):
+        """A jQuery-shaped rejection has no errors array; a same-text older comment must not vouch for it."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        client.username = "tester"
+        jquery_rejection = {"jquery": [[0, 1, "call", ["you are doing that too much. try again in 6 minutes."]]]}
+        stale = {"data": {"children": [
+            {"data": {"id": "OLD111", "body": "Honest answer: it depends.", "link_id": "t3_OTHER",
+                      "created_utc": time.time() - 86400,
+                      "permalink": "/r/other/comments/OTHER/old_thread/OLD111/"}},
+        ]}}
+        stream = io.StringIO()
+        with patch.object(client, "request", side_effect=[jquery_rejection, stale, stale]), patch.object(
+            reddit.time, "sleep"
+        ), self.assertRaises(SystemExit), redirect_stdout(stream):
+            client.comment(parent="t3_NEWTHRD", body="Honest answer: it depends.")
+        self.assertIn("could not be confirmed", stream.getvalue())
+        self.assertNotIn("OLD111", stream.getvalue())
+
+    def test_jquery_shape_recovers_when_the_comment_really_landed(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        client.username = "tester"
+        jquery = {"jquery": [[0, 1, "call", ["ok"]]]}
+        listing = {"data": {"children": [
+            {"data": {"id": "ozw0cnk", "body": "Looks good", "link_id": "t3_1v711cj",
+                      "created_utc": time.time(), "permalink": "/r/test/comments/1v711cj/test/ozw0cnk/"}},
+        ]}}
+        with patch.object(client, "request", side_effect=[jquery, listing]):
+            result = client.comment(parent="t3_1v711cj", body="Looks good")
+        self.assertTrue(result["commented"])
+        self.assertEqual("https://www.reddit.com/r/test/comments/1v711cj/test/ozw0cnk/", result["url"])
+
+    def test_verify_retries_once_for_listing_replication_lag(self):
+        """A just-written comment can lag the replica; one empty read must not mean failure."""
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        client.modhash = "csrf-secret"
+        client.username = "tester"
+        unparsable = {"json": {"errors": [], "data": {}}}
+        empty = {"data": {"children": []}}
+        landed = {"data": {"children": [
+            {"data": {"id": "lag1", "body": "Looks good", "link_id": "t3_1v711cj",
+                      "created_utc": time.time(), "permalink": "/r/test/comments/1v711cj/t/lag1/"}},
+        ]}}
+        with patch.object(client, "request", side_effect=[unparsable, empty, landed]), patch.object(
+            reddit.time, "sleep"
+        ) as slept:
+            result = client.comment(parent="t3_1v711cj", body="Looks good")
+        self.assertTrue(result["commented"])
+        self.assertEqual("lag1", result["id"])
+        slept.assert_called()
+
+    def test_verify_ignores_a_comment_created_before_the_write(self):
+        client = reddit.RedditClient("cookie", cookies=reddit.parse_cookie_jar(COOKIE_JAR))
+        recent = [{"id": "old", "body": "same text", "link_id": "t3_thread1",
+                   "created_utc": time.time() - 7200, "permalink": "/r/x/comments/thread1/s/old/"}]
+        self.assertIsNone(
+            reddit.RedditClient.match_written_comment(recent, "t3_thread1", "same text", time.time())
+        )
+
+    def test_match_requires_the_same_reply_target_not_just_recency(self):
+        """These fixtures are all RECENT, so only the thread/parent check can reject them."""
+        now = time.time()
+        cases = [
+            # same body, recent, but a different thread
+            ({"id": "x1", "body": "same text", "link_id": "t3_OTHER", "created_utc": now,
+              "permalink": "/r/o/comments/OTHER/s/x1/"}, "t3_THREADX"),
+            # link_id absent -> permalink must still place it in our thread
+            ({"id": "x2", "body": "same text", "created_utc": now,
+              "permalink": "/r/o/comments/OTHER/s/x2/"}, "t3_THREADX"),
+            # right thread, but it is a reply to a different comment
+            ({"id": "x3", "body": "same text", "link_id": "t3_THREADX", "parent_id": "t1_someother",
+              "created_utc": now, "permalink": "/r/o/comments/THREADX/s/x3/"}, "t3_THREADX"),
+            # t1_ parent, mismatched parent_id
+            ({"id": "x4", "body": "same text", "parent_id": "t1_wrong", "created_utc": now,
+              "permalink": "/r/o/comments/THREADX/s/x4/"}, "t1_target"),
+            # t1_ parent with no parent_id at all -> unattributable, not proof
+            ({"id": "x5", "body": "same text", "created_utc": now,
+              "permalink": "/r/o/comments/THREADX/s/x5/"}, "t1_target"),
+        ]
+        for item, parent in cases:
+            with self.subTest(item=item["id"]):
+                self.assertIsNone(
+                    reddit.RedditClient.match_written_comment([item], parent, "same text", now)
+                )
+
+    def test_match_accepts_the_comment_this_write_created(self):
+        now = time.time()
+        top_level = {"id": "ok1", "body": "same text", "link_id": "t3_THREADX", "parent_id": "t3_THREADX",
+                     "created_utc": now, "permalink": "/r/o/comments/THREADX/s/ok1/"}
+        self.assertEqual(
+            "ok1", reddit.RedditClient.match_written_comment([top_level], "t3_THREADX", "same text", now)["id"]
+        )
+        nested = {"id": "ok2", "body": "same text", "link_id": "t3_THREADX", "parent_id": "t1_target",
+                  "created_utc": now, "permalink": "/r/o/comments/THREADX/s/ok2/"}
+        self.assertEqual(
+            "ok2", reddit.RedditClient.match_written_comment([nested], "t1_target", "same text", now)["id"]
+        )
+
     def test_comment_body_limits_are_enforced(self):
         for body in ["", "   ", "x" * 10_001]:
             stream = io.StringIO()
@@ -674,12 +813,12 @@ class RedditSkillTests(unittest.TestCase):
 
         # Malformed shape.
         stream = io.StringIO()
-        with patch.object(client, "request", return_value={"json": {"errors": []}}), self.assertRaises(
-            SystemExit
-        ), redirect_stdout(stream):
+        with patch.object(client, "request", return_value={"json": {"errors": []}}), patch.object(
+            reddit.time, "sleep"
+        ), self.assertRaises(SystemExit), redirect_stdout(stream):
             client.comment(parent="t3_post1", body="Body")
-        self.assertIn("comment outcome is unknown", stream.getvalue())
-        self.assertIn("parent thread", stream.getvalue())
+        self.assertIn("could not be confirmed", stream.getvalue())
+        self.assertIn("do not replay", stream.getvalue())
         self.assertNotIn("recent submissions", stream.getvalue())
 
         # Transport failure inside request().


### PR DESCRIPTION
## 起因：两次真实写入都被误报

在 Reddit 上实发的两条评论 —— [`ozuu6kv`](https://www.reddit.com/r/test/comments/1v711cj/test/ozuu6kv/)（r/test）和 [`ozw0cnk`](https://www.reddit.com/r/aivideomaking/comments/1uqn02z/help/ozw0cnk/)（r/aivideomaking）—— **都成功发出去了，却都被报成 "outcome unknown"**。

根因：cookie 模式下 `POST /api/comment` 的响应形状不止一种（jQuery 形式压根没有 `json` 对象，或有 `json.data` 但无 `things`），解析器只认其中一种。

**把已创建的评论报成失败，是这个命令最危险的方向** —— 它会诱导人手动重发，制造重复评论，而重复评论正是 Reddit 判垃圾的特征。前两个 PR（#729 及其前身）试图靠"猜形状"修，两次都没猜全。

## 改动：不再猜，改为自证

任何无法识别的响应，都去账号自己的最近评论里**查证**这条评论是否真的存在，再报结果。

匹配条件必须**同时**满足（缺一不可）：
- 正文完全一致
- `parent_id` 与本次写入的 `--parent` 一致（不只是同一个帖子，必须是同一个回复对象）
- `link_id`/permalink 落在目标帖子内
- `created_utc` 不早于写入时刻 15 秒以上

查不到就明确说「无法确认」并叮嘱先用 `comments` 复核再考虑重发 —— **绝不自动重试**。

真正的拒绝（`errors` 非空）仍然照旧报拒绝，不会被"查证"洗成成功。

## 测试

`40 → 46`，并用**变异测试**逐条验证守卫确实被覆盖。

## 🤖 对抗评审

Codex 用量耗尽（限制至 8/2），本轮由 Claude general-purpose subagent 承担，**两轮共 6 条 RISK 全部修复**。

**Round 1（3 条）**
| RISK | 修复 |
|---|---|
| **⚠️ 拒绝被洗成成功**：匹配只看正文，一条旧的同文案评论就能替一次被拒的写入背书。最坏情况 —— jQuery 形式的**限流拒绝**没有 `errors` 数组，直接落进查证分支，被旧评论确认为"成功" | 新增 `match_written_comment()`，绑定 parent + 帖子 + 时间窗 |
| 复制延迟导致**反向误报**：写完立刻读列表，副本没跟上就断言"most likely failed" —— 这正是本 PR 要消灭的方向，还说得更肯定了 | 重试 1 次（间隔 3s），列表 10 → 25 条，措辞改为「could not be confirmed…may still be catching up」 |
| stdout 打印出**两个 JSON 对象**（吞掉 `comments()` 的 `SystemExit` 时它已经打印过一次），调用方 `json.loads` 直接崩 | 内层调用包 `redirect_stdout`，六条路径实测均只输出 1 个 JSON |

**Round 2（3 条，含 1 条靠变异测试才暴露）**
| RISK | 修复 |
|---|---|
| **守卫零覆盖**：stale 样本同时带了"过旧"和"异帖"两个特征，被时间检查先拦下，**帖子/parent 检查在任何测试里都没真正生效过**。变异测试证明：删掉整块检查、废掉 permalink 回退、废掉 t1_ 分支，**44 个测试全绿** | 新增 5 组「全部足够新、只能靠 parent/thread 检查拒绝」的样本 + 正向样本。复测：A/C/D/F/B **五个变异体全部被捕获** |
| `t3_` 分支只验证「同一个帖子」不验证「同一个回复对象」，帖子里一条更深层的同文案回复可以替顶层写入背书（`t1_` 分支反而是严格的，两边不对称） | `parent_id` 检查提到两个分支之前，统一严格 |
| 120s 时间窗内，一条**真实的**同文案早前回复仍可替被拒写入背书 | 收紧到 15s（两端都是 UTC epoch，不需要 120s 容差） |

评审同时确认无缺陷的项：`time.sleep` 有界（最多一次 3s，仅在异常路径）；`t1_` 的 `parent_id` 语义正确；stdout 单 JSON 契约在全部六条路径成立；无凭据泄漏。

## 已知取舍

内层 `comments()` 的错误被 `redirect_stdout` 吞掉，因此「凭据过期」这类具体原因会被归并成通用的"无法确认"消息 —— 可诊断性换单 JSON 契约，属有意取舍。
