### PR TITLE
fix(skills): correct API-backed skills that no longer match the contract

### DIFF
--- a/skills/face-transform/SKILL.md
+++ b/skills/face-transform/SKILL.md
@@ -61,19 +61,25 @@ POST /face/beautify
 
 ### 3. Age Transformation
 
+`age_infos` is required — one entry per face, each carrying the target `age`.
+
 ```json
 POST /face/change-age
 {
-  "image_url": "https://example.com/portrait.jpg"
+  "image_url": "https://example.com/portrait.jpg",
+  "age_infos": [{ "age": 60 }]
 }
 ```
 
 ### 4. Gender Swap
 
+`gender_infos` is required. `gender` is `0` to turn a male face female, `1` for the reverse.
+
 ```json
 POST /face/change-gender
 {
-  "image_url": "https://example.com/portrait.jpg"
+  "image_url": "https://example.com/portrait.jpg",
+  "gender_infos": [{ "gender": 1 }]
 }
 ```
 
@@ -113,7 +119,19 @@ POST /face/detect-live
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `image_url` | Yes (most endpoints) | Source face image URL |
+| `image_url` | Yes (all except `/face/swap`) | Source face image URL |
+
+### `/face/change-age`
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `age_infos` | Yes | Array of `{ "age": <number> }`, one per face. Omitting it returns `400 age_infos is required` |
+
+### `/face/change-gender`
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `gender_infos` | Yes | Array of `{ "gender": 0\|1 }` — `0` male→female, `1` female→male. Each entry also accepts an optional `face_rect` |
 
 ### `/face/swap`
 

--- a/skills/fish-audio/SKILL.md
+++ b/skills/fish-audio/SKILL.md
@@ -36,6 +36,8 @@ Synchronous responses return a direct audio URL:
 |----------|---------|
 | `POST /fish/tts` | Text-to-speech generation |
 | `GET /fish/model` | Browse/search public Fish reference voices |
+| `GET /fish/model/{id}` | Fetch one reference voice by ID |
+| `POST /fish/model` | Clone a voice — create a reference model from an audio URL |
 | `POST /fish/tasks` | Poll async TTS jobs when `async: true` |
 
 ## Workflows
@@ -115,4 +117,4 @@ Headers:
 - Choose the Fish engine with the **`model` request header**, not a JSON `model` field.
 - Use `reference_id` from `GET /fish/model` — not `voice_id`.
 - Synchronous requests return `audio_url` directly; async jobs should be polled via `/fish/tasks`.
-- The current OpenAPI spec documents voice browsing via `GET /fish/model`; it does **not** document a voice-cloning write endpoint.
+- Voice cloning is `POST /fish/model`. `voices` must be a **single** HTTP(S) audio URL string — not an array, and not a file upload. It returns the `_id` you then pass to `/fish/tts` as `reference_id`.

--- a/skills/gpt-image-2/SKILL.md
+++ b/skills/gpt-image-2/SKILL.md
@@ -50,9 +50,11 @@ Response (both endpoints): `{"data":[{"url":"https://...png"}]}` → download `d
 |---|---|
 | 16:9 | `1792x1024` (HD), `2048x1152`, `3840x2160` (4K) |
 | 9:16 | `1024x1792`, `1152x2048`, `2160x3840` |
-| 1:1 | `1024x1024`, `2048x2048`, `4096x4096` |
+| 1:1 | `1024x1024`, `2048x2048`, `2880x2880` (4K) |
 
-(Omit `size` or use `"auto"` to let the model pick. Invalid sizes 400.)
+(Omit `size` or use `"auto"` to let the model pick. Custom sizes must have both sides a
+multiple of 16, each side ≤ 3840, total pixels between 655,360 and 8,294,400, and an aspect
+ratio ≤ 3:1 — otherwise 400.)
 
 ## Tips
 
@@ -61,4 +63,7 @@ Response (both endpoints): `{"data":[{"url":"https://...png"}]}` → download `d
 - For **character/scene consistency** across video beats, generate one hero image, then
   `edits` it per beat instead of regenerating from scratch.
 - Text in images renders legibly — good for titles/labels you don't want to overlay in HTML.
