### PR TITLE
fix(youtube): harden resumable auto upload

### DIFF
--- a/skills/youtube/SKILL.md
+++ b/skills/youtube/SKILL.md
@@ -10,7 +10,7 @@ when_to_use: |
   install time to publish videos — confirm before uploading and
   re-prompt to re-install if the upload scope is missing.
 connections: [google/youtube]
-allowed_tools: [Bash]
+allowed_tools: [Bash, publish_artifact]
 license: Apache-2.0
 metadata:
   author: acedatacloud
@@ -146,18 +146,28 @@ FILE="${FILE:-/path/to/video.mp4}"
 TITLE="My title"
 DESC="My description"
 # privacyStatus: public | unlisted | private
-read -r -d '' META <<JSON
-{"snippet":{"title":"$TITLE","description":"$DESC","categoryId":"22"},
- "status":{"privacyStatus":"unlisted","selfDeclaredMadeForKids":false}}
-JSON
+META=$(jq -n --arg title "$TITLE" --arg description "$DESC" '{
+  snippet: {title: $title, description: $description, categoryId: "22"},
+  status: {privacyStatus: "unlisted", selfDeclaredMadeForKids: false}
+}')
 
-# 1. Init resumable session -> capture the upload URL from the Location header.
-UPLOAD_URL=$(curl -sS -D - -o /dev/null \
+# 1. Init the resumable session. Keep headers, body and status so a missing
+# Location reports the real API error instead of turning into an empty PUT URL.
+INIT_HEADERS=$(mktemp)
+INIT_BODY=$(mktemp)
+INIT_HTTP=$(curl -sS -D "$INIT_HEADERS" -o "$INIT_BODY" -w '%{http_code}' \
   -H "Authorization: Bearer $GOOGLE_YOUTUBE_TOKEN" \
   -H "Content-Type: application/json; charset=UTF-8" \
   -H "X-Upload-Content-Type: video/*" \
   -X POST "https://www.googleapis.com/upload/youtube/v3/videos?uploadType=resumable&part=snippet,status" \
-  -d "$META" | tr -d '\r' | awk '/^[Ll]ocation:/{print $2}')
+  -d "$META")
+UPLOAD_URL=$(tr -d '\r' < "$INIT_HEADERS" | awk 'tolower($1) == "location:" {print $2; exit}')
+if [ -z "$UPLOAD_URL" ]; then
+  echo "upload init failed: HTTP $INIT_HTTP: $(jq -r '.error.message // .' "$INIT_BODY" 2>/dev/null || cat "$INIT_BODY")"
+  rm -f "$INIT_HEADERS" "$INIT_BODY"
+  exit 1
+fi
+rm -f "$INIT_HEADERS" "$INIT_BODY"
 
 # 2. Upload the bytes -> returns the created video resource (has .id).
 RESULT=$(curl -sS -H "Authorization: Bearer $GOOGLE_YOUTUBE_TOKEN" \
@@ -172,6 +182,13 @@ Delete a downloaded temp file only **after** you've confirmed an id came back
 (`echo "$RESULT" | jq -e .id >/dev/null && rm -f "$FILE"`). On a 401/403 or a
 dropped connection the download is still good and re-uploading beats re-fetching
 a few hundred MB.
+
+After a confirmed upload returns a real `.id`, call `publish_artifact` exactly
+once so the result appears in **My Outputs**. Use `kind="video"`,
+`channel="youtube"`, `status="delivered"`, the real title, and the canonical
+`https://www.youtube.com/watch?v=<id>` URL. Include the actual privacy in the
+summary. If the upload fails or no `.id` is returned, do not record a delivered
+artifact and never fabricate a URL.
 
 `categoryId` `22` = "People & Blogs" (a safe default). To set a custom
 thumbnail (needs the file to be processed first), call

--- a/tests/test_youtube_skill.py
+++ b/tests/test_youtube_skill.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+
+
+SKILL = Path(__file__).parents[1] / "skills" / "youtube" / "SKILL.md"
+
+
+def body() -> str:
+    return SKILL.read_text()
+
+
+class YouTubeSkillContractTests(unittest.TestCase):
+    def test_publish_artifact_remains_available_after_skill_load(self) -> None:
+        self.assertIn("allowed_tools: [Bash, publish_artifact]", body())
+
+    def test_upload_metadata_is_built_with_jq_arguments(self) -> None:
+        text = body()
+        self.assertIn('META=$(jq -n --arg title "$TITLE" --arg description "$DESC"', text)
+        self.assertNotIn("read -r -d '' META", text)
+
+    def test_resumable_init_preserves_diagnostics_and_guards_put(self) -> None:
+        text = body()
+        self.assertIn('INIT_HEADERS=$(mktemp)', text)
+        self.assertIn('INIT_BODY=$(mktemp)', text)
+        self.assertIn("-w '%{http_code}'", text)
+        self.assertIn('tolower($1) == "location:"', text)
+        self.assertIn('if [ -z "$UPLOAD_URL" ]; then', text)
+        self.assertIn('upload init failed: HTTP $INIT_HTTP', text)
+        self.assertLess(
+            text.index('if [ -z "$UPLOAD_URL" ]; then'),
+            text.index('-X PUT --upload-file "$FILE" "$UPLOAD_URL"'),
+        )
+
+    def test_success_records_only_a_real_youtube_url(self) -> None:
+        text = body()
+        self.assertIn("call `publish_artifact` exactly", text)
+        self.assertIn('`channel="youtube"`', text)
+        self.assertIn("https://www.youtube.com/watch?v=<id>", text)
+        self.assertIn("never fabricate a URL", text)
+
+    def test_upload_example_defaults_to_unlisted(self) -> None:
+        self.assertIn('privacyStatus: "unlisted"', body())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep `publish_artifact` available while the YouTube skill is active
- preserve resumable-init headers, body, and HTTP status so upload failures expose the real API error
- build upload metadata with `jq --arg` and require a real YouTube ID before recording delivery
- add contract tests for unattended upload safety

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"` (86 passed)
- `python3 -m unittest discover -s tests -p "test_youtube_skill.py" -v` (5 passed)
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)