### PR TITLE
docs(minimax): remove watermark parameter

### DIFF
--- a/skills/minimax-video/SKILL.md
+++ b/skills/minimax-video/SKILL.md
@@ -24,7 +24,6 @@ Generate 4–15 second videos through `POST https://api.acedata.cloud/minimax/vi
 | `audio_urls` | 1–3 public HTTP(S) URLs | omitted |
 | `resolution` | `768P`, `2K` | `2K` |
 | `ratio` | `16:9`, `9:16` | `16:9` |
-| `aigc_watermark` | boolean | false |
 | `duration` | integer 4–15 | 4 |
 | `async` | boolean | false |
 | `callback_url` | public HTTP(S) webhook | omitted |


### PR DESCRIPTION
## Contract

`POST /minimax/videos` (API `64f22fd9-0efd-445e-b0b1-135682fd66d7`) no longer exposes `aigc_watermark`. After the coordinated runtime change, explicitly sending either boolean value is rejected as an unsupported field (HTTP 400), rather than silently ignored.

## Changes and validation

Removes the parameter from the canonical `minimax-video` Skill contract while leaving linked agent mirrors untouched. Validation: Skill frontmatter and endpoint structure passed targeted checks, and `git diff --check` passed.

## Dependency graph

consumer surfaces → PlatformService runtime enforcement + PlatformBackend OpenAPI/docs → generated Docs/downstream reconciliation

This consumer removal is safe to merge before the runtime/contract switch because it only stops emitting an optional field whose existing default is already `false`.

## Rollout / rollback

Release before or with the PlatformService and PlatformBackend PRs. Roll back together with the coordinated set; do not restore the parameter in only one surface.

## Out of scope

Legacy `/hailuo/videos`, billing rules, generated Docs files, and historical validation reports.

Adversarial review: not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