-- Both endpoints are synchronous; no `/tasks` polling.
+- `n` accepts **1–10** and you are billed **per image returned**, not per request — `n: 4`
+  costs 4×. (`response_format: "b64_json"` still requires `n: 1`.)
+- Both endpoints are synchronous by default. For long 4K jobs pass `callback_url` (optionally
+  with `async: true`) and poll `POST /openai/tasks` with `{"id": "<task_id>"}`.

--- a/skills/sora-video/SKILL.md
+++ b/skills/sora-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sora-video
-description: Generate AI videos with OpenAI Sora via AceDataCloud API. Use when creating videos from text prompts, generating videos from reference images, or using character references from existing videos. Supports text-to-video, image-to-video, and character-driven generation with multiple models and resolutions.
+description: UNAVAILABLE — the Sora endpoints now return 404 and the service is unpublished; use veo-video, kling-video or seedance-video instead. Historical reference for AceDataCloud's OpenAI Sora API. Was used when creating videos from text prompts, generating videos from reference images, or using character references from existing videos. Supports text-to-video, image-to-video, and character-driven generation with multiple models and resolutions.
 license: Apache-2.0
 metadata:
   author: acedatacloud
@@ -9,6 +9,13 @@ compatibility: Requires ACEDATACLOUD_API_TOKEN in .env file (see _shared/authent
 ---
 
 # Sora Video Generation
+
+> [!WARNING]
+> **This service is currently unavailable.** `/sora/videos` and `/sora/tasks` return
+> `404 no Route matched with those values`, and the Sora service is no longer published
+> in the API catalog. The reference below is kept for historical accuracy only — do not
+> build against it. For video generation use [veo-video](../veo-video/SKILL.md),
+> [kling-video](../kling-video/SKILL.md) or [seedance-video](../seedance-video/SKILL.md).
 
 Generate AI videos through AceDataCloud's OpenAI Sora API.
 
@@ -81,10 +88,10 @@ POST /sora/videos
 | Parameter | Values | Description |
 |-----------|--------|-------------|
 | `model` | `"sora-2"`, `"sora-2-pro"` | Model to use (required) |
-| `size` | `"small"`, `"large"` | Video resolution |
-| `duration` | `10`, `15`, `25` | Duration in seconds (25 only with sora-2-pro) |
-| `orientation` | `"landscape"` (16:9), `"portrait"` (9:16), `"square"` (1:1) | Video orientation |
-| `version` | `"1.0"` | API version — version `1.0` enables duration up to 25s, orientation, character references, and image inputs |
+| `size` | `"small"`, `"large"`, `"720x1280"`, `"1280x720"`, `"1024x1792"`, `"1792x1024"` | Video resolution |
+| `duration` | `4`, `8`, `10`, `12`, `15`, `25` | Duration in seconds (25 only with sora-2-pro; version 2.0 supports 4/8/12) |
+| `orientation` | `"landscape"` (16:9), `"portrait"` (9:16) | Video orientation — version 1.0 only |
+| `version` | `"1.0"` (default), `"2.0"` | API version. `1.0` enables duration up to 25s, `orientation`, character references and image inputs; `2.0` uses pixel `size` values and drops `orientation` |
 
 ## Gotchas
 
@@ -94,4 +101,4 @@ POST /sora/videos
 - `orientation` sets the aspect ratio — use `"portrait"` for mobile-first content
 - Task states use `"succeeded"` (not "completed") — check for this value when polling
 
-> **MCP:** `pip install mcp-sora` | Hosted: `https://sora.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)
+> **MCP:** the hosted endpoint `https://sora.mcp.acedata.cloud/mcp` currently returns 503, in line with the service being unavailable. See [all MCP servers](../_shared/mcp-servers.md)

--- a/skills/veo-video/SKILL.md
+++ b/skills/veo-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: veo-video
-description: Generate AI videos with Google Veo via AceDataCloud API. Use when creating videos from text descriptions, animating still images into video, upscaling/extending videos, re-shooting with new camera motion, or inserting/removing objects. Supports Veo 2 Fast, Veo 3, and Veo 3.1 models including fast and ingredient variants.
+description: Generate AI videos with Google Veo via AceDataCloud API. Use when creating videos from text descriptions, animating still images into video, upscaling/extending videos, re-shooting with new camera motion, or inserting/removing objects. Supports Veo 3 and Veo 3.1 models including fast and ingredient variants.
 license: Apache-2.0
 metadata:
   author: acedatacloud
@@ -37,7 +37,6 @@ curl -X POST https://api.acedata.cloud/veo/tasks \
 
 | Model | Audio | Best For |
 |-------|-------|----------|
-| `veo2-fast` | No | Fast, cost-effective generation (default) |
 | `veo3` | Yes (native) | Full audiovisual generation |
 | `veo3-fast` | Yes (native) | Faster audiovisual generation |
 | `veo31` | Yes (native) | Veo 3.1, highest quality |
@@ -68,7 +67,7 @@ POST /veo/videos
   "action": "image2video",
   "prompt": "the scene gently comes to life with wind and subtle motion",
   "image_urls": ["https://example.com/landscape.jpg"],
-  "model": "veo2-fast",
+  "model": "veo31-fast",
   "aspect_ratio": "16:9"
 }
 ```
@@ -107,7 +106,7 @@ POST /veo/videos
 | Parameter | Values | Description |
 |-----------|--------|-------------|
 | `action` | `"text2video"`, `"image2video"`, `"ingredients2video"`, `"get1080p"` | Generation mode |
-| `model` | see Models table | Model to use (default: `veo2-fast`) |
+| `model` | see Models table | Model to use |
 | `resolution` | `"4k"`, `"1080p"`, `"gif"` | Output resolution (default: 720p) |
 | `aspect_ratio` | `"16:9"`, `"9:16"` | Aspect ratio — only valid for `image2video` |
 | `image_urls` | array of strings | Reference image URLs — for `image2video` (up to 2) or `ingredients2video` (up to 3) |
@@ -117,23 +116,6 @@ POST /veo/videos
 ## Post-Generation Endpoints
 
 After generating a video, use these endpoints to further process it:
-
-### Upsample (`POST /veo/upsample`)
-
-Upscale a generated video to 1080p, 4K, or convert to GIF.
-
-```json
-POST /veo/upsample
-{
-  "video_id": "your-video-id",
-  "action": "4k"
-}
-```
-
-| Parameter | Values | Description |
-|-----------|--------|-------------|
-| `video_id` | string | Task ID from `/veo/videos`, `/veo/extend`, `/veo/reshoot`, or `/veo/objects` |
-| `action` | `"1080p"`, `"4k"`, `"gif"` | Upsample target |
 
 ### Extend (`POST /veo/extend`)
 
@@ -150,62 +132,13 @@ POST /veo/extend
 
 | Parameter | Values | Description |
 |-----------|--------|-------------|
-| `video_id` | string | Task ID from `/veo/videos` or a prior `/veo/extend` |
-| `model` | `"veo31-fast"`, `"veo31"` | Only Veo 3.1 series is supported |
+| `video_id` | string | **Required.** Task ID from `/veo/videos` or a prior `/veo/extend` |
+| `model` | `"veo31-fast"`, `"veo31"` | **Required.** Only Veo 3.1 series is supported |
 | `prompt` | string | Optional: guides the extended segment |
-
-### Reshoot (`POST /veo/reshoot`)
-
-Re-render a video keeping the same content but applying new camera motion.
-
-```json
-POST /veo/reshoot
-{
-  "video_id": "your-video-id",
-  "motion_type": "LEFT_TO_RIGHT"
-}
-```
-
-| Parameter | Values | Description |
-|-----------|--------|-------------|
-| `video_id` | string | Task ID from `/veo/videos` (cannot use `/veo/extend` output) |
-| `motion_type` | see table below | Camera motion to apply |
-
-**`motion_type` values:**
-`STATIONARY`, `STATIONARY_UP`, `STATIONARY_DOWN`, `STATIONARY_LEFT`, `STATIONARY_RIGHT`, `STATIONARY_DOLLY_IN_ZOOM_OUT`, `STATIONARY_DOLLY_OUT_ZOOM_IN`, `UP`, `DOWN`, `LEFT_TO_RIGHT`, `RIGHT_TO_LEFT`, `FORWARD`, `BACKWARD`, `DOLLY_IN_ZOOM_OUT`, `DOLLY_OUT_ZOOM_IN`
-
-### Objects (`POST /veo/objects`)
-
-Insert or remove objects in a video using mask-based inpainting.
-
-```json
-POST /veo/objects
-{
-  "video_id": "your-video-id",
-  "action": "insert",
-  "prompt": "add a flying bird"
-}
-```
-
-```json
-POST /veo/objects
-{
-  "video_id": "your-video-id",
-  "action": "remove",
-  "image_mask": "https://example.com/mask.jpg"
-}
-```
-
-| Parameter | Values | Description |
-|-----------|--------|-------------|
-| `video_id` | string | Task ID (cannot use `/veo/extend` output) |
-| `action` | `"insert"`, `"remove"` | Operation type |
-| `prompt` | string | Required for `insert`; optional for `remove` |
-| `image_mask` | string | URL or base64 JPEG — white pixels = target region. Required for `remove`; optional for `insert` |
 
 ## Gotchas
 
-- Veo 3 and 3.1 models generate **native audio** — `veo2-fast` does NOT support audio
+- Veo 3 and 3.1 models generate **native audio**
 - The `get1080p` action uses `video_id` (from a prior generation), not a URL
 - `aspect_ratio` is **only valid** for the `image2video` action
 - `image_urls` accepts an array — up to 2 images for `image2video`, up to 3 for `ingredients2video`
@@ -214,6 +147,5 @@ POST /veo/objects
 - `translation: true` auto-translates Chinese or other non-English prompts before sending to Veo
 - Task polling uses `id` (not `task_id`) in the `/veo/tasks` request body
 - Task states use `"succeeded"` (not "completed") — check for this value when polling
-- `/veo/extend` output **cannot** be used as input for `/veo/reshoot` or `/veo/objects`
 
 > **MCP:** `pip install mcp-veo` | Hosted: `https://veo.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)

