### PR TITLE
fix(skills): 移除公开 skill 中硬编码的个人账号信息

### DIFF
--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -54,7 +54,7 @@ Stats come straight from Bilibili: `view` (阅读), `like` (点赞), `reply` (�
 ```sh
 BILI="$SKILL_DIR/scripts/bilibili.py"; [ -f "$BILI" ] || BILI=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/bilibili.py' 2>/dev/null | head -1)
 python3 "$BILI" whoami
-# → {"mid": 91207595, "name": "...", "level": 4}
+# → {"mid": 10000000, "name": "...", "level": 4}
 ```
 
 On a not-logged-in / auth error the cookie is expired — have the user reconnect

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -53,7 +53,7 @@ Stats come straight from CSDN: `view_count` (阅读), `digg_count` (点赞),
 ```sh
 CSDN="$SKILL_DIR/scripts/csdn.py"; [ -f "$CSDN" ] || CSDN=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/csdn.py' 2>/dev/null | head -1)
 python3 "$CSDN" whoami
-# → {"username": "...", "nickname": "...", "articles_total": 1597}
+# → {"username": "...", "nickname": "...", "articles_total": 0}
 ```
 
 On a WAF 403 / auth error the cookie is expired — tell the user to reconnect at

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -63,15 +63,15 @@ python3 scripts/discord_user.py whoami
 # list the servers (guilds) the account is in
 python3 scripts/discord_user.py guilds
 # list text channels in a server
-python3 scripts/discord_user.py channels --guild 1133012399448928276
+python3 scripts/discord_user.py channels --guild GUILD_ID
 # read recent messages in a channel
-python3 scripts/discord_user.py messages --channel 1133012400174534792 --limit 20
+python3 scripts/discord_user.py messages --channel CHANNEL_ID --limit 20
 # send — dry-run first, then re-run with a trailing --confirm
-python3 scripts/discord_user.py send --channel 1133012400174534792 --text "hello"
-python3 scripts/discord_user.py send --channel 1133012400174534792 --text "hello" --confirm
+python3 scripts/discord_user.py send --channel CHANNEL_ID --text "hello"
+python3 scripts/discord_user.py send --channel CHANNEL_ID --text "hello" --confirm
 # reply to a specific message
 python3 scripts/discord_user.py reply \
-  --channel 1133012400174534792 --message 987654321098765432 --text "on it" --confirm
+  --channel CHANNEL_ID --message MESSAGE_ID --text "on it" --confirm
 ```
 
 `--confirm` is honored ONLY as the final argument (one strip), so a message body

--- a/skills/discord/scripts/discord_user.py
+++ b/skills/discord/scripts/discord_user.py
@@ -17,10 +17,10 @@ account access — NEVER echo or print it.
 Examples:
   python3 discord_user.py whoami
   python3 discord_user.py guilds
-  python3 discord_user.py channels --guild 1133012399448928276
-  python3 discord_user.py messages --channel 1133012400174534792 --limit 20
-  python3 discord_user.py send --channel 1133012400174534792 --text "hello" --confirm
-  python3 discord_user.py reply --channel 1133012400174534792 --message 987654321 --text "on it" --confirm
+  python3 discord_user.py channels --guild GUILD_ID
+  python3 discord_user.py messages --channel CHANNEL_ID --limit 20
+  python3 discord_user.py send --channel CHANNEL_ID --text "hello" --confirm
+  python3 discord_user.py reply --channel CHANNEL_ID --message MESSAGE_ID --text "on it" --confirm
 """
 
 from __future__ import annotations

--- a/skills/google-gmail/SKILL.md
+++ b/skills/google-gmail/SKILL.md
@@ -383,7 +383,7 @@ BODY='Hi Alice,
 Just a quick test note from the AceDataCloud Gmail connector.
 
 Best,
-Qingcai'
+YOUR_NAME'
 
 # Multi-line subject lines need MIME encoded-word for non-ASCII; ASCII is fine raw.
 RAW=$(printf 'To: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\nMIME-Version: 1.0\r\n\r\n%s' \

--- a/skills/juejin/SKILL.md
+++ b/skills/juejin/SKILL.md
@@ -47,7 +47,7 @@ Stats come straight from 掘金: `view_count` (阅读), `digg_count` (点赞),
 ```sh
 JJ="$SKILL_DIR/scripts/juejin.py"; [ -f "$JJ" ] || JJ=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/juejin.py' 2>/dev/null | head -1)
 python3 "$JJ" whoami
-# → {"user_id": "...", "name": "...", "post_article_count": 336}
+# → {"user_id": "...", "name": "...", "post_article_count": 0}
 ```
 
 On an auth error (`err_no` 401 / "请登录") the cookie is expired — have the user

--- a/skills/mastodon/SKILL.md
+++ b/skills/mastodon/SKILL.md
@@ -64,7 +64,7 @@ curl -sS -X POST "$MASTODON_BASE_URL/api/v1/statuses" \
 Use the `id` from `verify_credentials`:
 
 ```bash
-ACCT_ID="14715"   # from verify_credentials
+ACCT_ID="ACCOUNT_ID"   # from verify_credentials
 curl -sS "$MASTODON_BASE_URL/api/v1/accounts/$ACCT_ID/statuses?limit=20&exclude_replies=true&exclude_reblogs=true" \
   -H "Authorization: Bearer $MASTODON_ACCESS_TOKEN" \
   | jq '.[] | {id, url, boosts: .reblogs_count, favs: .favourites_count, replies: .replies_count, created_at}'

--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -98,7 +98,7 @@ python3 $WX conversations --history --limit 20
 First list conversations, then use the `id` as `conversation_id`:
 
 ```bash
-python3 $WX messages "34642176898@chatroom" --limit 50 --order asc
+python3 $WX messages "CONVERSATION_ID" --limit 50 --order asc
 ```
 
 ### Historical Messages
@@ -107,7 +107,7 @@ Read from Wisdom's decrypted WeChat local databases:
 
 ```bash
 python3 $WX history --limit 50
-python3 $WX history --talker "34642176898@chatroom" --limit 50
+python3 $WX history --talker "CONVERSATION_ID" --limit 50
 python3 $WX history --limit 20 --offset 20
 ```
 

--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -51,7 +51,7 @@ last argument** so a message/caption that merely contains "--confirm" can never 
 
 ```sh
 python3 "$TG" whoami
-# → {"id": 8367450178, "username": "GermeyAce", "name": "Germey", "phone": "..."}
+# → {"id": 100000000, "username": "<the connected handle>", "name": "<display name>", "phone": "..."}
 ```
 
 On an auth/session error the stored session is dead — tell the user to reconnect at

--- a/skills/toutiao/SKILL.md
+++ b/skills/toutiao/SKILL.md
@@ -54,7 +54,7 @@ Stats come straight from 头条: `impression_count` (展现), `read_count` (阅�
 ```sh
 TT="$SKILL_DIR/scripts/toutiao.py"; [ -f "$TT" ] || TT=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/toutiao.py' 2>/dev/null | head -1)
 python3 "$TT" whoami
-# → {"user_id": ..., "name": "...", "articles_total": 273}
+# → {"user_id": ..., "name": "...", "articles_total": 0}
 ```
 
 On an auth error the cookie is expired — tell the user to reconnect at

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -50,8 +50,8 @@ python3 "$X" whoami          # confirm the shipped CLI can read the authenticate
 ## Read commands (run directly)
 
 ```sh
-python3 $X whoami --expect GermeyAce                         # verify this exact account
 python3 $X whoami                                            # discover the authenticated account
+python3 $X whoami --expect SCREEN_NAME                       # optional: assert a specific account
 python3 $X search --query "ai agents" --product Latest --limit 20   # Top | Latest | Media
 python3 $X search-users --query "openai" --limit 10
 python3 $X timeline --limit 20                               # my home timeline
@@ -65,19 +65,22 @@ python3 $X trends --category trending --limit 20             # trending|for-you|
 ## Verify the connection first
 
 ```sh
-python3 $X whoami --expect GermeyAce
-# → {"id": "...", "screen_name": "GermeyAce", "identity_verified": true, ...}
+python3 $X whoami
+# → {"id": "...", "screen_name": "<the connected handle>", "identity_verified": true, ...}
 ```
 
 `whoami` reads the authenticated account's screen name from X account settings,
-then resolves its public profile. `--expect` compares that server-authenticated
-screen name with the required account before any write. This avoids X's
-Cloudflare-blocked `UserByRestId` endpoint without trusting a local identity
-cookie. Always use `--expect` when the user names the required account.
+then resolves its public profile. This avoids X's Cloudflare-blocked
+`UserByRestId` endpoint without trusting a local identity cookie.
+
+`--expect <screen_name>` is optional: pass it only when the user explicitly names
+the account they want to act as, and it will abort if the connected cookie
+belongs to someone else. Do not invent an expected handle — plain `whoami` is
+the default.
 
 On an actual auth error the cookie is expired — have the user reconnect at
 <https://auth.acedata.cloud/user/connections>. A Cloudflare block is different:
-reconnecting cookies does not fix it. Use `--expect` for identity checks; other
+reconnecting cookies does not fix it. Use `whoami` for identity checks; other
 blocked endpoints need `X_PROXY` or the official X API. Do **not** loop-retry.
 
 ## Write commands — GATED (dry-run unless trailing `--confirm`)

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -19,7 +19,7 @@ breakage.
 
 Examples:
   python3 x.py whoami
-    python3 x.py whoami --expect GermeyAce
+  python3 x.py whoami --expect SCREEN_NAME
   python3 x.py search --query "python" --product Latest --limit 20
   python3 x.py timeline --limit 20
   python3 x.py user-tweets --user elonmusk --type Tweets --limit 20
@@ -107,7 +107,7 @@ def cloudflare_block_message(error: Exception) -> str | None:
     ray = f" Ray ID: {ray_match.group(1)}." if ray_match else ""
     return (
         "X blocked this automated web-API request at Cloudflare; the login cookies may still be valid."
-        f"{ray} For identity checks, use `whoami --expect <screen_name>`; for other blocked endpoints, "
+        f"{ray} For identity checks, use `whoami`; for other blocked endpoints, "
         "configure X_PROXY or use the official X API."
     )
 

--- a/skills/yuque/SKILL.md
+++ b/skills/yuque/SKILL.md
@@ -43,8 +43,8 @@ python3 "$SKILL_DIR/scripts/yuque.py" whoami
 
 # List knowledge bases, then the documents in one.
 python3 "$SKILL_DIR/scripts/yuque.py" repos
-python3 "$SKILL_DIR/scripts/yuque.py" docs germey/blog --limit 20
-python3 "$SKILL_DIR/scripts/yuque.py" doc germey/blog DOC_ID
+python3 "$SKILL_DIR/scripts/yuque.py" docs REPO_NAMESPACE --limit 20
+python3 "$SKILL_DIR/scripts/yuque.py" doc REPO_NAMESPACE DOC_ID
 ```
 
 ## Create and update
@@ -55,18 +55,18 @@ by default and only publishes publicly with an explicit `--public`.
 
 ```bash
 # First call is always a dry run and does not load credentials or call the API.
-python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+python3 "$SKILL_DIR/scripts/yuque.py" create REPO_NAMESPACE \
   --title "标题" --content-file /tmp/article.md
 
 # Create it privately after the user confirms.
-python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+python3 "$SKILL_DIR/scripts/yuque.py" create REPO_NAMESPACE \
   --title "标题" --content-file /tmp/article.md --confirm
 
 # Public publishing additionally requires --public.
-python3 "$SKILL_DIR/scripts/yuque.py" create germey/blog \
+python3 "$SKILL_DIR/scripts/yuque.py" create REPO_NAMESPACE \
   --title "标题" --content-file /tmp/article.md --public --confirm
 
-python3 "$SKILL_DIR/scripts/yuque.py" update germey/blog DOC_ID \
+python3 "$SKILL_DIR/scripts/yuque.py" update REPO_NAMESPACE DOC_ID \
   --title "新标题" --content-file /tmp/article.md --public --confirm
 ```
 
@@ -81,7 +81,7 @@ first if the user only wants part of it changed.
 ## Delete
 
 ```bash
-python3 "$SKILL_DIR/scripts/yuque.py" delete germey/blog DOC_ID --confirm
+python3 "$SKILL_DIR/scripts/yuque.py" delete REPO_NAMESPACE DOC_ID --confirm
 ```
 
 Use the real returned `doc_id` and URL. Do not retry a timed-out write

--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -138,7 +138,7 @@ python3 "$BLOG" question <question-id>     # a question's info + whether I answe
 ```sh
 ZDIR="$SKILL_DIR"; [ -f "$ZDIR/scripts/blog.py" ] || ZDIR=$(find /tmp -maxdepth 8 -path '*/skills/*/scripts/blog.py' 2>/dev/null | head -1 | sed 's#/scripts/blog.py##')
 python3 "$ZDIR/scripts/blog.py" whoami
-# → {"id": "...", "name": "崔庆才丨静觅", "url_token": "Germey", ...}
+# → {"id": "...", "name": "<the connected display name>", "url_token": "<the connected handle>", ...}
 ```
 
 On a `401`/`403` the cookie is expired — tell the user to reconnect at

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -17,8 +17,8 @@ x = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(x)
 
 
-def user(user_id: str = "4807296432", screen_name: str = "GermeyAce") -> SimpleNamespace:
-    return SimpleNamespace(id=user_id, screen_name=screen_name, name="Germey Ace")
+def user(user_id: str = "1000000000", screen_name: str = "example_user") -> SimpleNamespace:
+    return SimpleNamespace(id=user_id, screen_name=screen_name, name="Example User")
 
 
 def tweet(tweet_id: str, *, media: bool) -> SimpleNamespace:
@@ -43,21 +43,21 @@ class XSkillTests(unittest.TestCase):
     def test_whoami_expect_uses_authenticated_settings_without_user_by_id(self) -> None:
         class V11:
             async def settings(self):
-                return {"screen_name": "GermeyAce"}, None
+                return {"screen_name": "example_user"}, None
 
         class Client:
             v11 = V11()
 
             async def get_user_by_screen_name(self, screen_name):
-                self_test.assertEqual(screen_name, "GermeyAce")
+                self_test.assertEqual(screen_name, "example_user")
                 return user()
 
             async def get_user_by_id(self, _user_id):
                 raise AssertionError("expected-account verification must not call UserByRestId")
 
         self_test = self
-        result = run_payload(x.cmd_whoami(Client(), SimpleNamespace(expect="@GermeyAce")))
-        self.assertEqual(result["screen_name"], "GermeyAce")
+        result = run_payload(x.cmd_whoami(Client(), SimpleNamespace(expect="@example_user")))
+        self.assertEqual(result["screen_name"], "example_user")
         self.assertTrue(result["identity_verified"])
         self.assertEqual(result["verification"], "authenticated_settings_matches_expected_screen_name")
 
@@ -72,14 +72,14 @@ class XSkillTests(unittest.TestCase):
             async def get_user_by_screen_name(self, _screen_name):
                 raise AssertionError("mismatch must stop before public profile lookup")
 
-        error = run_error(x.cmd_whoami(Client(), SimpleNamespace(expect="GermeyAce")))["error"]
+        error = run_error(x.cmd_whoami(Client(), SimpleNamespace(expect="example_user")))["error"]
         self.assertIn("@OtherAccount", error)
-        self.assertIn("not @GermeyAce", error)
+        self.assertIn("not @example_user", error)
 
     def test_whoami_without_expect_uses_authenticated_settings(self) -> None:
         class V11:
             async def settings(self):
-                return {"screen_name": "GermeyAce"}, None
+                return {"screen_name": "example_user"}, None
 
         class Client:
             v11 = V11()
@@ -88,7 +88,7 @@ class XSkillTests(unittest.TestCase):
                 return user(screen_name=screen_name)
 
         result = run_payload(x.cmd_whoami(Client(), SimpleNamespace(expect=None)))
-        self.assertEqual(result["screen_name"], "GermeyAce")
+        self.assertEqual(result["screen_name"], "example_user")
         self.assertEqual(result["verification"], "authenticated_settings_screen_name")
 
     def test_user_media_falls_back_to_tweets_and_filters_media(self) -> None:
@@ -105,7 +105,7 @@ class XSkillTests(unittest.TestCase):
                 return [tweet("1", media=False), tweet("2", media=True), tweet("3", media=True)]
 
         result = run_payload(
-            x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+            x.cmd_user_tweets(Client(), SimpleNamespace(user="example_user", type="Media", limit=1))
         )
         self.assertEqual(calls, [("Media", 1), ("Tweets", 40)])
         self.assertEqual(result["type"], "Media")
@@ -123,7 +123,7 @@ class XSkillTests(unittest.TestCase):
 
         with self.assertRaisesRegex(KeyError, "unexpected"):
             asyncio.run(
-                x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+                x.cmd_user_tweets(Client(), SimpleNamespace(user="example_user", type="Media", limit=1))
             )
 
     def test_user_media_falls_back_on_explicit_dependency_error(self) -> None:
@@ -137,7 +137,7 @@ class XSkillTests(unittest.TestCase):
                 return [tweet("1", media=True)]
 
         result = run_payload(
-            x.cmd_user_tweets(Client(), SimpleNamespace(user="GermeyAce", type="Media", limit=1))
+            x.cmd_user_tweets(Client(), SimpleNamespace(user="example_user", type="Media", limit=1))
         )
         self.assertEqual(result["fallback"], "Tweets (locally filtered for media)")
 
@@ -182,8 +182,8 @@ class XSkillTests(unittest.TestCase):
         self.assertNotIn("huge html", message)
 
     def test_whoami_parser_accepts_expected_screen_name(self) -> None:
-        args = x.build_parser().parse_args(["whoami", "--expect", "GermeyAce"])
-        self.assertEqual(args.expect, "GermeyAce")
+        args = x.build_parser().parse_args(["whoami", "--expect", "example_user"])
+        self.assertEqual(args.expect, "example_user")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
11 个 skill 的示例里混入了作者本人的真实账号数据（真实 handle、
账号 ID、文章数、Discord snowflake、微信群 ID、邮件签名）。这些 skill
会分发给所有平台用户并载入 agent 上下文，示例中的真值可能被照抄。

- x：GermeyAce → SCREEN_NAME；`--expect` 从「必须」改为「可选，仅当
  用户明确指定账号时使用」。该 flag 从来不是写操作的实际闸门（写命令
  由末位 `--confirm` 把关，见 x.py），所以放宽不构成安全回退。
- telegram / zhihu / bilibili / csdn / juejin / toutiao：whoami 示例
  输出里的真实 handle、mid、文章计数改为占位值。
- discord：`send --confirm` 示例里的两个真实 guild/channel snowflake
  （2023-07-24 生成，相差 173ms）改为 GUILD_ID / CHANNEL_ID。
- yuque：germey/blog → REPO_NAMESPACE（单 token —— 语雀 namespace
  本身就是 `user/book`，两段式占位符会让 agent 拼出 a/b/b）。
- personal-wechat：真实群 ID → CONVERSATION_ID（不带 @chatroom 后缀，
  接口返回的 id 已含该后缀）。
- google-gmail / mastodon：邮件签名里的真名、verify_credentials 取回
  的真实 account id 改为占位。
- tests/test_x.py 同步改用通用固定值。

sh 代码块内的占位符统一用裸大写（`SCREEN_NAME` 而非 `<screen_name>`）
—— 尖括号是 shell 重定向语法，会让整个代码块语法错误并跳过后续行。

## 🤖 对抗评审

Codex 配额耗尽，回退到 Claude general-purpose subagent，两轮收敛。

第 1 轮，8 项 RISK，全部核实属实并已修：
- RISK: yuque `NAMESPACE/REPO_SLUG` 两段式占位结构性错误 → 已改单 token。
- RISK: tests/test_x.py 残留 GermeyAce ×12 → 已改为 example_user。
- RISK: discord 两个 ID 是真实 snowflake 且在写操作示例中 → 已占位化。
  （decode 验证：2023-07-24T12:26:46，两者相差 173ms。）
- RISK: x.py:110 运行时报错仍写 `whoami --expect <screen_name>`，与新
  文档「不要臆造 expect 值」直接矛盾 → 已改为 `whoami`。
- RISK: `<screen_name>` 在 sh 块里触发重定向语法错误 → 已复现
  （exit=2 且跳过后续行）并改为裸大写。
- RISK: bilibili mid / personal-wechat 群 ID 同类泄露 → 已占位化。
- RISK: heading 从 `## Verify the connection first` 改名，偏离其他 12
  个 skill 的惯例 → 已还原。

第 2 轮验证前述修复无误、测试断言语义未被削弱（`--expect` 不匹配的
用例仍对比两个不同 handle），并新增 2 项，均已修：
- RISK: google-gmail 邮件正文签名残留作者真名 → YOUR_NAME。
- RISK: `CONVERSATION_ID@chatroom` 重复后缀（重犯第 1 轮的结构错误）
  → 改为裸 CONVERSATION_ID。

评审反驳/结论（未改动项）：`--expect` 放宽不是安全回退。代码证据：
该参数只注册在 whoami 子命令（x.py:474），只在 cmd_whoami 读取
（x.py:255-262）；post/thread/like/follow/delete 全部直接调用 twikit，
不做身份校验；每次进程只跑一个子命令，前一次 whoami 无法为后续写操作
把关。真正的写闸门是末位 `--confirm`，本次未改动。

测试：仓库 77 项 + 8 个 skill 的 pytest 套件全部通过。

