### PR TITLE
docs(ai-chat): drop 4 zero-traffic Kimi K2 models from the model table

### DIFF
--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -62,7 +62,7 @@ models include:
 | Gemini | `gemini-3.5-flash`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
 | Grok | `grok-4.5`, `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
 | DeepSeek | `deepseek-r1`, `deepseek-r1-0528`, `deepseek-v3`, `deepseek-v3-250324`, `deepseek-v3.2-exp`, `deepseek-v4-flash` |
-| Kimi | `kimi-k3`, `kimi-k2.6`, `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking`, `kimi-k2-instruct-0905`, `kimi-k2-0905-preview`, `kimi-k2-turbo-preview`, `kimi-k2-0711-preview` |
+| Kimi | `kimi-k3`, `kimi-k2.6`, `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` |
 | GLM | `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5v`, `glm-3-turbo` |
 
 `/aichat2/conversations` also accepts `model_group` values


### PR DESCRIPTION
配合 PlatformBackend#1269 的 Skill 文档同步。

从 ai-chat SKILL.md 的 Kimi 模型表移除 4 个真实调用为 0 的模型：

- `kimi-k2-instruct-0905`
- `kimi-k2-0905-preview`
- `kimi-k2-turbo-preview`
- `kimi-k2-0711-preview`

7 天 CLS 显示四者真实调用均为 0（表面各约 1000 次全部来自平台 E2E 探针）。

保留：`kimi-k3`、`kimi-k2.6`、`kimi-k2.5`、`kimi-k2-thinking-turbo`、`kimi-k2-thinking`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)