--- a/skills/webextrator/SKILL.md
+++ b/skills/webextrator/SKILL.md
@@ -106,9 +106,10 @@ POST /webextrator/tasks
 | `wait_for_selector` | No | CSS selector to wait for before ready |
 | `block_resources` | No | Drop `image`/`font`/`media`/`stylesheet`/`xhr`/`fetch` |
 | `headers` | No | Extra request headers for the target site |
+| `user_agent` | No | Override the browser User-Agent |
 | `cookies` | No | Cookies to install before navigation |
-| `mode` | No | `sync` (default) or `async` (returns job id) |
-| `callback_url` | No | Posted the final envelope when `mode=async` |
+| `async` | No | `true` submits without blocking; poll `/webextrator/tasks` for the result |
+| `callback_url` | No | Posted the final envelope when running asynchronously |
 | `bypass_cache` | No | Skip the Redis result cache for this request |
 | `cache_ttl_seconds` | No | Override cache TTL; `0` disables caching |
 


### PR DESCRIPTION
## 背景

把 23 个 API 类 skill 逐一对照 PlatformBackend 的 OpenAPI 合约,发现 6 个已漂移。**下述每一条都用真实 API 调用复现过**,不是纸面推断。

## 修复

### 🔴 face-transform —— 照文档抄必然 400

