### PR TITLE
fix(tiktok): confirm and upload drafts reliably

### DIFF
--- a/skills/tiktok/SKILL.md
+++ b/skills/tiktok/SKILL.md
@@ -46,7 +46,16 @@ they will fail with `scope_not_authorized`.
 
 This is the working path. The video lands in the creator's TikTok **inbox /
 drafts**; they open the TikTok app to add caption, sound and privacy, then post.
-Confirm with the user before uploading.
+
+Required order:
+
+1. Download the exact video locally, but do not upload it yet.
+2. Call `request_action_confirmation` with `kind: "generic"`, the real video
+   preview, and a summary that says this uploads to drafts rather than publishing.
+3. If cancelled, stop. If confirmed, run exactly one upload:
+   `python3 skills/tiktok/scripts/tiktok.py upload video.mp4`.
+4. Poll with `python3 skills/tiktok/scripts/tiktok.py status PUBLISH_ID` until
+   terminal. Never call `upload` again while polling.
 
 Two source modes. **`FILE_UPLOAD` is the reliable one** — `PULL_FROM_URL` only
 works from a domain verified in the developer portal, and ours is not verified

--- a/skills/tiktok/scripts/tiktok.py
+++ b/skills/tiktok/scripts/tiktok.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Upload one video to TikTok inbox using FILE_UPLOAD, or fetch status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE_URL = "https://open.tiktokapis.com/v2"
+MAX_CHUNK_SIZE = 64 * 1024 * 1024
+
+
+def output(value: object) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2))
+
+
+def fail(message: str) -> None:
+    output({"ok": False, "error": message})
+    raise SystemExit(1)
+
+
+def token() -> str:
+    value = os.environ.get("TIKTOK_TOKEN")
+    if not value:
+        fail("TIKTOK_TOKEN is not set — reconnect TikTok and retry")
+    return value
+
+
+def api(path: str, body: dict) -> dict:
+    request = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {token()}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode())
+    except urllib.error.HTTPError as error:
+        raw = error.read().decode("utf-8", "replace")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            fail(f"TikTok returned HTTP {error.code}")
+    except urllib.error.URLError as error:
+        fail(f"network error reaching TikTok: {error.reason}")
+    api_error = payload.get("error") or {}
+    if api_error.get("code") not in (None, "ok"):
+        fail(f"TikTok API error {api_error.get('code')}: {api_error.get('message') or 'request failed'}")
+    return payload.get("data") or {}
+
+
+def upload_file(path: str) -> dict:
+    size = os.path.getsize(path)
+    if size <= 0:
+        fail("video file is empty")
+    if size > MAX_CHUNK_SIZE:
+        fail("video exceeds the 64 MB single-upload limit")
+    init = api(
+        "/post/publish/inbox/video/init/",
+        {"source_info": {"source": "FILE_UPLOAD", "video_size": size, "chunk_size": size, "total_chunk_count": 1}},
+    )
+    upload_url = init.get("upload_url")
+    publish_id = init.get("publish_id")
+    if not upload_url or not publish_id:
+        fail("TikTok init response did not contain upload_url and publish_id")
+    with open(path, "rb") as video:
+        body = video.read()
+    request = urllib.request.Request(
+        upload_url,
+        data=body,
+        headers={
+            "Content-Type": "video/mp4",
+            "Content-Length": str(size),
+            "Content-Range": f"bytes 0-{size - 1}/{size}",
+        },
+        method="PUT",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            status = response.status
+    except urllib.error.HTTPError as error:
+        status = error.code
+    except urllib.error.URLError as error:
+        fail(f"network error uploading video: {error.reason}")
+    if status != 201:
+        fail(f"TikTok upload returned HTTP {status}, expected 201")
+    return {"publish_id": publish_id, "status": "UPLOADED"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    upload = sub.add_parser("upload")
+    upload.add_argument("file")
+    status = sub.add_parser("status")
+    status.add_argument("publish_id")
+    args = parser.parse_args()
+    if args.command == "upload":
+        data = upload_file(args.file)
+    else:
+        data = api("/post/publish/status/fetch/", {"publish_id": args.publish_id})
+    output({"ok": True, "data": data})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tiktok.py
+++ b/tests/test_tiktok.py
@@ -1,0 +1,92 @@
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).parents[1] / "skills" / "tiktok" / "scripts" / "tiktok.py"
+spec = importlib.util.spec_from_file_location("tiktok_script", MODULE_PATH)
+tiktok = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(tiktok)
+
+
+class Response:
+    def __init__(self, payload=None, status=200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload or {}).encode()
+
+
+class TikTokScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.token_patch = patch.dict(os.environ, {"TIKTOK_TOKEN": "secret-token"})
+        self.token_patch.start()
+
+    def tearDown(self):
+        self.token_patch.stop()
+
+    def test_file_upload_initializes_and_puts_one_chunk(self):
+        init = Response({"data": {"publish_id": "pub_1", "upload_url": "https://upload.test/one"}, "error": {"code": "ok"}})
+        uploaded = Response(status=201)
+        stdout = io.StringIO()
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            video.write(b"video-bytes")
+            video.flush()
+            with patch("urllib.request.urlopen", side_effect=[init, uploaded]) as mocked, patch(
+                "sys.argv", ["tiktok.py", "upload", video.name]
+            ), redirect_stdout(stdout):
+                tiktok.main()
+
+        init_request, put_request = [call.args[0] for call in mocked.call_args_list]
+        self.assertTrue(init_request.full_url.endswith("/post/publish/inbox/video/init/"))
+        self.assertEqual(
+            json.loads(init_request.data),
+            {"source_info": {"source": "FILE_UPLOAD", "video_size": 11, "chunk_size": 11, "total_chunk_count": 1}},
+        )
+        self.assertEqual(put_request.method, "PUT")
+        self.assertEqual(put_request.data, b"video-bytes")
+        self.assertEqual(put_request.headers["Content-range"], "bytes 0-10/11")
+        rendered = stdout.getvalue()
+        self.assertNotIn("secret-token", rendered)
+        self.assertEqual(json.loads(rendered)["data"]["publish_id"], "pub_1")
+
+    def test_status_fetch_posts_publish_id(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=Response({"data": {"status": "SEND_TO_USER_INBOX"}, "error": {"code": "ok"}}),
+        ) as mocked, patch("sys.argv", ["tiktok.py", "status", "pub_1"]), redirect_stdout(io.StringIO()):
+            tiktok.main()
+        self.assertEqual(json.loads(mocked.call_args.args[0].data), {"publish_id": "pub_1"})
+
+    def test_api_error_is_structured(self):
+        stdout = io.StringIO()
+        with patch(
+            "urllib.request.urlopen",
+            return_value=Response({"data": {}, "error": {"code": "spam_risk", "message": "blocked"}}),
+        ), self.assertRaises(SystemExit), redirect_stdout(stdout):
+            tiktok.api("/post/publish/status/fetch/", {"publish_id": "pub_1"})
+        self.assertEqual(json.loads(stdout.getvalue()), {"ok": False, "error": "TikTok API error spam_risk: blocked"})
+
+    def test_empty_file_is_rejected_before_network(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video, patch("urllib.request.urlopen") as mocked, self.assertRaises(
+            SystemExit
+        ), redirect_stdout(io.StringIO()):
+            tiktok.upload_file(video.name)
+        mocked.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve TikTok FILE_UPLOAD as the reliable path; no Direct Post or PULL_FROM_URL behavior is introduced
- require generic action confirmation before running exactly one draft upload
- add a standard-library helper for single-chunk FILE_UPLOAD and status polling

## Scope
Exactly 3 files: TikTok Skill, helper, helper tests. Direct Post remains disabled pending TikTok audit.

## Verification
- CI-equivalent unittest suite: 81 passed
- cross-site boundary tests: 2 passed
- Python compile and diff checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)