### PR TITLE
fix(personal-wechat): 对齐 Wisdom 现网 API —— 修死接口 404 + 支持真·艾特

### DIFF
--- a/skills/personal-wechat/SKILL.md
+++ b/skills/personal-wechat/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: personal-wechat
-description: Operate the user's personal WeChat account through their self-hosted Wisdom service (BYOC) — check login status, list contacts/conversations, read and summarize history, search contacts, refresh the local history DB, and send messages only after explicit confirmation. Use when the user mentions 个人微信, 我的微信, WeChat personal chat, 微信聊天记录, 微信联系人, reading/summarizing WeChat messages, or sending a WeChat message.
+description: Operate the user's personal WeChat account through their self-hosted Wisdom service (BYOC) — check status, list contacts/conversations, read messages, poll for new ones, search contacts, browse Moments, and (after explicit confirmation) send messages with real @-mentions, post or delete Moments, and manage group chats. Use when the user mentions 个人微信, 我的微信, WeChat personal chat, 微信聊天记录, 微信联系人, 微信群, 朋友圈, reading/summarizing WeChat messages, or sending a WeChat message.
 when_to_use: |
   Trigger for the user's personal WeChat account via their own Wisdom server:
-  check status/account, list contacts, list recent conversations, read or
-  summarize a chat, query local history, search contacts, or send a message.
-  This acts on the user's real desktop WeChat, so writes are gated behind
-  explicit confirmation.
+  check status/account, list contacts, list conversations, read or summarize a
+  chat, poll for new messages, search contacts, browse Moments, send a message
+  (with real @-mentions, quote-replies, or media), publish/delete a Moment, or
+  create/invite/remove/rename a group. This acts on the user's real desktop
+  WeChat, so every write is gated behind explicit confirmation.
 connections: [personalwechat]
 allowed_tools: [Bash]
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Personal WeChat via Wisdom
@@ -23,17 +24,17 @@ an HTTP API.
 
 Credentials are injected by the `personalwechat` BYOC connector:
 
-- `PERSONALWECHAT_BASE_URL` — Wisdom server base URL, e.g. `http://82.156.126.14:8000`.
+- `PERSONALWECHAT_BASE_URL` — Wisdom server base URL, e.g. `http://203.0.113.10:8000`.
 - `PERSONALWECHAT_API_TOKEN` — Wisdom `API_TOKEN`. Secret — never echo, print, or log it.
 
 The helper sends the token as `Authorization: Bearer ...`; it never puts the
-token in the URL. For queued UI operations such as search and send, the helper
-submits the task and waits for `/api/tasks/{id}` before printing the final
-result.
+token in the URL. Wisdom answers every UI-driven action (search, send, Moments,
+groups) with `202` + a task ID; the helper polls `/api/tasks/{id}` for you and
+prints only the final result.
 
-This is the user's **real personal WeChat account**. Read operations can run
-directly. Sending messages or files must be dry-run first, then performed only
-after the user explicitly approves the exact target and content.
+This is the user's **real personal WeChat account**. Read operations run
+directly. Every write — send, Moment, group change — dry-runs first and only
+executes after the user explicitly approves that exact payload.
 
 ## CLI
 
@@ -57,12 +58,23 @@ python3 $WX status
 Expected healthy shape:
 
 ```json
-{"auth":{"logged_in":true,"wechat_running":true,"page":"logged_in"}}
+{"status":"ready","since":"…","wechat_running":true,"logged_in":true,"error":null}
 ```
 
-If `logged_in=false`, tell the user to open the Wisdom web UI / RDP and scan the
-WeChat QR code. If the API returns 401, ask the user to reconnect the Personal
-WeChat connector with the current Wisdom API token.
+`/api/status` is the **single** source of truth for connectivity. Judge it by
+`status`, `wechat_running` and `logged_in` — nothing else.
+
+| Symptom | Meaning |
+|---|---|
+| `status: "ready"`, `logged_in: true` | Healthy — proceed. |
+| `status: "qr_scan"` / `logged_in: false` | Ask the user to open the Wisdom web UI / RDP and scan the WeChat QR code. |
+| `status: "preparing"` | The decrypted DB snapshot is still being built. Wait and retry; reads may fail until it finishes. |
+| `status: "error"` | Report `error.code` / `error.message` to the user. |
+| HTTP 401 | Ask the user to reconnect the Personal WeChat connector with the current Wisdom API token. |
+| Connection refused / timeout | Ask the user to check the Windows host, security group, and port 8000. |
+
+Never infer "WeChat is offline" from a 404 on some other path — a 404 means that
+route does not exist on this Wisdom version, not that the account is logged out.
 
 ## Read Workflows
 
@@ -76,58 +88,59 @@ python3 $WX account
 
 ```bash
 python3 $WX contacts --limit 50
+python3 $WX contacts --type group --limit 100
+python3 $WX contacts --limit 100 --offset 100
 ```
 
