### PR TITLE
docs(suno): use negative_tags in music skill

### DIFF
--- a/skills/suno-music/SKILL.md
+++ b/skills/suno-music/SKILL.md
@@ -150,7 +150,7 @@ For best results follow this multi-step workflow:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `lyric_prompt` | object | Structured prompt payload for auto-generating lyrics (used when `custom: true` without explicit `lyric`) |
-| `style_negative` | string | Style tags to avoid (e.g., `"heavy metal, distortion"`) |
+| `negative_tags` | string | Style or genre tags to avoid (e.g., `"heavy metal, distortion"`); used in custom mode |
 | `style_influence` | number | Strength of style influence (advanced custom mode, v5+ only) |
 | `audio_weight` | number | Weight for audio reference when covering (advanced, v5+ only) |
 | `duration` | integer | Target track length in seconds (typically 10–360). Best supported on `generate` with `custom: true` on newer models such as `chirp-v5-5` |


### PR DESCRIPTION
## Contract
Standardize the public Suno excluded-style request field as `negative_tags`. Runtime workers retain `style_negative` only as a compatibility alias, with `negative_tags` taking precedence.

## Dependency graph
PlatformService runtime -> PlatformBackend contract/docs -> MCP, Dify, Skills, APIs, Nexior clients.

## Review
Adversarial review not requested.

## Rollout / rollback
This is additive at runtime and non-billing. Roll back the repository commit if needed; old clients continue working during rollout.

Depends on the PlatformBackend contract PR.

## Validation
- Markdown diff check passed.