`/face/change-age` 和 `/face/change-gender` 的示例都漏了必传参数:

```
POST /face/change-age {"image_url": "..."}
-> 400 {"code":"bad_request","message":"age_infos is required"}
```

补上 `age_infos` / `gender_infos` 及各自的参数表(含 `gender` 的 0=男变女 / 1=女变男 语义)。

### 🔴 gpt-image-2 —— 计费陷阱(最高低估 10 倍)

原文写「不支持 `n > 1`,只返回一张并按一张计费」。实测恰好相反:

```
{"model":"gpt-image-2","n":2} -> data 长度 2,cost 0.2024 credits
```

`cost/api` 的规则是 `{"*": [0.2, {"var":["n",1]}]}` —— **按张计费,n 最大 10**。照原文理解成本会低估最多 10 倍。

同时:
- `4096x4096` 实测 `400 size width and height must each be ≤ 3840`,改为 `2880x2880`
- 补全四条尺寸约束(×16 / 每边 ≤3840 / 总像素 655,360–8,294,400 / 宽高比 ≤3:1)—— 只写其中三条会让 `512x512` 这种「看着合规」的尺寸仍然 400
- 原文断言「两个端点都同步,无 `/tasks` 轮询」有误,实际支持 `callback_url` + `POST /openai/tasks`