-### Recent Conversations
+`--limit` is clamped to 200 per page (Wisdom's ceiling). Page with `--offset`
+rather than asking for a bigger limit.
 
-Use the normal conversations endpoint first; it prefers WeChat DB when ready and
-falls back to Wisdom's app DB.
+### Conversations
 
 ```bash
 python3 $WX conversations --limit 20
 ```
 
-For decrypted local WeChat history sessions:
-
-```bash
-python3 $WX conversations --history --limit 20
-```
+Each entry's `id` is what `messages` takes as `conversation_id`. This reads the
+decrypted WeChat database directly and already covers full history — there is no
+separate "history" endpoint.
 
 ### Messages in a Conversation
 
-First list conversations, then use the `id` as `conversation_id`:
-
 ```bash
 python3 $WX messages "CONVERSATION_ID" --limit 50 --order asc
+python3 $WX messages "CONVERSATION_ID" --limit 50 --offset 50
 ```
 
-### Historical Messages
+Output includes `mentions`, `quoted_text` and `conversation_type`, so you can see
+who was @-mentioned and what a 引用 reply was replying to.
 
-Read from Wisdom's decrypted WeChat local databases:
+### New Messages Since a Timestamp
 
 ```bash
-python3 $WX history --limit 50
-python3 $WX history --talker "CONVERSATION_ID" --limit 50
-python3 $WX history --limit 20 --offset 20
+python3 $WX poll --since 1785000000 --limit 100
 ```
 
-### Raw SQL, Read-Only Only
+`--since` is a Unix timestamp in seconds. Use this to catch up after a gap
+instead of re-reading a whole conversation.
 
-Wisdom permits only `SELECT` and `PRAGMA`:
+### Moments (朋友圈)
 
 ```bash
-python3 $WX sql MicroMsg.db 'SELECT count(*) AS cnt FROM Session'
+python3 $WX moments --limit 30
+python3 $WX moments --limit 30 --self-only
 ```
 
-Use raw SQL only for diagnostics or targeted metadata queries. Do not dump large
-message tables unless the user explicitly asks.
+This is a synced view cache, so a just-deleted post may linger until WeChat
+re-syncs.
 
-### Refresh History DB
+### Tasks
 
-If history looks stale, refresh the decrypted DB snapshot:
+Inspect queued/finished UI tasks when a write seems stuck:
 
 ```bash
-python3 $WX refresh-history
+python3 $WX tasks --limit 20
+python3 $WX task TASK_ID
 ```
 
 ## Search
@@ -136,28 +149,94 @@ python3 $WX refresh-history
 python3 $WX search "Alice"
 ```
 
-Search drives the WeChat UI, so it may be slower than local DB history reads.
+Search drives the WeChat UI, so it is slower than the local DB reads above. Use
+it to confirm a target exists before sending.
 
-## Sending Messages — GATED
+## Writes — ALL GATED
 
-`send` dry-runs by default. It never sends unless `--confirm` is present, or
-unless an AceDataCloud scheduled task pre-authorized this Skill and you use
-`--unattended-confirm`.
+Every write command below dry-runs by default, printing the exact payload it
+would submit. It executes only with `--confirm`, or with `--unattended-confirm`
+when an AceDataCloud scheduled task pre-authorized this Skill.
+
+Show the dry-run to the user, get explicit approval of the exact target and
+content, then re-run with `--confirm`. Never put `--confirm` in the first
+attempt. Never infer consent from vague text.
+
+### Send a Message
 
 ```bash
 python3 $WX send "Alice" "今晚 8 点开会吗？"
-# -> {"dry_run": true, ...}
-```
-
-Show the dry-run output to the user and ask for explicit approval of the exact
-recipient and text. Only then run:
-
-```bash
+# -> {"dry_run": true, "action": "send", ...}
 python3 $WX send "Alice" "今晚 8 点开会吗？" --confirm
 ```
 
-Never add `--confirm` in the first attempt. Never infer consent from vague text.
-The user must clearly approve sending this exact message.
+**Real @-mentions in a group.** Pass `--mention` (repeatable) — Wisdom drives
+WeChat's own mention popover, producing a genuine @-notification. Do NOT type
+`@Name` into the message text and hope; that is inert text that notifies nobody.
+
+```bash
+python3 $WX send "项目群" "记得今天交周报" --mention "Doms Jay" --confirm
+python3 $WX send "项目群" "记得今天交周报" --mention "Alice" --mention "Bob" --confirm
+python3 $WX send "项目群" "全员通知" --mention-all --confirm     # owner/admin only
+```
+
+The send result echoes `mentions`. If it comes back `null` after you passed
+`--mention`, the mention did not register — tell the user instead of claiming
+the @ succeeded.
+
+**Quote-reply.** Replies to the newest message in that chat whose text matches:
+
+```bash
+python3 $WX send "Alice" "这个我来跟" --quote-text "这个 bug 谁跟一下" --confirm
+```
+
+`--quote-text` takes precedence over mentions, and falls back to a plain send if
+no matching message is found.
+
+**Media.** Wisdom downloads the URL on the Windows host and sends the file:
+
+```bash
+python3 $WX send "Alice" --type image --image-url https://example.com/a.png --confirm
+python3 $WX send "Alice" --type video --video-url https://example.com/a.mp4 --confirm
+python3 $WX send "Alice" --type file  --file-url  https://example.com/a.pdf --confirm
+```
+
+**Retries.** A send whose outcome you never saw may still have been delivered.
+When retrying, pass the same `--idempotency-key` so Wisdom returns the original
+task instead of sending twice:
+
+```bash
+python3 $WX send "Alice" "hi" --idempotency-key daily-2026-08-04 --confirm
+```
+
+### Moments (朋友圈)
+
+```bash
+python3 $WX moment-post "今天上线了新功能"
+python3 $WX moment-post "看看这张图" --image-url https://example.com/a.png --visibility public --confirm
+```
+
+`--visibility` is `public` / `private` / `partial` / `exclude`
+(公开 / 私密 / 部分可见 / 不给谁看), defaulting to `public`.
+
+Deleting is **irreversible**. `match` must be a distinctive substring of one of
+the user's own Moments; Wisdom refuses ambiguous matches rather than guessing:
+
+```bash
+python3 $WX moment-delete "Veo Videos Generation API"
+python3 $WX moment-delete "Veo Videos Generation API" --confirm
+```
+
+### Group Chats
+
+These are visible to other people — always confirm the exact member list first.
+
+```bash
+python3 $WX group-create "Alice" "Bob" --name "项目群" --confirm   # needs >= 2 members
+python3 $WX group-invite "项目群" "Carol" --confirm
+python3 $WX group-remove "项目群" "Carol" --confirm                # kicks; visible to the group
+python3 $WX group-rename "项目群" "项目群 2026" --confirm           # renames for everyone
+```
 
 ### Scheduled-task unattended confirmation
 
@@ -169,7 +248,7 @@ specific Skills for unattended execution. If all of these are true:
 - `AICHAT_ACTIVE_SKILL` appears in `AICHAT_UNATTENDED_ALLOWED_SKILLS`
 
 then the user has pre-authorized this Skill for that scheduled task. In that
-case, use:
+case, use `--unattended-confirm` in place of `--confirm`:
 
 ```bash
 python3 $WX send "Alice" "今晚 8 点开会吗？" --unattended-confirm
@@ -183,25 +262,32 @@ selected in its unattended authorization settings.
 
 - Never print `PERSONALWECHAT_API_TOKEN`.
 - Treat `PERSONALWECHAT_BASE_URL + API_TOKEN` as full remote control of the user's WeChat.
-- For normal chat write/send operations: dry-run first, ask for explicit approval, then re-run with `--confirm`.
-- For scheduled-task unattended writes: use `--unattended-confirm` only when the platform env says this Skill is pre-authorized.
-- Do not call logout/restart endpoints from the skill unless the user explicitly asks to repair the Wisdom service.
-- If Wisdom returns 503 for history, run `python3 $WX refresh-history` once, then retry the read.
-- If the server is unreachable, ask the user to check the Windows host / security group / port 8000.
+- Dry-run every write first, ask for explicit approval, then re-run with `--confirm`.
+- Use `--unattended-confirm` only when the platform env says this Skill is pre-authorized.
+- Group and Moment writes are visible to other people; `moment-delete` is irreversible.
+- Report what actually happened. If `mentions` came back `null`, the @ did not register.
+- Do not call restart/logout endpoints unless the user explicitly asks to repair the service.
+- Judge connectivity only by `python3 $WX status`. A 404 on another path means that route
+  does not exist, not that WeChat is offline.
 
 ## Endpoint Mapping
 
 The helper wraps these Wisdom endpoints:
 
-- `GET /api/status`
-- `GET /api/auth/status`
-- `GET /api/account`
-- `GET /api/contacts?version=2.0`
-- `GET /api/conversations`
-- `GET /api/conversations/history`
-- `GET /api/messages`
-- `GET /api/messages/history`
-- `POST /api/messages/history/query`
-- `POST /api/messages/history/refresh`
-- `POST /api/search`
-- `POST /api/messages/send` (only after `--confirm` or verified `--unattended-confirm`)
+| Command | Endpoint |
+|---|---|
+| `status` | `GET /api/status` |
+| `account` | `GET /api/account` |
+| `contacts` | `GET /api/contacts` |
+| `conversations` | `GET /api/conversations` |
+| `messages` | `GET /api/messages` |
+| `poll` | `GET /api/messages/poll` |
+| `moments` | `GET /api/moments` |
+| `tasks` / `task` | `GET /api/tasks`, `GET /api/tasks/{id}` |
+| `search` | `POST /api/search` |
+| `send` | `POST /api/messages/send` |
+| `moment-post` / `moment-delete` | `POST /api/moments`, `DELETE /api/moments` |
+| `group-create` / `-invite` / `-remove` / `-rename` | `POST /api/groups`, `/invite`, `/remove`, `/rename` |
+
+Everything from `search` down is a queued UI task (`202` + task ID); the write
+ones additionally need `--confirm` or a verified `--unattended-confirm`.

--- a/skills/personal-wechat/scripts/personal_wechat.py
+++ b/skills/personal-wechat/scripts/personal_wechat.py
@@ -20,6 +20,10 @@ API_TOKEN = os.environ.get("PERSONALWECHAT_API_TOKEN", "")
 MAX_TEXT_CHARS = 800
 SKILL_SLUGS = {"personal-wechat", "acedatacloud/personal-wechat"}
 
+# Wisdom rejects an over-ceiling limit with 422 instead of clamping, so clamp here: a
+# generous --limit degrades to the largest page rather than failing the whole command.
+MAX_LIMIT = {"contacts": 200, "conversations": 200, "messages": 200, "poll": 500, "moments": 200, "tasks": 200}
+
 
 def _die(message: str, code: int = 1) -> None:
     print(json.dumps({"error": message}, ensure_ascii=False), file=sys.stderr)
@@ -28,6 +32,10 @@ def _die(message: str, code: int = 1) -> None:
 
 def _json(data) -> None:
     print(json.dumps(data, ensure_ascii=False, default=str))
+
+
+def clamp(value: int, ceiling: int) -> int:
+    return max(1, min(value, ceiling))
 
 
 def request(method: str, path: str, *, params: dict | None = None, body: dict | None = None):
@@ -91,33 +99,80 @@ def request_task(method: str, path: str, *, params: dict | None = None, body: di
 
 def compact_conversation(item: dict) -> dict:
     return {
-        "id": item.get("id") or item.get("strUsrName"),
-        "name": item.get("name") or item.get("display_name") or item.get("strNickName"),
+        "id": item.get("id"),
+        "name": item.get("name"),
         "type": item.get("type"),
-        "unread_count": item.get("unread_count") if "unread_count" in item else item.get("nUnReadCount"),
-        "last_active_at": item.get("last_active_at") or item.get("nTime"),
+        "is_pinned": item.get("is_pinned"),
+        "unread_count": item.get("unread_count"),
+        "last_active_at": item.get("last_active_at"),
         "last_message_count": len(item.get("messages") or []),
     }
 
 
 def compact_message(item: dict) -> dict:
-    text = item.get("text") or item.get("StrContent") or item.get("DisplayContent")
+    text = item.get("text")
     if isinstance(text, str) and len(text) > MAX_TEXT_CHARS:
         text = text[:MAX_TEXT_CHARS] + f"... [truncated {len(text) - MAX_TEXT_CHARS} chars]"
     return {
-        "id": item.get("id") or item.get("MsgSvrID") or item.get("localId"),
-        "conversation_id": item.get("conversation_id") or item.get("StrTalker"),
+        "id": item.get("id"),
+        "conversation_id": item.get("conversation_id"),
         "conversation_name": item.get("conversation_name"),
+        "conversation_type": item.get("conversation_type"),
         "sender_id": item.get("sender_id"),
         "sender_name": item.get("sender_name"),
         "direction": item.get("direction"),
-        "type": item.get("type") or item.get("Type"),
+        "type": item.get("type"),
         "text": text,
-        "sent_at": item.get("sent_at") or item.get("CreateTime"),
+        "mentions": item.get("mentions"),
+        "quoted_text": item.get("quoted_text"),
+        "sent_at": item.get("sent_at"),
     }
 
 
-def main() -> None:
+def compact_moment(item: dict) -> dict:
+    return {
+        "feed_id": item.get("feed_id"),
+        "author_name": item.get("author_name"),
+        "is_self": item.get("is_self"),
+        "caption": item.get("caption"),
+        "article_title": item.get("article_title"),
+        "article_url": item.get("article_url"),
+        "media_count": item.get("media_count"),
+        "create_time": item.get("create_time"),
+    }
+
+
+def gate(args, *, action: str, preview: dict) -> bool:
+    """Return True when the write may proceed, else print the dry-run and stop.
+
+    Writes touch the user's real WeChat account, so they need either explicit approval
+    of this exact payload (--confirm) or a platform pre-authorization (--unattended-confirm).
+    """
+    if getattr(args, "unattended_confirm", False):
+        allowed, reason = unattended_confirm_allowed(SKILL_SLUGS)
+        if allowed:
+            return True
+        _json({"dry_run": True, "action": action, **preview, "error": "unattended_confirmation_denied", "reason": reason})
+        return False
+    if getattr(args, "confirm", False):
+        return True
+    _json(
+        {
+            "dry_run": True,
+            "action": action,
+            **preview,
+            "note": "Re-run with --confirm after explicit user approval, or --unattended-confirm when this Skill is pre-authorized for an AceDataCloud scheduled task.",
+        }
+    )
+    return False
+
+
+def add_write_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--unattended-confirm", action="store_true")
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Personal WeChat (Wisdom) CLI")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
@@ -126,10 +181,12 @@ def main() -> None:
 
     contacts = sub.add_parser("contacts")
     contacts.add_argument("--limit", type=int, default=20)
+    contacts.add_argument("--offset", type=int, default=0)
+    contacts.add_argument("--type", choices=["friend", "group", "official"], default=None)
 
     convs = sub.add_parser("conversations")
     convs.add_argument("--limit", type=int, default=20)
-    convs.add_argument("--history", action="store_true")
+    convs.add_argument("--offset", type=int, default=0)
 
     msgs = sub.add_parser("messages")
     msgs.add_argument("conversation_id")
@@ -137,73 +194,179 @@ def main() -> None:
     msgs.add_argument("--offset", type=int, default=0)
     msgs.add_argument("--order", choices=["asc", "desc"], default="asc")
 
-    hist = sub.add_parser("history")
-    hist.add_argument("--talker", default="")
-    hist.add_argument("--limit", type=int, default=50)
-    hist.add_argument("--offset", type=int, default=0)
-
-    sql = sub.add_parser("sql")
-    sql.add_argument("db")
-    sql.add_argument("sql")
+    poll = sub.add_parser("poll")
+    poll.add_argument("--since", type=int, required=True, help="Unix timestamp in seconds")
+    poll.add_argument("--limit", type=int, default=100)
 
     search = sub.add_parser("search")
     search.add_argument("query")
 
     send = sub.add_parser("send")
     send.add_argument("target")
-    send.add_argument("text")
-    send.add_argument("--confirm", action="store_true")
-    send.add_argument("--unattended-confirm", action="store_true")
+    send.add_argument("text", nargs="?", default=None)
+    send.add_argument("--type", choices=["text", "image", "video", "file"], default="text")
+    send.add_argument("--image-url", default=None)
+    send.add_argument("--video-url", default=None)
+    send.add_argument("--file-url", default=None)
+    send.add_argument("--mention", action="append", default=None, metavar="NAME", help="Real @-mention of a group member; repeatable")
+    send.add_argument("--mention-all", action="store_true", help="@-mention everyone (group owner/admin only)")
+    send.add_argument("--quote-text", default=None, help="Quote-reply to the newest message whose text matches this")
+    send.add_argument("--idempotency-key", default=None)
+    add_write_flags(send)
 
-    refresh = sub.add_parser("refresh-history")
-    refresh.set_defaults(cmd="refresh-history")
+    moments = sub.add_parser("moments")
+    moments.add_argument("--limit", type=int, default=30)
+    moments.add_argument("--self-only", action="store_true")
 
-    args = parser.parse_args()
+    moment_post = sub.add_parser("moment-post")
+    moment_post.add_argument("text", nargs="?", default=None)
+    moment_post.add_argument("--image-url", action="append", default=None, metavar="URL")
+    moment_post.add_argument("--visibility", choices=["public", "private", "partial", "exclude"], default="public")
+    add_write_flags(moment_post)
+
+    moment_delete = sub.add_parser("moment-delete")
+    moment_delete.add_argument("match", help="Distinctive substring of one of your own Moments; must be unique")
+    add_write_flags(moment_delete)
+
+    group_create = sub.add_parser("group-create")
+    group_create.add_argument("members", nargs="+", help="Names of at least 2 contacts")
+    group_create.add_argument("--name", default=None)
+    add_write_flags(group_create)
+
+    group_invite = sub.add_parser("group-invite")
+    group_invite.add_argument("group")
+    group_invite.add_argument("members", nargs="+")
+    add_write_flags(group_invite)
+
+    group_remove = sub.add_parser("group-remove")
+    group_remove.add_argument("group")
+    group_remove.add_argument("members", nargs="+")
+    add_write_flags(group_remove)
+
+    group_rename = sub.add_parser("group-rename")
+    group_rename.add_argument("group")
+    group_rename.add_argument("new_name")
+    add_write_flags(group_rename)
+
+    tasks = sub.add_parser("tasks")
+    tasks.add_argument("--limit", type=int, default=20)
+
+    task = sub.add_parser("task")
+    task.add_argument("task_id")
+
+    return parser
+
+
+def build_send_body(args) -> dict:
+    if args.type == "text" and not args.text:
+        _die("text is required for --type text")
+    media = {"image": args.image_url, "video": args.video_url, "file": args.file_url}.get(args.type)
+    if args.type != "text" and not media:
+        _die(f"--{args.type}-url is required for --type {args.type}")
+
+    body = {"target": args.target, "type": args.type, "text": args.text}
+    if args.image_url:
+        body["image_url"] = args.image_url
+    if args.video_url:
+        body["video_url"] = args.video_url
+    if args.file_url:
+        body["file_url"] = args.file_url
+    if args.mention:
+        body["mentions"] = args.mention
+    if args.mention_all:
+        body["mention_all"] = True
+    if args.quote_text:
+        body["quote_text"] = args.quote_text
+    if args.idempotency_key:
+        body["idempotency_key"] = args.idempotency_key
+    return body
+
+
+def main() -> None:
+    args = build_parser().parse_args()
 
     if args.cmd == "status":
-        _json({"status": request("GET", "/api/status"), "auth": request("GET", "/api/auth/status")})
+        _json(request("GET", "/api/status"))
     elif args.cmd == "account":
         _json(request("GET", "/api/account"))
     elif args.cmd == "contacts":
-        data = request("GET", "/api/contacts", params={"limit": args.limit, "version": "2.0"})
+        params = {"limit": clamp(args.limit, MAX_LIMIT["contacts"]), "offset": args.offset}
+        if args.type:
+            params["type"] = args.type
+        data = request("GET", "/api/contacts", params=params)
         _json({"total": data.get("total"), "contacts": data.get("contacts", [])})
     elif args.cmd == "conversations":
-        if args.history:
-            data = request("GET", "/api/conversations/history", params={"limit": args.limit})
-            _json({"count": data.get("count"), "conversations": [compact_conversation(i) for i in data.get("conversations", [])]})
-        else:
-            data = request("GET", "/api/conversations", params={"limit": args.limit})
-            _json({"total": data.get("total"), "conversations": [compact_conversation(i) for i in data.get("conversations", [])]})
+        params = {"limit": clamp(args.limit, MAX_LIMIT["conversations"]), "offset": args.offset}
+        data = request("GET", "/api/conversations", params=params)
+        _json({"total": data.get("total"), "conversations": [compact_conversation(i) for i in data.get("conversations", [])]})
     elif args.cmd == "messages":
         data = request(
             "GET",
             "/api/messages",
-            params={"conversation_id": args.conversation_id, "limit": args.limit, "offset": args.offset, "order": args.order},
+            params={
+                "conversation_id": args.conversation_id,
+                "limit": clamp(args.limit, MAX_LIMIT["messages"]),
+                "offset": args.offset,
+                "order": args.order,
+            },
         )
         _json([compact_message(i) for i in data])
-    elif args.cmd == "history":
-        params = {"limit": args.limit, "offset": args.offset}
-        if args.talker:
-            params["talker"] = args.talker
-        data = request("GET", "/api/messages/history", params=params)
-        _json({"count": data.get("count"), "db_ready": data.get("db_ready"), "messages": [compact_message(i) for i in data.get("messages", [])]})
-    elif args.cmd == "sql":
-        data = request("POST", "/api/messages/history/query", body={"db": args.db, "sql": args.sql})
-        _json(data)
+    elif args.cmd == "poll":
+        data = request("GET", "/api/messages/poll", params={"since": args.since, "limit": clamp(args.limit, MAX_LIMIT["poll"])})
+        _json([compact_message(i) for i in data])
     elif args.cmd == "search":
         _json(request_task("POST", "/api/search", body={"query": args.query}, timeout=120))
     elif args.cmd == "send":
-        if args.unattended_confirm:
-            allowed, reason = unattended_confirm_allowed(SKILL_SLUGS)
-            if not allowed:
-                _json({"dry_run": True, "target": args.target, "text": args.text, "error": "unattended_confirmation_denied", "reason": reason})
-                return
-        elif not args.confirm:
-            _json({"dry_run": True, "target": args.target, "text": args.text, "note": "Re-run with --confirm after explicit user approval, or --unattended-confirm when this Skill is pre-authorized for an AceDataCloud scheduled task."})
+        body = build_send_body(args)
+        if not gate(args, action="send", preview={"target": args.target, "payload": body}):
             return
-        _json(request_task("POST", "/api/messages/send", body={"target": args.target, "type": "text", "text": args.text}))
-    elif args.cmd == "refresh-history":
-        _json(request("POST", "/api/messages/history/refresh"))
+        _json(request_task("POST", "/api/messages/send", body=body))
+    elif args.cmd == "moments":
+        params = {"limit": clamp(args.limit, MAX_LIMIT["moments"]), "self_only": "true" if args.self_only else "false"}
+        data = request("GET", "/api/moments", params=params)
+        _json({"total": data.get("total"), "moments": [compact_moment(i) for i in data.get("moments", [])]})
+    elif args.cmd == "moment-post":
+        if not args.text and not args.image_url:
+            _die("a Moment needs text, images, or both")
+        body = {"text": args.text, "visibility": args.visibility}
+        if args.image_url:
+            body["image_urls"] = args.image_url
+        if not gate(args, action="moment-post", preview={"payload": body}):
+            return
+        _json(request_task("POST", "/api/moments", body=body))
+    elif args.cmd == "moment-delete":
+        body = {"match": args.match}
+        if not gate(args, action="moment-delete", preview={"payload": body, "warning": "Deleting a Moment is irreversible."}):
+            return
+        _json(request_task("DELETE", "/api/moments", body=body))
+    elif args.cmd == "group-create":
+        if len(args.members) < 2:
+            _die("group-create needs at least 2 members")
+        body = {"members": args.members}
+        if args.name:
+            body["name"] = args.name
+        if not gate(args, action="group-create", preview={"payload": body}):
+            return
+        _json(request_task("POST", "/api/groups", body=body))
+    elif args.cmd == "group-invite":
+        body = {"group": args.group, "members": args.members}
+        if not gate(args, action="group-invite", preview={"payload": body}):
+            return
+        _json(request_task("POST", "/api/groups/invite", body=body))
+    elif args.cmd == "group-remove":
+        body = {"group": args.group, "members": args.members}
+        if not gate(args, action="group-remove", preview={"payload": body, "warning": "Removing members is visible to the whole group."}):
+            return
+        _json(request_task("POST", "/api/groups/remove", body=body))
+    elif args.cmd == "group-rename":
+        body = {"group": args.group, "new_name": args.new_name}
+        if not gate(args, action="group-rename", preview={"payload": body, "warning": "Renaming changes the group name for every member."}):
+            return
+        _json(request_task("POST", "/api/groups/rename", body=body))
+    elif args.cmd == "tasks":
+        _json(request("GET", "/api/tasks", params={"limit": clamp(args.limit, MAX_LIMIT["tasks"])}))
+    elif args.cmd == "task":
+        _json(request("GET", f"/api/tasks/{args.task_id}"))
 
 
 if __name__ == "__main__":

--- a/skills/personal-wechat/tests/test_personal_wechat.py
+++ b/skills/personal-wechat/tests/test_personal_wechat.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "personal_wechat.py"
@@ -12,6 +15,39 @@ assert SPEC and SPEC.loader
 sys.path.insert(0, str(SCRIPT.parent))
 personal_wechat = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(personal_wechat)
+
+
+# Routes Wisdom removed. The skill kept calling all of these until they started
+# 404ing in production; keep them from creeping back in.
+RETIRED_ROUTES = (
+    "/api/auth/status",
+    "/api/conversations/history",
+    "/api/messages/history",
+    "/api/messages/history/query",
+    "/api/messages/history/refresh",
+)
+
+
+def run(argv: list[str], *, responses=None, task_result=None):
+    """Invoke main() with argv, capturing every HTTP call the CLI would make."""
+    calls: list[dict] = []
+
+    def fake_request(method, path, *, params=None, body=None):
+        calls.append({"method": method, "path": path, "params": params, "body": body})
+        if responses and path in responses:
+            return responses[path]
+        if path.startswith("/api/tasks/"):
+            return {"status": "succeeded", "result": task_result}
+        return {} if method == "GET" else {"id": "task-1"}
+
+    printed: list[str] = []
+    with patch.object(personal_wechat, "request", side_effect=fake_request):
+        with patch("builtins.print", side_effect=lambda *a, **k: printed.append(a[0] if a else "")):
+            with patch.object(sys, "argv", ["personal_wechat.py", *argv]):
+                personal_wechat.main()
+
+    stdout = [json.loads(line) for line in printed if isinstance(line, str) and line.startswith(("{", "["))]
+    return calls, stdout
 
 
 def test_wait_task_returns_successful_result() -> None:
@@ -23,3 +59,142 @@ def test_wait_task_returns_successful_result() -> None:
         result = personal_wechat.wait_task("task-1", timeout=0.1)
 
     assert result == {"sent": True}
+
+
+def test_script_references_no_retired_routes() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    for route in RETIRED_ROUTES:
+        assert route not in source, f"{route} was removed from Wisdom"
+
+
+def test_skill_doc_references_no_retired_routes() -> None:
+    doc = (SCRIPT.parents[1] / "SKILL.md").read_text(encoding="utf-8")
+    for route in RETIRED_ROUTES:
+        assert route not in doc, f"{route} was removed from Wisdom"
+
+
+def test_status_only_reads_api_status() -> None:
+    """The 404 outage: status also probed /api/auth/status, failing the whole command."""
+    calls, _ = run(["status"], responses={"/api/status": {"status": "ready", "logged_in": True}})
+
+    assert [c["path"] for c in calls] == ["/api/status"]
+
+
+@pytest.mark.parametrize(
+    "argv,ceiling,path,response",
+    [
+        (["contacts", "--limit", "500"], 200, "/api/contacts", {"total": 0, "contacts": []}),
+        (["conversations", "--limit", "500"], 200, "/api/conversations", {"total": 0, "conversations": []}),
+        (["messages", "CONV", "--limit", "500"], 200, "/api/messages", []),
+        (["poll", "--since", "1", "--limit", "5000"], 500, "/api/messages/poll", []),
+    ],
+)
+def test_limit_is_clamped_instead_of_422(argv, ceiling, path, response) -> None:
+    calls, _ = run(argv, responses={path: response})
+
+    assert calls[0]["params"]["limit"] == ceiling
+
+
+def test_send_dry_runs_by_default() -> None:
+    calls, stdout = run(["send", "Alice", "hi"])
+
+    assert calls == []
+    assert stdout[0]["dry_run"] is True
+
+
+def test_send_with_confirm_posts_the_payload() -> None:
+    calls, _ = run(["send", "Alice", "hi", "--confirm"], task_result={"sent": True})
+
+    assert calls[0]["path"] == "/api/messages/send"
+    assert calls[0]["body"] == {"target": "Alice", "type": "text", "text": "hi"}
+
+
+def test_mentions_go_to_the_api_not_into_the_text() -> None:
+    """A pasted '@Name' notifies nobody; only the mentions field is a real @-mention."""
+    calls, _ = run(
+        ["send", "项目群", "周报", "--mention", "Doms Jay", "--mention", "Alice", "--confirm"],
+        task_result={"sent": True},
+    )
+
+    body = calls[0]["body"]
+    assert body["mentions"] == ["Doms Jay", "Alice"]
+    assert body["text"] == "周报"
+
+
+def test_mention_all_is_forwarded() -> None:
+    calls, _ = run(["send", "项目群", "通知", "--mention-all", "--confirm"], task_result={"sent": True})
+
+    assert calls[0]["body"]["mention_all"] is True
+
+
+def test_quote_and_idempotency_key_are_forwarded() -> None:
+    calls, _ = run(
+        ["send", "Alice", "我来跟", "--quote-text", "谁跟一下", "--idempotency-key", "k-1", "--confirm"],
+        task_result={"sent": True},
+    )
+
+    body = calls[0]["body"]
+    assert body["quote_text"] == "谁跟一下"
+    assert body["idempotency_key"] == "k-1"
+
+
+def test_media_send_requires_its_url() -> None:
+    with pytest.raises(SystemExit):
+        run(["send", "Alice", "--type", "image", "--confirm"])
+
+
+def test_media_send_forwards_the_url() -> None:
+    calls, _ = run(
+        ["send", "Alice", "--type", "image", "--image-url", "https://example.com/a.png", "--confirm"],
+        task_result={"sent": True},
+    )
+
+    assert calls[0]["body"]["image_url"] == "https://example.com/a.png"
+
+
+@pytest.mark.parametrize(
+    "argv,path,method",
+    [
+        (["moment-post", "hello"], "/api/moments", "POST"),
+        (["moment-delete", "some distinctive text"], "/api/moments", "DELETE"),
+        (["group-create", "Alice", "Bob"], "/api/groups", "POST"),
+        (["group-invite", "项目群", "Carol"], "/api/groups/invite", "POST"),
+        (["group-remove", "项目群", "Carol"], "/api/groups/remove", "POST"),
+        (["group-rename", "项目群", "新名字"], "/api/groups/rename", "POST"),
+    ],
+)
+def test_every_write_dry_runs_then_executes(argv, path, method) -> None:
+    dry_calls, stdout = run(argv)
+    assert dry_calls == [], f"{argv[0]} must not touch the API without --confirm"
+    assert stdout[0]["dry_run"] is True
+
+    calls, _ = run([*argv, "--confirm"], task_result={"ok": True})
+    assert calls[0]["path"] == path
+    assert calls[0]["method"] == method
+
+
+def test_group_create_needs_two_members() -> None:
+    with pytest.raises(SystemExit):
+        run(["group-create", "Alice", "--confirm"])
+
+
+def test_moment_post_needs_text_or_images() -> None:
+    with pytest.raises(SystemExit):
+        run(["moment-post", "--confirm"])
+
+
+def test_unattended_confirm_is_denied_outside_a_scheduled_task(monkeypatch) -> None:
+    monkeypatch.delenv("AICHAT_UNATTENDED_MODE", raising=False)
+    calls, stdout = run(["send", "Alice", "hi", "--unattended-confirm"])
+
+    assert calls == []
+    assert stdout[0]["error"] == "unattended_confirmation_denied"
+
+
+def test_unattended_confirm_allows_a_preauthorized_skill(monkeypatch) -> None:
+    monkeypatch.setenv("AICHAT_UNATTENDED_MODE", "true")
+    monkeypatch.setenv("AICHAT_ACTIVE_SKILL", "acedatacloud/personal-wechat")
+    monkeypatch.setenv("AICHAT_UNATTENDED_ALLOWED_SKILLS", '["acedatacloud/personal-wechat"]')
+    calls, _ = run(["send", "Alice", "hi", "--unattended-confirm"], task_result={"sent": True})
+
+    assert calls[0]["path"] == "/api/messages/send"


### PR DESCRIPTION
## 背景

线上一次真实会话里，给微信群发消息 + 艾特某人失败。表象是"微信离线（HTTP 404）"，
实际排查下来是 **skill 停留在旧版 Wisdom API 上**，一半命令打的是服务端已经删除的路由。

## 逐条核对（skill 调用 vs Wisdom 现网路由表）

| skill 调用 | 现状 |
|---|---|
| `GET /api/auth/status` | ❌ 已删 → `status` 命令必 404、exit 2 |
| `GET /api/conversations/history` | ❌ 已删 |
| `GET /api/messages/history` | ❌ 已删 |
| `POST /api/messages/history/query`（`sql`） | ❌ 已删 |
| `POST /api/messages/history/refresh` | ❌ 已删 |
| `contacts?limit=500&version=2.0` | ❌ 服务端 `le=200` → 422 |
| `send` 仅 target/type/text | ⚠️ 丢掉 mentions / quote / 媒体 / 幂等键 |
| `/api/messages/poll`、`/api/moments`、`/api/groups`、`/api/tasks` | ⚠️ 服务端都有，skill 未暴露 |

其中 `/api/*/history*` 四个接口是 Wisdom 有意下线的：规范化的
`GET /api/conversations` / `GET /api/messages` 直读解密后的微信库，本身已覆盖全量历史
（见 `Wisdom/docs/SPEC.md` §4.8）。

## 两个用户可见的 bug

1. **误报"微信离线"**：`status` 同时请求 `/api/status` 和已删的 `/api/auth/status`，
   后者 404 把整条命令判死。而 `/api/status` 当时返回的是
   `{"status":"ready","wechat_running":true,"logged_in":true}` —— 微信一直好好的。

2. **艾特发不出去**：服务端 `send_text_to_open_chat()` 通过 `mentions` 字段驱动微信自己的
   mention popover，产生**真正的 @ 通知**。skill 没传这个字段，只能把 `@Doms Jay` 作为
   裸文本塞进正文，回执 `mentions` 为 `null`，被艾特的人收不到任何通知。

## 改动

**修漂移**
- `status` 只读 `/api/status`，并按 `status` / `wechat_running` / `logged_in` 分诊；
  文档明确写入"404 ≠ 微信离线"。
- 删除四个已下线的 history 接口调用。
- 所有 `limit` 在客户端夹紧到服务端上限，超限降级为最大页而不是整条命令 422。

**补齐 send 能力**
- `--mention`（可重复）/ `--mention-all` → 真·艾特；文档明确禁止把 `@Name` 写进正文。
- `--quote-text` 引用回复；`--type image|video|file` + 对应 URL；`--idempotency-key` 重试防重发。

**新增命令**
- 读：`poll`（断连补齐）、`moments`、`tasks` / `task`
- 写：`moment-post` / `moment-delete`、`group-create` / `-invite` / `-remove` / `-rename`

**安全**：所有新写操作沿用既有的 dry-run + `--confirm` / `--unattended-confirm` 门禁，
统一走一个 `gate()` helper。`moment-delete` 不可逆、群操作对他人可见，dry-run 里都带 warning。

## 测试

1 个 → 25 个，锁住这次真正踩的坑：

- 死接口不得复现 —— 脚本和 SKILL.md **双向**断言五条已下线路由
- `status` 只打一个端点（回归这次的 404 事故）
- 艾特必须进 `mentions` 字段、不得混进正文
- 每个写操作默认 dry-run、`--confirm` 后打对端点和 HTTP 方法
- unattended 授权的放行与拒绝两条路径

```
25 passed in 0.07s
```

仓库级 `tests/`（77 passed）、frontmatter、marketplace.json 门禁本地均已通过。
`.github/skills` 与 `.agents/skills` 是指向 `skills/` 的符号链接，同步门禁天然恒等。

🤖 Generated with [Claude Code](https://claude.com/claude-code)