### PR TITLE
没声明 initial_url，会话就落在消费端首页

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -39,6 +39,9 @@ execution:
     origins:
       - https://www.xiaohongshu.com
       - https://creator.xiaohongshu.com
+    # Without this the session lands on origins[0] — the consumer homepage,
+    # which carries no creator surface at all.
+    initial_url: https://creator.xiaohongshu.com/publish/publish
     capabilities:
       - tabs.read
       - tabs.manage

--- a/skills/xiaohongshu/tests/test_browser_contract.py
+++ b/skills/xiaohongshu/tests/test_browser_contract.py
@@ -139,6 +139,14 @@ def test_browser_execution_frontmatter_contract() -> None:
     assert re.search(r"^    skill_revision: 4\.3\.0$", frontmatter, re.MULTILINE)
     assert re.search(r"^    provider: xiaohongshu/xiaohongshu$", frontmatter, re.MULTILINE)
     assert _nested_list(frontmatter, "origins") == EXPECTED_ORIGINS
+    # Publishing lives on creator.; without an explicit initial_url the session
+    # silently lands on origins[0], the consumer homepage, and every run has to
+    # navigate off it before it can do anything.
+    assert re.search(
+        r"^    initial_url: https://creator\.xiaohongshu\.com/publish/publish$",
+        frontmatter,
+        re.MULTILINE,
+    )
     assert _nested_list(frontmatter, "capabilities") == EXPECTED_CAPABILITIES
     assert _top_level_list(frontmatter, "allowed_tools") == EXPECTED_FACADES
     assert "  browser_contract: contracts/browser-manifest.compact.json" in frontmatter


### PR DESCRIPTION
`initial_url` 缺省时会静默回落到 `origins[0]`（`browserExecution.ts:89` 的 `?? origins?.[0]`），这里是 `https://www.xiaohongshu.com` —— 一个完全没有创作面的页面。

后果有两层：

1. 每次会话开场都得先从首页导航走，白费一跳。
2. 更糟的是**会话中途重开时**：发布做到一半，标签页被换成首页，等于前功尽弃。会话 `960096f3` 就是这样，图传成功之后 tab 被换掉，文案一个字也没填进去。

发布只存在于 `creator.` 上，直接声明它。

## 配套

会话重开的真根因（relay 续期结构性失败）修在：https://github.com/AceDataCloud/PlatformService/pull/1820

## 验证

`test_browser_contract.py` 加了断言守住这个声明：`11 passed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)