### 🔴 veo-video —— 默认模型已下线 + 三个端点已废弃

`veo2-fast` 被列为默认,但实测 `400 model not found`。已从模型表、示例、默认说明、gotcha **以及 frontmatter description**(skill 选择层读的正是这个字段)中移除。

`/veo/upsample`、`/veo/reshoot`、`/veo/objects` 早已 `stage=Deprecated`(migration `0207`/`0217`),`service_api_mapping.json` 中 veo 只剩 `/veo/videos` + `/veo/tasks`,但 skill 仍在完整教学。已删除。

### 🔴 webextrator —— 所有异步示例都是空转

文档写 `mode: sync|async`,但两个 spec 里都**没有 `mode`**,真实字段是布尔 `async`。实测传 `mode` 被静默忽略、同步返回 —— 用户以为提交了异步任务。另补 `user_agent`。

### 🟠 fish-audio —— 否认了一个真实存在的端点

原文断言「spec 未提供语音克隆写端点」。实际 `POST /fish/model` 是 Production 接口。已补该端点 + `GET /fish/model/{id}`,并注明 `voices` 必须是**单个** URL 字符串(传数组会 400)。

### 🟠 sora-video —— 服务已整体下线

```
POST /sora/videos -> 404 {"message":"no Route matched with those values"}
```

migration `0173_deprecate_sora` 已移除 Kong 路由,服务 `private=True` 且 0 个 API,托管 MCP 也返回 503。**精修一个 404 服务的枚举反而会让它显得刚被验证过**,因此改为加显著下线横幅 + frontmatter 提示,并指向 veo/kling/seedance。

## 验证

- 在 `ubuntu:22.04` 复刻 `validate.yml` 的完整校验逻辑跑全部 95 个 skill:**0 errors**
- `pytest tests/`:79 passed

## 🤖 对抗评审

Codex 额度耗尽,回退 Claude `general-purpose` subagent(符合 AGENTS.md 自动检测回退)。评审做了**独立的 live 探测和数学核算**,找出 **2 条我新引入的错误**:

| # | RISK | 处理 |
|---|---|---|
| 1 | **我新加的 extend `aspect_ratio`/`resolution` 行**:虽在 spec 中,但当前服务实现忽略它们 | **已撤回** — 复验:传非法值三次均无校验、直接跳到 video_id 查找,证明被丢弃。不承诺不可观察的行为 |
| 5 | **我写的尺寸约束只有三条**,`512x512` 全满足却仍 400 | **已修** — 复验 `512x512` → `total pixels must be between 655360 and 8294400`;`3840x1024` → `aspect ratio must be ≤ 3:1`。补齐四条 |
| 2 | sora 服务整体 404,精修枚举方向错误 | **已改** — 复验 404 + MCP 503,改为下线横幅 |
| 3 | `veo2` 仍残留在 frontmatter description | **已修** |
| 4 | veo 三个废弃端点仍在完整教学 | **已删** |
| 6 | fish `voices` 是单个 URL 字符串,非数组 | **已修** — 复验传数组 400 |

评审同时**确认无误**(已复核):face 的 0/1 性别语义与 spec 译文一致;表格内 `0\|1` 转义渲染正常,全部表格列数无错位;webextrator `async`/`user_agent` 属实、旧 `mode` 确不存在;保留的 9 个尺寸预设逐个验算均满足全部四条约束(`3840x2160`/`2880x2880` 恰好等于像素上限,边界包含正确);sora 枚举本身忠于 spec;6 个文件无供应商泄漏。

评审提出的 `age` 有 `[10,80]` 范围一条,我复核后**不成立** —— spec 中 `age` 的 `minimum`/`maximum` 均为 `None`,故未采纳。

🤖 Generated with [Claude Code](https://claude.com/claude-code)