### PR TITLE
fix(xiaohongshu): 明确要求导航后先等加载再读取

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -268,6 +268,9 @@ The helper is deterministic and has no network or browser access. Pass JSON thro
 
 - A read succeeds only when a fresh page observation contains the requested visible data; say when data is truncated, unavailable, or ambiguous.
 - A navigation succeeds only when a fresh read shows the expected same-origin page.
+- Xiaohongshu renders client-side: `browser.navigate` returns before the feed exists.
+  Always `browser.wait` for the content you need, then read. A read taken straight
+  after navigating comes back empty and must not be reported as "no data".
 - A reversible interaction succeeds only when a fresh read confirms the target state.
 - A comment/reply succeeds only when the exact text and target are visibly confirmed after submission.
 - A publish/schedule succeeds only when a visible success state or destination confirms it. Return the canonical note URL when visible.


### PR DESCRIPTION
## 背景

根因诊断（[Index #317](https://github.com/AceDataCloud/Index/pull/317)）**阶段三 · E1**。

## 线上实测

`browser.navigate` 返回后**立刻** `browser.get_text`，`result` 是**空字符串**；加 5 秒等待后才读到完整内容：

```
首页 / 点点 / ai / RED / 直播 / 发布 / 通知 / 我
沪ICP备13030189号 | 营业执照 | ...
```

小红书是客户端渲染，`browser.navigate` 完成时 feed 尚未存在。

## 问题

Completion rules 原本只说「navigation 成功需要 fresh read 确认同源页面」，**没有约束读取时机**。模型因此会在导航后立即读取，并把空结果当成「页面无数据」上报——这正是 E2E 里观察到的现象之一。

## 改动

补一条显式规则（单文件、3 行）：

> Xiaohongshu renders client-side: `browser.navigate` returns before the feed exists. Always `browser.wait` for the content you need, then read. A read taken straight after navigating comes back empty and must not be reported as "no data".

> 按用户要求发出，admin review 合并。
