### PR TITLE
docs(ai-chat): image models aren't chat models

### DIFF
--- a/skills/ai-chat/SKILL.md
+++ b/skills/ai-chat/SKILL.md
@@ -59,7 +59,7 @@ models include:
 | OpenAI / reasoning | `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o1`, `o3`, `o4-mini` |
 | OpenAI free-tier chat-completions | `gpt-5.5:free`, `gpt-5:free`, `gpt-4.1:free`, `gpt-4o:free`, `gpt-4o-mini:free`, `gpt-oss:free` |
 | Claude | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`, `claude-3-7-sonnet-20250219` |
-| Gemini | `gemini-3.5-flash`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
+| Gemini | `gemini-3.5-flash`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-pro-preview`, `gemini-2.5-flash-lite`, `gemini-2.0-flash-lite` |
 | Grok | `grok-4.5`, `grok-4`, `grok-4-0709`, `grok-3`, `grok-3-fast` |
 | DeepSeek | `deepseek-r1`, `deepseek-r1-0528`, `deepseek-v3`, `deepseek-v3-250324`, `deepseek-v3.2-exp`, `deepseek-v4-flash` |
 | Kimi | `kimi-k3`, `kimi-k2.6`, `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` |
@@ -67,6 +67,12 @@ models include:
 
 `/aichat2/conversations` also accepts `model_group` values
 `chatgpt`, `claude`, `gemini`, `grok`, `kimi`, `glm`, and `deepseek`.
+
+> **Image-generating models are not chat models.** Names ending in `-image`
+> (e.g. `gemini-*-image`, `gpt-4o-image`) are image-generation models and do
+> not work on any chat surface listed above. Generate images through the
+> dedicated endpoints instead — Gemini via
+> `POST /v1beta/models/{model}:generateContent`, or `/nano-banana/images`.
 
 ## OpenAI-Compatible Chat
 


### PR DESCRIPTION
## 问题

`skills/ai-chat/SKILL.md` 的模型表挂在一个同时声明了四个端点的标题下：

```
| POST /aichat2/conversations       | Recommended stateful ... |
| POST /aichat/conversations        | Legacy ...               |
| POST /openai/chat/completions     | OpenAI-compatible ...    |
| POST /openai/responses            | OpenAI-compatible ...    |
```

表名是通用的 "Currently Documented Model Families"，**没有任何 per-endpoint 归属标注**。所以 Gemini 那行里的 `gemini-3.1-flash-image-preview` 读起来像是"上面任一端点都能用"。

**实际上哪个都不能用。** 这是个给 LLM agent 读的 skill，含糊会直接变成错误调用。

## 实测证据

同一个 payload 形状打 `/aichat2/conversations`：

| model | HTTP |
|---|---|
| `gemini-3.1-pro`（对照组） | **200** `{"answer":"OK"}` |
| `gemini-3.1-flash-image-preview` | **400** |
| `gpt-4o-image` | **500** |
| `gpt-image-1` | **400** |

对照组排除了"payload 格式不对"这个解释——文本模型用同样的结构就是 200。

图像模型在账号池里只有 native 通道，chat 类端点一律打不通。

## 改动

- 从 Gemini 行移除 `gemini-3.1-flash-image-preview`
- 加一段覆盖整个 `-image` 类的说明，指向真正能用的端点

```
> **Image-generating models are not chat models.** Names ending in `-image`
> (e.g. `gemini-*-image`, `gpt-4o-image`) are image-generation models and do
> not work on any chat surface listed above. Generate images through the
> dedicated endpoints instead — Gemini via
> `POST /v1beta/models/{model}:generateContent`, or `/nano-banana/images`.
```

写成类别规则而非逐个点名，这样将来新增 `-image` 模型不必再改这里。

`.agents/` 和 `.github/` 下无该模型名的副本（grep 零命中），无需同步。

## 关联

- [PlatformBackend#1286](https://github.com/AceDataCloud/PlatformBackend/pull/1286) — chat enum 摘掉图像模型（已合并 + 已 sync 上线）
- [PlatformService#1832](https://github.com/AceDataCloud/PlatformService/pull/1832) — 图像模型不再作为文本模型的降级替补
- [Clis#646](https://github.com/AceDataCloud/Clis/pull/646) — CLI 模型列表（已合并）

## 顺带发现（本 PR 不处理）

`/aichat2/conversations` 的 OpenAPI enum 里还留着这三个图像模型（`gpt-4o-image`、`gpt-image-1`、`gemini-3.1-flash-image-preview`），实测全部失败。那是独立议题——涉及 OpenAI 系上游、根因不同，需要单独调查，不宜塞进这次 gemini 收尾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)