### PR TITLE
fix: 重连提示改指向 Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Compatible with **30+ AI coding agents** via the [agentskills.io](https://agents
 
 ### Connectors
 
-These skills drive third-party connectors users wire up at [auth.acedata.cloud/user/connections](https://auth.acedata.cloud/user/connections). Each declares the OAuth / BYOC connection it needs in `connections:` frontmatter; the [aichat2](https://chat.acedata.cloud) runtime injects the matching access token into the sandbox before the skill's `Bash` calls run.
+These skills drive third-party connectors users wire up at [studio.acedata.cloud/console/connectors](https://studio.acedata.cloud/console/connectors). Each declares the OAuth / BYOC connection it needs in `connections:` frontmatter; the [aichat2](https://chat.acedata.cloud) runtime injects the matching access token into the sandbox before the skill's `Bash` calls run.
 
 | Skill | Description | Connection |
 |-------|-------------|------------|

--- a/skills/_shared/tencentcloud.md
+++ b/skills/_shared/tencentcloud.md
@@ -36,7 +36,7 @@ set -a; source .env; set +a
 
 > ⚠️ **Important:** Add `.env` to your `.gitignore` — never commit credentials to git.
 
-**Agent usage** (Claude / Studio / etc.): If you've installed the [腾讯云 connector](https://auth.acedata.cloud/user/connections) on AceDataCloud, your encrypted credentials are auto-injected as the env vars above when the agent runs any `tencentcloud-*` skill — no manual `.env` setup needed.
+**Agent usage** (Claude / Studio / etc.): If you've installed the [腾讯云 connector](https://studio.acedata.cloud/console/connectors) on AceDataCloud, your encrypted credentials are auto-injected as the env vars above when the agent runs any `tencentcloud-*` skill — no manual `.env` setup needed.
 
 ## Common regions
 

--- a/skills/_shared/wecom.md
+++ b/skills/_shared/wecom.md
@@ -62,7 +62,7 @@ set -a; source .env; set +a
 > ⚠️ **Never commit `.env`** — the Secret is equivalent to full app access. Add it to `.gitignore`.
 
 **Agent usage** (Claude / Studio / etc.): install the
-[企业微信 connector](https://auth.acedata.cloud/user/connections) on AceDataCloud once. Your
+[企业微信 connector](https://studio.acedata.cloud/console/connectors) on AceDataCloud once. Your
 CorpID / Secret / AgentId are AES-256-GCM encrypted at rest and injected as the env vars above
 only inside the sandbox while the skill runs — no manual `.env` setup needed. Revoke anytime from
 the connections page.

--- a/skills/acedatacloud/SKILL.md
+++ b/skills/acedatacloud/SKILL.md
@@ -39,7 +39,7 @@ user token), **not** the per-service API token used for `api.acedata.cloud`.
    (or `POST /api/v1/platform-tokens/`). It starts with `platform-` and never expires.
 2. Provide it one of two ways:
    - **Connector (recommended in studio / chat):** install the **AceDataCloud**
-     connector at [auth.acedata.cloud/user/connections](https://auth.acedata.cloud/user/connections)
+     connector at [studio.acedata.cloud/console/connectors](https://studio.acedata.cloud/console/connectors)
      and paste the token once — the runtime injects `ACEDATACLOUD_PLATFORM_TOKEN`
      into the sandbox automatically (this skill declares `connections: [acedatacloud]`).
    - **Local `.env`:**

--- a/skills/bilibili/SKILL.md
+++ b/skills/bilibili/SKILL.md
@@ -58,7 +58,7 @@ python3 "$BILI" whoami
 ```
 
 On a not-logged-in / auth error the cookie is expired — have the user reconnect
-at <https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+at <https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/bilibili/scripts/bilibili.py
+++ b/skills/bilibili/scripts/bilibili.py
@@ -74,7 +74,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect Bilibili at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -202,7 +202,7 @@ def bili_nav(jar):
     data = nav.get("data") or {}
     if not data.get("isLogin"):
         die("not logged in (cookie expired?) — reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return data
 
 
@@ -780,7 +780,7 @@ def cmd_drafts(jar, args):
                  jar, referer="https://member.bilibili.com/")
     if d.get("code"):  # 0 = ok; anything truthy is an auth/API error
         die(f"draft list error (code={d.get('code')}): {d.get('message')} — "
-            f"cookie may be expired; reconnect at https://auth.acedata.cloud/user/connections.")
+            f"cookie may be expired; reconnect at https://studio.acedata.cloud/console/connectors.")
     items = _drafts_of(d)
     out({"page": args.page, "count": len(items), "drafts": [{
         "aid": x.get("id"),

--- a/skills/cnblogs/scripts/cnblogs.py
+++ b/skills/cnblogs/scripts/cnblogs.py
@@ -49,7 +49,7 @@ class CNBlogsClient:
         if not token:
             die(
                 "CNBLOGS_TOKEN is not set. Reconnect 博客园 at "
-                "https://auth.acedata.cloud/user/connections."
+                "https://studio.acedata.cloud/console/connectors."
             )
         return cls(token)
 

--- a/skills/csdn/SKILL.md
+++ b/skills/csdn/SKILL.md
@@ -57,7 +57,7 @@ python3 "$CSDN" whoami
 ```
 
 On a WAF 403 / auth error the cookie is expired — tell the user to reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** retry in a loop.
+<https://studio.acedata.cloud/console/connectors>. Do **not** retry in a loop.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 
@@ -89,7 +89,7 @@ image that fails to upload keeps its original URL (never blocks the post).
 ## Gotchas — surface before the user is surprised
 
 - **This is the user's real CSDN account.** Confirm before any publish.
-- **Cookie expiry / WAF 403**: reconnect at auth.acedata.cloud/user/connections —
+- **Cookie expiry / WAF 403**: reconnect at studio.acedata.cloud/console/connectors —
   never loop-retry a WAF block.
 - The editor save endpoint is signed with an HMAC key baked into CSDN's web
   bundle; if CSDN rotates it, publish fails loudly (reads still work).

--- a/skills/csdn/scripts/csdn.py
+++ b/skills/csdn/scripts/csdn.py
@@ -72,7 +72,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect CSDN at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -171,10 +171,10 @@ def get_json(url: str, jar: list, *, referer, origin):
     if "WAF" in text and "403" in text:
         die("CSDN WAF blocked the request (403). The cookie may be expired or "
             "the account needs to re-pass CSDN's captcha; reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     if status in (401, 403):
         die(f"auth failed ({status}) on {url} — cookie likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+            f"Reconnect at https://studio.acedata.cloud/console/connectors.")
     try:
         return json.loads(text)
     except json.JSONDecodeError:
@@ -209,7 +209,7 @@ def csdn_username(jar):
     u = cookie_value(jar, "UserName")
     if not u:
         die("no UserName cookie — reconnect CSDN at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return u
 
 

--- a/skills/cto51/SKILL.md
+++ b/skills/cto51/SKILL.md
@@ -43,7 +43,7 @@ python3 "$SKILL_DIR/scripts/cto51.py" whoami
 ```
 
 If this fails with a redirect or auth error, the cookie has expired. Ask the
-user to reconnect at `https://auth.acedata.cloud/user/connections` rather than
+user to reconnect at `https://studio.acedata.cloud/console/connectors` rather than
 retrying.
 
 ## Create a draft — GATED

--- a/skills/cto51/scripts/cto51.py
+++ b/skills/cto51/scripts/cto51.py
@@ -110,7 +110,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect 51CTO at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -149,13 +149,13 @@ def cookie_header(jar: list, url: str) -> str:
         pair = f"{name}={value}"
         if any(ch in pair for ch in "\r\n\x00"):
             die("a cookie in the jar contains a line break and cannot be sent — "
-                "reconnect at https://auth.acedata.cloud/user/connections.")
+                "reconnect at https://studio.acedata.cloud/console/connectors.")
         try:
             pair.encode("latin-1")
         except UnicodeEncodeError:
             die("a cookie in the jar contains characters that cannot be sent in "
                 "an HTTP header — reconnect at "
-                "https://auth.acedata.cloud/user/connections.")
+                "https://studio.acedata.cloud/console/connectors.")
         parts.append(pair)
     return "; ".join(parts)
 
@@ -197,7 +197,7 @@ def request(method: str, url: str, jar: list, *, headers=None, form=None,
         if e.code in (301, 302, 303, 307, 308):
             die("51CTO redirected the request — not followed, so no credential "
                 "left 51cto.com. You are most likely logged out; reconnect at "
-                "https://auth.acedata.cloud/user/connections."
+                "https://studio.acedata.cloud/console/connectors."
                 + (" This was a WRITE: its outcome is UNKNOWN — check your "
                    "drafts before retrying." if write else ""))
         # Draining the error body can itself raise (IncompleteRead / reset).
@@ -228,7 +228,7 @@ def publish_page(jar: list) -> tuple[str, dict]:
     status, html = request("GET", PUBLISH_PAGE, jar)
     if status in (401, 403):
         die("auth failed — cookie expired or invalid. Reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     if status != 200:
         die(f"unexpected status {status} loading the 51CTO publish page")
     m = _USER_RE.search(html)
@@ -238,10 +238,10 @@ def publish_page(jar: list) -> tuple[str, dict]:
         # changed" instead of always blaming the cookie.
         if "/user/login" in html or "home.51cto.com/login" in html:
             die("not logged in to 51CTO — reconnect at "
-                "https://auth.acedata.cloud/user/connections.")
+                "https://studio.acedata.cloud/console/connectors.")
         die("could not confirm the 51CTO session from the publish page — either "
             "the cookie expired or 51CTO changed its markup. Try reconnecting "
-            "at https://auth.acedata.cloud/user/connections; if that does not "
+            "at https://studio.acedata.cloud/console/connectors; if that does not "
             "help, this skill needs updating.")
     link, avatar = m.group(1), m.group(2)
     csrf_m = _CSRF_RE.search(html)

--- a/skills/didi-ride/SKILL.md
+++ b/skills/didi-ride/SKILL.md
@@ -27,7 +27,7 @@ The `didi` BYOC connector injects one env var into the sandbox:
 - `DIDI_MCP_KEY` — the user's DiDi MCP key. **Secret — never echo, print, or log it.**
 
 If `DIDI_MCP_KEY` is missing, tell the user to connect the DiDi connector at
-[auth.acedata.cloud/user/connections](https://auth.acedata.cloud/user/connections)
+[studio.acedata.cloud/console/connectors](https://studio.acedata.cloud/console/connectors)
 (they get the key by scanning the QR in the 滴滴出行 App or via
 <https://mcp.didichuxing.com/claw>).
 

--- a/skills/didi-ride/scripts/didi.py
+++ b/skills/didi-ride/scripts/didi.py
@@ -73,7 +73,7 @@ class MCPClient:
                     "error": f"HTTP {exc.code} from DiDi MCP",
                     "detail": detail,
                     "hint": "If 401/403, the DiDi connector key is missing or expired — "
-                    "reconnect at https://auth.acedata.cloud/user/connections",
+                    "reconnect at https://studio.acedata.cloud/console/connectors",
                 }
             )
         except urllib.error.URLError as exc:
@@ -208,7 +208,7 @@ def main() -> None:
             {
                 "error": "DIDI_MCP_KEY not set",
                 "hint": "Connect the DiDi connector at "
-                "https://auth.acedata.cloud/user/connections to inject the key.",
+                "https://studio.acedata.cloud/console/connectors to inject the key.",
             }
         )
 

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -31,12 +31,12 @@ connector injected. Check the environment first and follow the matching section:
 ```sh
 if [ -n "$DISCORD_USER_TOKEN" ]; then echo "mode: user-token (full)"; \
 elif [ -n "$DISCORD_TOKEN" ]; then echo "mode: oauth (read-only)"; \
-else echo "no Discord connection — connect at https://auth.acedata.cloud/user/connections"; fi
+else echo "no Discord connection — connect at https://studio.acedata.cloud/console/connectors"; fi
 ```
 
 Both tokens are **secret — full account access. Never echo or print them.** On
 `401`, the token expired or was revoked — tell the user to reconnect at
-`auth.acedata.cloud/user/connections`. On `429`, sleep the `retry_after`
+`studio.acedata.cloud/console/connectors`. On `429`, sleep the `retry_after`
 seconds, then retry; never parallelize.
 
 ---

--- a/skills/discord/scripts/discord_user.py
+++ b/skills/discord/scripts/discord_user.py
@@ -54,7 +54,7 @@ def load_token() -> str:
     tok = os.environ.get("DISCORD_USER_TOKEN")
     if not tok:
         die("DISCORD_USER_TOKEN is not set — connect Discord (User Token) at "
-            "https://auth.acedata.cloud/user/connections, then retry.")
+            "https://studio.acedata.cloud/console/connectors, then retry.")
     return tok.strip()
 
 
@@ -208,7 +208,7 @@ def main() -> None:
         asyncio.run(run(args))
     except LoginFailure as e:
         die("auth failed — the Discord user token is wrong or expired. Reconnect "
-            f"at https://auth.acedata.cloud/user/connections. ({e})")
+            f"at https://studio.acedata.cloud/console/connectors. ({e})")
     except Forbidden as e:
         die(f"forbidden by Discord (no access to that channel/server, or blocked): {e}")
     except NotFound as e:
@@ -222,7 +222,7 @@ def main() -> None:
         die(f"Discord API error (HTTP {status}): {e}")
     except Exception as e:
         die(f"Discord request failed ({type(e).__name__}: {e}). Likely an expired "
-            "token — reconnect at https://auth.acedata.cloud/user/connections.")
+            "token — reconnect at https://studio.acedata.cloud/console/connectors.")
 
 
 if __name__ == "__main__":

--- a/skills/discordbot/SKILL.md
+++ b/skills/discordbot/SKILL.md
@@ -30,7 +30,7 @@ than retrying.
 
 Errors are JSON `{"code": <n>, "message": "<reason>"}`. A `401` means the
 bot token is wrong/reset — ask the user to re-paste it at
-`auth.acedata.cloud/user/connections`. A `429` carries `retry_after`
+`studio.acedata.cloud/console/connectors`. A `429` carries `retry_after`
 (seconds) — sleep that long, then retry; never parallelize.
 
 ## Sending safety

--- a/skills/discordbot/scripts/discordbot.py
+++ b/skills/discordbot/scripts/discordbot.py
@@ -62,7 +62,7 @@ def api_request(method: str, path: str, payload: dict[str, Any] | None = None) -
     if not token:
         raise DiscordBotError(
             "DISCORDBOT_TOKEN is not set; connect Discord Bot at "
-            "https://auth.acedata.cloud/user/connections"
+            "https://studio.acedata.cloud/console/connectors"
         )
     body = json.dumps(payload).encode() if payload is not None else None
     request = urllib.request.Request(

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -25,7 +25,7 @@ diagnosing a `403`:
 ```sh
 if [ -n "$GITHUB_TOKEN" ]; then echo "mode: pat (user-created token)"; \
 elif [ -n "$GH_TOKEN" ]; then echo "mode: oauth"; \
-else echo "no GitHub connection — connect at https://auth.acedata.cloud/user/connections"; fi
+else echo "no GitHub connection — connect at https://studio.acedata.cloud/console/connectors"; fi
 ```
 
 Both are **secret — full account access within their scope. Never echo or
@@ -58,7 +58,7 @@ how you phrase the call:
 Users pick scopes at install time and every box is optional, so even the
 five above may be partially granted. A `404` on something you know exists,
 or a `403`, usually means a missing scope — not a wrong URL. Say so plainly
-and point the user at `auth.acedata.cloud/user/connections` to reconnect
+and point the user at `studio.acedata.cloud/console/connectors` to reconnect
 with the box ticked (OAuth) or to paste a token with wider permissions (PAT).
 
 ## Two ways to call gh — prefer subcommands
@@ -359,7 +359,7 @@ so those queries return `INSUFFICIENT_SCOPES`. Don't build recipes on it.
 ## Notes
 
 - For private repos the user MUST have granted `repo` scope when they
-  authorized the connection at `auth.acedata.cloud/user/connections`.
+  authorized the connection at `studio.acedata.cloud/console/connectors`.
   A 404 on a repo you know exists usually means missing scope, not a
   wrong URL.
 - When `--json` rejects a field name, gh prints the full list of valid

--- a/skills/habr/SKILL.md
+++ b/skills/habr/SKILL.md
@@ -32,7 +32,7 @@ python3 "$H" get --id ARTICLE_ID > draft.json
 ```
 
 An auth error means the Cookie expired. Ask the user to reconnect Habr at
-<https://auth.acedata.cloud/user/connections>; never retry in a loop.
+<https://studio.acedata.cloud/console/connectors>; never retry in a loop.
 
 ## Save or preview a draft
 

--- a/skills/hashnode/SKILL.md
+++ b/skills/hashnode/SKILL.md
@@ -40,7 +40,7 @@ python3 "$H" publications          # list the user's blogs (verifies the cookie)
 ```
 
 On an auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+<https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## ⚠️ Non-Pro blogs are automoderated — write EDITORIAL, not ads
 

--- a/skills/hashnode/scripts/hashnode.py
+++ b/skills/hashnode/scripts/hashnode.py
@@ -74,7 +74,7 @@ def load_cookies() -> list:
     raw = os.environ.get("HASHNODE_COOKIES")
     if not raw:
         die("HASHNODE_COOKIES is not set — connect Hashnode at "
-            "https://auth.acedata.cloud/user/connections, then retry.")
+            "https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -84,7 +84,7 @@ def load_cookies() -> list:
     if not any(c.get("name") == "hashnode-session" for c in jar):
         die("HASHNODE_COOKIES is missing the 'hashnode-session' cookie — re-capture "
             "on hashnode.com with the ACE extension, then reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return jar
 
 
@@ -163,7 +163,7 @@ def api(method, path, jar, *, body=None, _retried=False):
         return api(method, path, jar, body=body, _retried=True)
     if status in (401, 403):
         die(f"auth failed ({status}) on {path} — cookie likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+            f"Reconnect at https://studio.acedata.cloud/console/connectors.")
     # A hashnode.com/api path that 404s with an HTML body means the route/id is
     # wrong; a JSON {success:false} is a real API error.
     stripped = text.lstrip()

--- a/skills/juejin/SKILL.md
+++ b/skills/juejin/SKILL.md
@@ -51,7 +51,7 @@ python3 "$JJ" whoami
 ```
 
 On an auth error (`err_no` 401 / "请登录") the cookie is expired — have the user
-reconnect at <https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+reconnect at <https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/juejin/scripts/juejin.py
+++ b/skills/juejin/scripts/juejin.py
@@ -58,7 +58,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect 掘金 at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -145,7 +145,7 @@ def api_env(method: str, path: str, jar: list, *, body=None) -> dict:
         msg = env.get("err_msg", "")
         if err in (401, 403) or "登录" in str(msg):
             die(f"auth failed (err_no={err}: {msg}) — cookie likely expired. "
-                f"Reconnect at https://auth.acedata.cloud/user/connections.")
+                f"Reconnect at https://studio.acedata.cloud/console/connectors.")
         die(f"juejin API error on {path} (err_no={err}): {msg}")
     return env
 

--- a/skills/medium/SKILL.md
+++ b/skills/medium/SKILL.md
@@ -52,7 +52,7 @@ python3 "$MED" whoami
 ```
 
 On an auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+<https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/medium/scripts/medium.py
+++ b/skills/medium/scripts/medium.py
@@ -68,7 +68,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect Medium at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -163,7 +163,7 @@ def api(method, url, jar, *, body=None, _retried=False):
         return api(method, url, jar, body=body, _retried=True)
     if status in (401, 403):
         die(f"auth failed ({status}) on {url} — cookie likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+            f"Reconnect at https://studio.acedata.cloud/console/connectors.")
     clean = _PREFIX.sub("", text)
     try:
         d = json.loads(clean)
@@ -206,7 +206,7 @@ def md_me(jar):
     uid = cookie_value(jar, "uid")
     if not uid:
         die("no uid cookie — reconnect Medium at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     d = api("GET", f"{BASE}/_/api/users/{uid}", jar)
     val = (d.get("payload") or {}).get("value") or {}
     if not val.get("userId"):
@@ -606,7 +606,7 @@ def cmd_publish(jar, args):
     prime_xsrf(jar)
     if not cookie_value(jar, "xsrf"):
         die("could not obtain an xsrf token from Medium (cookie may be expired) — "
-            "reconnect at https://auth.acedata.cloud/user/connections.")
+            "reconnect at https://studio.acedata.cloud/console/connectors.")
 
     # 1. create empty draft
     d = api("POST", f"{BASE}/new-story", jar, body={})

--- a/skills/oschina/SKILL.md
+++ b/skills/oschina/SKILL.md
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/oschina.py" whoami
 ```
 
 If this fails with an auth error, the cookie has expired. Ask the user to
-reconnect at `https://auth.acedata.cloud/user/connections` rather than retrying.
+reconnect at `https://studio.acedata.cloud/console/connectors` rather than retrying.
 
 ## Create a draft — GATED
 

--- a/skills/oschina/scripts/oschina.py
+++ b/skills/oschina/scripts/oschina.py
@@ -77,7 +77,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect 开源中国 at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -141,7 +141,7 @@ def request(method: str, url: str, jar: list, *, headers=None, body=None, write:
         if e.code in (301, 302, 303, 307, 308):
             die(f"开源中国 redirected {method} {url} — not followed, so no "
                 f"credential left oschina.net. You are most likely logged out; "
-                f"reconnect at https://auth.acedata.cloud/user/connections."
+                f"reconnect at https://studio.acedata.cloud/console/connectors."
                 + (" This was a WRITE: its outcome is UNKNOWN — check your "
                    "drafts before retrying." if write else ""))
         raw = e.read()
@@ -179,7 +179,7 @@ def api_call(method: str, path: str, jar: list, *, body=None, write: bool = Fals
         code = env.get("code")
         if code in (40001, 401, 403) or "未登录" in msg or "登录" in msg:
             die(f"auth failed (code={code}: {msg}) — cookie likely expired. "
-                f"Reconnect at https://auth.acedata.cloud/user/connections.")
+                f"Reconnect at https://studio.acedata.cloud/console/connectors.")
         die(f"开源中国 API error on {path} (code={code}): {msg}")
     return env.get("result")
 

--- a/skills/reddit/SKILL.md
+++ b/skills/reddit/SKILL.md
@@ -42,7 +42,7 @@ python3 "$R" whoami
 ```
 
 If authentication fails, ask the user to reconnect at
-<https://auth.acedata.cloud/user/connections>. Do not loop-retry a blocked or
+<https://studio.acedata.cloud/console/connectors>. Do not loop-retry a blocked or
 expired session.
 
 ## Read

--- a/skills/reddit/scripts/reddit.py
+++ b/skills/reddit/scripts/reddit.py
@@ -100,7 +100,7 @@ def parse_cookie_jar(raw: str) -> list[dict]:
         die(
             "REDDIT_COOKIES is missing a valid reddit_session — log in on reddit.com, "
             "re-capture with the ACE extension, then reconnect at "
-            "https://auth.acedata.cloud/user/connections."
+            "https://studio.acedata.cloud/console/connectors."
         )
     return normalized
 
@@ -308,7 +308,7 @@ class RedditClient:
             return cls("cookie", cookies=parse_cookie_jar(raw_cookies))
         die(
             "No Reddit credential is available — connect Reddit with Cookie or OAuth at "
-            "https://auth.acedata.cloud/user/connections."
+            "https://studio.acedata.cloud/console/connectors."
         )
 
     @property
@@ -375,7 +375,7 @@ class RedditClient:
         if status in {401, 403}:
             die(
                 f"Reddit authentication failed ({status}) — the credential may be expired or blocked. "
-                "Reconnect at https://auth.acedata.cloud/user/connections."
+                "Reconnect at https://studio.acedata.cloud/console/connectors."
             )
         if status == 429:
             die("Reddit rate limit reached (429). Wait before retrying; do not loop-retry.")

--- a/skills/segmentfault/SKILL.md
+++ b/skills/segmentfault/SKILL.md
@@ -45,7 +45,7 @@ python3 "$SKILL_DIR/scripts/segmentfault.py" whoami
 ```
 
 If this fails with an auth error, the cookie has expired. Ask the user to
-reconnect at `https://auth.acedata.cloud/user/connections` rather than retrying.
+reconnect at `https://studio.acedata.cloud/console/connectors` rather than retrying.
 
 ## Create a draft — GATED
 

--- a/skills/segmentfault/scripts/segmentfault.py
+++ b/skills/segmentfault/scripts/segmentfault.py
@@ -79,7 +79,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect SegmentFault at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -143,7 +143,7 @@ def request(method: str, url: str, jar: list, *, headers=None, body=None, write:
         if e.code in (301, 302, 303, 307, 308):
             die(f"SegmentFault redirected {method} {url} — not followed, so no "
                 f"credential left segmentfault.com. You are most likely logged "
-                f"out; reconnect at https://auth.acedata.cloud/user/connections."
+                f"out; reconnect at https://studio.acedata.cloud/console/connectors."
                 + (" This was a WRITE: its outcome is UNKNOWN — check your "
                    "drafts before retrying." if write else ""))
         raw = e.read()
@@ -164,7 +164,7 @@ def request(method: str, url: str, jar: list, *, headers=None, body=None, write:
 def _auth_died(status: int, text: str) -> None:
     if status in (401, 403) or text.strip('"') == "Unauthorized":
         die("auth failed — cookie expired or invalid. Reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
 
 
 def session_token(jar: list) -> str:
@@ -175,7 +175,7 @@ def session_token(jar: list) -> str:
     if not m:
         die("could not find the SegmentFault session token on /write — you are "
             "probably logged out. Reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return m.group(1)
 
 
@@ -192,7 +192,7 @@ def cmd_whoami(jar, _args):
     )
     if not name and "登录" in html:
         die("not logged in — cookie expired. Reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     out({
         "platform": PLATFORM,
         "name": name.group(1) if name else None,

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -122,7 +122,7 @@ curl -sS -X POST https://slack.com/api/files.completeUploadExternal \
   `conversations.join` first (which also takes the channel id), then
   retry. Private channels and DMs need a manual invite — ask the user.
 - Always check `.ok` on the JSON response. `not_authed` / `invalid_auth`
-  → ask the user to re-authorize at `auth.acedata.cloud/user/connections`.
+  → ask the user to re-authorize at `studio.acedata.cloud/console/connectors`.
 - Channel ids start with `C` (channels), `D` (DMs), `G` (private). Don't
   invent ids — always look them up via `conversations.list` or
   `users.lookupByEmail`.

--- a/skills/substack/SKILL.md
+++ b/skills/substack/SKILL.md
@@ -51,7 +51,7 @@ python3 "$SUB" whoami
 ```
 
 On an auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+<https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/substack/scripts/substack.py
+++ b/skills/substack/scripts/substack.py
@@ -62,7 +62,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect Substack at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -137,7 +137,7 @@ def api(method, url, jar, *, body=None, _retried=False):
         return api(method, url, jar, body=body, _retried=True)
     if status in (401, 403):
         die(f"auth failed ({status}) on {url} — cookie likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+            f"Reconnect at https://studio.acedata.cloud/console/connectors.")
     try:
         d = json.loads(text) if text.strip() else {}
     except json.JSONDecodeError:

--- a/skills/telegram/SKILL.md
+++ b/skills/telegram/SKILL.md
@@ -55,7 +55,7 @@ python3 "$TG" whoami
 ```
 
 On an auth/session error the stored session is dead — tell the user to reconnect at
-https://auth.acedata.cloud/user/connections.
+https://studio.acedata.cloud/console/connectors.
 
 ## Read recipes
 

--- a/skills/tencent-docs/SKILL.md
+++ b/skills/tencent-docs/SKILL.md
@@ -56,7 +56,7 @@ Common error codes:
 
 | code | meaning | what to do |
 |---|---|---|
-| `400006` | access token invalid / expired | tell the user to reconnect 腾讯文档 at <https://auth.acedata.cloud/user/connections> — do **not** loop-retry |
+| `400006` | access token invalid / expired | tell the user to reconnect 腾讯文档 at <https://studio.acedata.cloud/console/connectors> — do **not** loop-retry |
 | `400007` | VIP (超级会员) privilege required | the requested capability needs a Tencent Docs 超级会员; tell the user, link <https://docs.qq.com/vip> |
 | `400008` | 积分 (credits) insufficient | AI-generation quota is exhausted; tell the user to top up |
 | `11607` / `-32603` | bad request params | recheck `fileID` / `type` / body fields against the recipe below |

--- a/skills/toutiao/SKILL.md
+++ b/skills/toutiao/SKILL.md
@@ -58,7 +58,7 @@ python3 "$TT" whoami
 ```
 
 On an auth error the cookie is expired — tell the user to reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** retry in a loop.
+<https://studio.acedata.cloud/console/connectors>. Do **not** retry in a loop.
 
 ## Publishing — GATED (dry-run unless trailing `--confirm`)
 
@@ -104,7 +104,7 @@ unless the body already carries 头条-hosted images).
   publish with 头条's own message — relay it, don't retry in a loop.
 - **14-day edit window**: 头条 refuses edits to articles published more than 14
   days ago, so this skill does not offer an edit command.
-- **Cookie expiry**: reconnect at auth.acedata.cloud/user/connections.
+- **Cookie expiry**: reconnect at studio.acedata.cloud/console/connectors.
 - **Never print `TOUTIAO_COOKIES`** — it is full account access.
 - **ToS**: cookie automation acts only on the user's own account with their own
   captured cookie; the user owns that risk.

--- a/skills/toutiao/scripts/toutiao.py
+++ b/skills/toutiao/scripts/toutiao.py
@@ -68,7 +68,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect 今日头条 at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -173,7 +173,7 @@ def api_envelope(method: str, path: str, jar: list, *, referer=None, body=None, 
                            nonfatal=nonfatal)
     if status in (401, 403) or "/auth/page/login" in text:
         msg = (f"auth failed ({status}) on {path} — cookie likely expired. "
-               f"Reconnect 今日头条 at https://auth.acedata.cloud/user/connections.")
+               f"Reconnect 今日头条 at https://studio.acedata.cloud/console/connectors.")
         if nonfatal:
             raise RuntimeError(msg)
         die(msg)
@@ -196,7 +196,7 @@ def api_envelope(method: str, path: str, jar: list, *, referer=None, body=None, 
         msg = env.get("message") or env.get("reason") or ""
         if code in (401, 403) or "登录" in str(msg):
             auth_msg = (f"auth failed (code={code}: {msg}) — cookie likely expired. "
-                        f"Reconnect at https://auth.acedata.cloud/user/connections.")
+                        f"Reconnect at https://studio.acedata.cloud/console/connectors.")
             if nonfatal:
                 raise RuntimeError(auth_msg)
             die(auth_msg)
@@ -689,7 +689,7 @@ def cmd_publish(jar, args):
     # deep in its API with an opaque code instead of "reconnect".
     if not cookie_value(jar, "csrftoken"):
         die("the 今日头条 cookie jar has no `csrftoken` — it is incomplete or "
-            "expired. Reconnect at https://auth.acedata.cloud/user/connections.")
+            "expired. Reconnect at https://studio.acedata.cloud/console/connectors.")
 
     # Render to HTML FIRST, then rewrite <img> tags — 头条 rejects the whole
     # article (7115) if any image isn't hosted on its own CDN with web_uri.

--- a/skills/weibo/SKILL.md
+++ b/skills/weibo/SKILL.md
@@ -59,7 +59,7 @@ python3 "$WB" whoami
 ```
 
 On an auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. Do **not** loop-retry.
+<https://studio.acedata.cloud/console/connectors>. Do **not** loop-retry.
 
 ## Posting — GATED (dry-run unless trailing `--confirm`)
 

--- a/skills/weibo/scripts/weibo.py
+++ b/skills/weibo/scripts/weibo.py
@@ -61,7 +61,7 @@ def load_cookies() -> list:
     raw = os.environ.get(env)
     if not raw:
         die(f"{env} is not set — connect 微博 at "
-            f"https://auth.acedata.cloud/user/connections, then retry.")
+            f"https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -142,7 +142,7 @@ def get_json(url, jar):
     status, text = request("GET", url, jar)
     if status in (401, 403):
         die(f"auth failed ({status}) on {url} — cookie likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections.")
+            f"Reconnect at https://studio.acedata.cloud/console/connectors.")
     try:
         return json.loads(text)
     except json.JSONDecodeError:
@@ -153,7 +153,7 @@ def st_token(jar):
     tok = cookie_value(jar, "XSRF-TOKEN")
     if not tok:
         die("no XSRF-TOKEN cookie — reconnect 微博 at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return tok
 
 
@@ -165,7 +165,7 @@ def wb_uid(jar):
     uid = data.get("uid")
     if not uid:
         die("not logged in or uid unavailable (cookie expired?) — reconnect 微博 "
-            "at https://auth.acedata.cloud/user/connections.")
+            "at https://studio.acedata.cloud/console/connectors.")
     return uid
 
 

--- a/skills/x/SKILL.md
+++ b/skills/x/SKILL.md
@@ -79,7 +79,7 @@ belongs to someone else. Do not invent an expected handle — plain `whoami` is
 the default.
 
 On an actual auth error the cookie is expired — have the user reconnect at
-<https://auth.acedata.cloud/user/connections>. A Cloudflare block is different:
+<https://studio.acedata.cloud/console/connectors>. A Cloudflare block is different:
 reconnecting cookies does not fix it. Use `whoami` for identity checks; other
 blocked endpoints need `X_PROXY` or the official X API. Do **not** loop-retry a
 Cloudflare block or an auth error.

--- a/skills/x/scripts/x.py
+++ b/skills/x/scripts/x.py
@@ -71,7 +71,7 @@ def load_cookie_dict() -> dict:
     raw = os.environ.get("X_COOKIES")
     if not raw:
         die("X_COOKIES is not set — connect X (Twitter) at "
-            "https://auth.acedata.cloud/user/connections, then retry.")
+            "https://studio.acedata.cloud/console/connectors, then retry.")
     try:
         jar = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -86,7 +86,7 @@ def load_cookie_dict() -> dict:
     if "auth_token" not in cookies or "ct0" not in cookies:
         die("X_COOKIES is missing auth_token / ct0 — re-capture the cookie on "
             "x.com with the ACE extension, then reconnect at "
-            "https://auth.acedata.cloud/user/connections.")
+            "https://studio.acedata.cloud/console/connectors.")
     return cookies
 
 
@@ -595,7 +595,7 @@ def main() -> None:
         asyncio.run(run(args))
     except (Unauthorized,) as e:
         die(f"auth failed — cookie likely expired. Reconnect X at "
-            f"https://auth.acedata.cloud/user/connections. ({e})")
+            f"https://studio.acedata.cloud/console/connectors. ({e})")
     except (AccountLocked, AccountSuspended) as e:
         die(f"account locked/suspended by X: {e}")
     except TooManyRequests as e:
@@ -635,7 +635,7 @@ def main() -> None:
                 "cookie. Retry after twikit/X compatibility is fixed."
             )
         die(f"X request failed ({type(e).__name__}: {e}). Likely an expired "
-            f"cookie — reconnect at https://auth.acedata.cloud/user/connections "
+            f"cookie — reconnect at https://studio.acedata.cloud/console/connectors "
             f"— or twikit drift vs X's internal API.")
 
 

--- a/skills/yuque/SKILL.md
+++ b/skills/yuque/SKILL.md
@@ -49,7 +49,7 @@ python3 "$Y" whoami
 ```
 
 On an auth error, ask the user to reconnect at
-<https://auth.acedata.cloud/user/connections>. Never ask for their password,
+<https://studio.acedata.cloud/console/connectors>. Never ask for their password,
 and never ask them to paste a Cookie into the chat.
 
 ## Read

--- a/skills/yuque/scripts/yuque.py
+++ b/skills/yuque/scripts/yuque.py
@@ -42,7 +42,7 @@ TOKEN_ONLY_COMMANDS = {"update", "delete"}
 MAX_CONTENT_BYTES = 10 * 1024 * 1024
 MAX_ITEMS = 100
 
-RECONNECT = "https://auth.acedata.cloud/user/connections"
+RECONNECT = "https://studio.acedata.cloud/console/connectors"
 
 
 def output(value) -> None:

--- a/skills/yuque/tests/test_yuque.py
+++ b/skills/yuque/tests/test_yuque.py
@@ -55,7 +55,7 @@ class ModeSelection(unittest.TestCase):
     def test_no_credential_dies_with_a_reconnect_hint(self):
         code, payload = run(["whoami"], {})
         self.assertEqual(code, 1)
-        self.assertIn("connections", payload["error"])
+        self.assertIn("console/connectors", payload["error"])
 
     def test_cookie_jar_without_ctoken_is_rejected(self):
         jar = [c for c in COOKIES if c["name"] != "yuque_ctoken"]

--- a/skills/zhihu/SKILL.md
+++ b/skills/zhihu/SKILL.md
@@ -142,7 +142,7 @@ python3 "$ZDIR/scripts/blog.py" whoami
 ```
 
 On a `401`/`403` the cookie is expired — tell the user to reconnect at
-<https://auth.acedata.cloud/user/connections> (re-capture with the ACE
+<https://studio.acedata.cloud/console/connectors> (re-capture with the ACE
 extension). Do **not** retry in a loop.
 
 ## Reading recipes
@@ -234,7 +234,7 @@ python3 "$BLOG" edit-answer --id <answer-id> --content-file ans.html --confirm  
 - **This is the user's real Zhihu account.** Confirm before any publish / answer /
   edit; reading exposes their own private drafts.
 - **Cookie expiry**: Zhihu cookies are short-lived. A `401`/`403` means
-  reconnect at auth.acedata.cloud/user/connections — never loop-retry.
+  reconnect at studio.acedata.cloud/console/connectors — never loop-retry.
 - **ToS**: cookie automation is against most platforms' terms. This only ever
   acts on the user's own account with their own captured cookie; the user owns
   that risk. Never use it to scrape other people's content at scale.

--- a/skills/zhihu/scripts/blog.py
+++ b/skills/zhihu/scripts/blog.py
@@ -73,7 +73,7 @@ def load_cookies(platform: str) -> list[dict]:
     if not raw:
         die(
             f"{env} is not set — connect the {platform} account at "
-            f"https://auth.acedata.cloud/user/connections, then retry."
+            f"https://studio.acedata.cloud/console/connectors, then retry."
         )
     try:
         jar = json.loads(raw)
@@ -156,7 +156,7 @@ def get_json(url: str, jar: list[dict], **kw):
     if status == 401 or status == 403:
         die(
             f"auth failed ({status}) on {url} — the cookie is likely expired. "
-            f"Reconnect at https://auth.acedata.cloud/user/connections."
+            f"Reconnect at https://studio.acedata.cloud/console/connectors."
         )
     try:
         return status, json.loads(text)


### PR DESCRIPTION
连接器管理已搬到 Studio，但各 skill 抛给用户的「去这里重新连接」提示、以及 `SKILL.md` 里的操作指引，还写着 `auth.acedata.cloud/user/connections` —— 用户照着点会落到旧页面。

## 改了什么

47 个文件、92 处（27 个 `.md` + 19 个 `.py`，加一个测试断言）：

| 旧 | 新 |
|---|---|
| `auth.acedata.cloud/user/connections` | `studio.acedata.cloud/console/connectors` |
| `auth.acedata.cloud/user/skills` | `studio.acedata.cloud/console/skills` |

带 scheme 和不带 scheme 的写法都处理了。

## 确认过不涉及协议

`.py` 里的命中全是 `RECONNECT` 常量和异常消息（给用户读的），`grep` 确认没有一处被用作 `redirect_uri` / `oauth` / `callback`。这点和 PlatformService#1800 里的情况不同 —— 那边 `connectionOAuthProvider.ts` 有真正的 OAuth 契约值需要保留，这里没有。

## 顺带修了一条测试断言

`skills/yuque/tests/test_yuque.py:58` 原本是：

```python
self.assertIn("connections", payload["error"])
```

新路径 `/console/connectors` **不含 "connections" 子串**，所以这条会挂。改为断言 `"console/connectors"`。

值得一提：这条断言是**跑测试才发现的** —— 前期调研用 grep 找"测试是否锁死该 URL"时没命中它，因为它断言的是子串而不是完整 URL。

## 验证

- 根测试 `python3 -m unittest discover -s tests`：**77 passed**
- 逐个 skill 的测试套件（CI 的 per-skill 步骤）：**全部 OK**
- 56 个 Python 文件 `ast.parse` 全部通过（确认批量替换没破坏语法）
- `.github/skills` / `.agents/skills` 两个镜像目录已确认无残留旧链接
