### PR TITLE
docs(turnstile): 示例里的 started_at/finished_at 改成 Unix 浮点秒

### DIFF
--- a/skills/turnstile/SKILL.md
+++ b/skills/turnstile/SKILL.md
@@ -31,8 +31,8 @@ A successful synchronous response:
 ```json
 {
   "token": "0.mNQ2f9uP6mQ0y3H5Q8bqO7iM...",
-  "started_at": "2026-07-24T09:34:13+00:00",
-  "finished_at": "2026-07-24T09:34:25+00:00",
+  "started_at": 1784885653.0,
+  "finished_at": 1784885665.0,
   "elapsed": 12.4
 }
 ```


### PR DESCRIPTION
跟随平台的计时字段统一（[PlatformService#1778](https://github.com/AceDataCloud/PlatformService/pull/1778)）。

`skills/turnstile/SKILL.md` 的响应示例仍写着 ISO 字符串，与线上不符。

🤖 Generated with [Claude Code](https://claude.com/claude-code)