### PR TITLE
fix(x): retry X's intermittent identity 404s instead of blaming cookies

### DIFF
--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -81,7 +81,13 @@ the default.
 On an actual auth error the cookie is expired — have the user reconnect at
 <https://auth.acedata.cloud/user/connections>. A Cloudflare block is different:
 reconnecting cookies does not fix it. Use `whoami` for identity checks; other
-blocked endpoints need `X_PROXY` or the official X API. Do **not** loop-retry.
+blocked endpoints need `X_PROXY` or the official X API. Do **not** loop-retry a
+Cloudflare block or an auth error.
+
+A **404 is not an auth error.** X's identity endpoints 404 on roughly a quarter
+of calls even with healthy cookies, on every account. `whoami` already retries
+those internally, so if it still reports a 404, wait a moment and run it again —
+do not tell the user to reconnect.
 
 ## Write commands — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -245,8 +245,52 @@ async def resolve_user(client, target: str):
 
 # ── read commands ───────────────────────────────────────────────────
 
+IDENTITY_ATTEMPTS = 4
+
+
+class _UnraisableSentinel(Exception):
+    """Stands in for twikit's NotFound when twikit is absent, so the unit tests
+    (which mock the client entirely) can exercise these paths."""
+
+
+def not_found_error():
+    try:
+        from twikit.errors import NotFound
+    except Exception:
+        return _UnraisableSentinel
+    return NotFound
+
+
+async def retry_flaky_not_found(client, call, what: str):
+    """Run `call(client)`, retrying X's intermittent 404s on a fresh session.
+
+    X's identity endpoints 404 on roughly a quarter of calls even with healthy
+    cookies (measured over 20-trial batches on three separate accounts), so a
+    404 here is NOT an expired cookie. Returns (result, client) — the client is
+    replaced on each retry because reusing the failing session keeps 404ing.
+    """
+    not_found = not_found_error()
+    last_error = None
+    for attempt in range(IDENTITY_ATTEMPTS):
+        if attempt:
+            await asyncio.sleep(0.6 * attempt)
+            client = make_client()
+        try:
+            return await call(client), client
+        except not_found as e:
+            last_error = e
+    die(
+        f"X returned 404 for {what} on {IDENTITY_ATTEMPTS} consecutive attempts. "
+        "That endpoint is intermittently flaky — a 404 is not an expired cookie, "
+        "so reconnecting will not help. Retry the same command in a moment. "
+        f"({last_error})"
+    )
+
+
 async def cmd_whoami(client, args):
-    settings, _ = await client.v11.settings()
+    (settings, _), client = await retry_flaky_not_found(
+        client, lambda c: c.v11.settings(), "the authenticated account's settings"
+    )
     authenticated_screen_name = settings.get("screen_name") if isinstance(settings, dict) else None
     if not isinstance(authenticated_screen_name, str) or not re.fullmatch(
         r"[A-Za-z0-9_]{1,15}", authenticated_screen_name
@@ -260,7 +304,11 @@ async def cmd_whoami(client, args):
                 f"connected X account is @{authenticated_screen_name}, not @{expected_screen_name}; "
                 "stopped without performing any write"
             )
-    u = await client.get_user_by_screen_name(authenticated_screen_name)
+    u, client = await retry_flaky_not_found(
+        client,
+        lambda c: c.get_user_by_screen_name(authenticated_screen_name),
+        f"@{authenticated_screen_name}'s profile",
+    )
     result = fmt_user(u)
     result.update(
         {


### PR DESCRIPTION
## 问题

用户的一次真实会话里，`x` 技能反复报「404 / not found」，模型据此告诉用户 **cookie 过期了、去重新连接**。这个结论是错的 —— cookie 完全健康。

X 的身份端点（`/1.1/account/settings.json`、`UserByScreenName`）**在 cookie 正常的情况下也会间歇性返回 404**。在三个不同账号上各做 20 次实测，失败率稳定在 ~25%。`twikit` 把它抛成 `NotFound`，原来的 `cmd_whoami` 直接冒泡 → 模型看到 404 就往「认证失效」上归因，把用户引向一次毫无意义的重新授权。

## 改动

- `retry_flaky_not_found(client, call, what)`：只对 `NotFound` 重试，最多 4 次，退避 0.6s×attempt，**每次重试换一个全新的 client**（复用失败的 session 会继续 404）。非 404 异常原样抛出。
- 4 次全 404 才 `die()`，错误文案明说「404 不是 cookie 过期，重连没用，过一会儿再试」。
- `cmd_whoami` 的两次身份调用（`v11.settings()` + `get_user_by_screen_name`）都走这条路径。
- `SKILL.md` 增补一段，告诉模型 404 不是 auth error、whoami 已内部重试、**不要让用户去重连**。

`twikit` 的导入是懒加载 + guarded（`not_found_error()` → 缺 `twikit` 时回落到 `_UnraisableSentinel`），和这个文件里 `make_client()` / `main()` 已有的惰性导入写法一致 —— `tests/test_x.py` 通过 `importlib` 加载脚本并完全 mock client，必须能在**没装 twikit** 的 CI 环境跑通。

## 验证

**生产沙箱真机 A/B**（pod `platform-service-sandbox-...-hjn28`，真实连接的 cookie jar，各 12 次）：

| | ok | err |
|---|---|---|
| 旧代码 | 9 | **3**（全部 `status: 404 … "Sorry, that page does not exist","code":34`）|
| 新代码 | **12** | 0 |

- 全量单测 `python3 -m unittest discover -s tests -p 'test_*.py'` → **77 tests, OK**（改动前因无条件 import twikit 挂 3 个）。
- 额外 4 项针对性用例：重试后恢复、耗尽后的错误文案、无 twikit 的 sentinel 路径、非 404 异常不被吞。
- **变异测试**：把 `not_found = not_found_error()` 换成写死 `_UnraisableSentinel` → 用例转红；还原 → 转绿。证明这个 guard 是有承载的，不是摆设。

全程未打印任何 cookie 值（只输出过 cookie 名、条数、base64 字节长度），临时文件已从沙箱与 auth-backend pod 清理。

## 🤖 对抗评审

评审方：`codex exec --sandbox read-only`（跨模型），两轮。

**第 1 轮 — RISK（已修）**
> `retry_flaky_not_found()` 在进入任何 fake client 调用前无条件 `from twikit.errors import NotFound`，导致 `tests/test_x.py` 中直接调用 `cmd_whoami()` 的单测在未安装 `twikit` 的仓库环境下失败，即使测试本来完全 mock 了 client。`skills/x/scripts/x.py:259`
>
> 只读验证：`python3 -m unittest tests.test_x` → 11 个测试中 3 个因 `ModuleNotFoundError: No module named 'twikit'` 失败。

**接受并修复。** 这是真的 CI 回归 —— `.github/workflows/validate.yml:85` 跑的正是 discover 形式。改成 `_UnraisableSentinel` + `not_found_error()` 惰性 guard，沿用本文件既有写法。修复后全量 77 tests OK。

**第 2 轮 — 3 项全部 CLEAN**
1. 复跑 discover：77 passed。
2. guarded import 修好了无 twikit 路径；生产 `main()` 仍会先 import `twikit.errors`，所以真实的 twikit 损坏不会被静默降级成 sentinel；重试只捕获 `NotFound`，非 404 正常传播；`die()` 抛的 `SystemExit` 未被吞掉。
3. `SKILL.md` 与新行为一致（重试仅限身份 404，不覆盖 auth / Cloudflare），未发现新的上游信息泄露。
