### PR TITLE
feat: add capability spotlight video skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Compatible with **30+ AI coding agents** via the [agentskills.io](https://agents
 | [happyhorse-video](skills/happyhorse-video/) | Generate and edit videos with Happy Horse |
 | [seedance-video](skills/seedance-video/) | Generate dance/motion videos with ByteDance Seedance |
 | [maestro-video](skills/maestro-video/) | Produce complete videos from a brief with script, media, voiceover, captions, and editing |
+| [capability-spotlight-video](skills/capability-spotlight-video/) | Produce a recurring, evidence-led Ace Data Cloud capability video series with topic/demo/style/layout/voice rotation |
 
 ### AI Chat & Tools
 

--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: capability-spotlight-video
+description: Produce a recurring Ace Data Cloud Capability Spotlight series. Each run selects one live, evidence-rich platform capability, creates a representative demo that proves its unique strength, and hands a branded, non-repetitive production kit to Maestro. Use for scheduled Ace Data Cloud product videos that must rotate across image, video, chat/agent, CAPTCHA, audio, web/data, identity, and end-to-end production capabilities.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+connections: [acedatacloud]
+compatibility: Requires the AceDataCloud connector, AceDataCloud and Maestro MCP servers, and whichever capability MCP is selected for the current spotlight.
+---
+
+# Ace Data Cloud Capability Spotlight
+
+Create **one deep, evidence-led capability video per run**. Do not make a broad platform montage and do not default to Image APIs.
+
+Read before acting:
+
+- [brand kit](references/brand-kit.md)
+- [topic registry](references/topic-registry.md)
+
+## 1. Discover live truth
+
+Load the AceDataCloud MCP and verify candidates with the public catalog—not memory:
+
+1. `acedatacloud_list_services` / `acedatacloud_get_service`
+2. `acedatacloud_list_apis` / `acedatacloud_get_api_spec`
+3. `acedatacloud_search_docs` / `acedatacloud_get_doc`
+4. `acedatacloud_list_model_catalog` when the topic names a model
+
+A candidate is eligible only when its service/API is live, public documentation is readable, and this run can produce or capture its required evidence. Never expose provider routing, supplier names, private IDs, signed URLs, account data, or real credentials.
+
+## 2. Select a non-repeating spotlight
+
+Read `{{run_count}}`, `{{date_iso}}`, and `{{last_output}}`. Call `maestro_list_tasks(limit=30)` and inspect recent Capability Spotlight artifact markers when available.
+
+Extract the last 12 runs' fields:
+
+`FAMILY_ID TOPIC_ID DEMO_ID STYLE_ID LAYOUT_ID PALETTE_ID VOICE_ID ASSET_HASHES`
+
+Select from the topic registry using these rules:
+
+- no `TOPIC_ID` from the last 8 runs;
+- no `DEMO_ID` from the last 12 runs;
+- a family may appear at most once in the last 3 runs;
+- avoid the last 4 `STYLE_ID` and `LAYOUT_ID`, last 3 `PALETTE_ID` and `VOICE_ID`;
+- derive a reproducible tiebreaker from `{{date_iso}}:{{run_count}}`; do not use unconstrained randomness;
+- stop when history or live evidence is unavailable—never fall back to a generic image showcase.
+
+Write the selected IDs before generating anything.
+
+## 3. Prove the unique advantage
+
+Load only the selected capability's MCP/Skill. Execute one registry hero recipe and inspect its full-resolution result.
+
+The result must prove the topic's distinctive value from pixels, motion, UI, or a real task trace:
+
+- generated media topics use the actual accepted output;
+- product topics use faithful live screenshots or real interaction evidence;
+- API panels are authored HTML, never screenshots of docs;
+- full `safe_request_json` stays evidence-only;
+- on-screen `display_request_json` is valid, minimal 4–7-line JSON with `Bearer $ACEDATACLOUD_API_KEY` only;
+- one video teaches one primary capability plus at most two supporting proofs.
+
+Do not accept a generic beautiful image/clip when the registry calls for typography, editing fidelity, reference consistency, multimodal control, agent tools, memory, scheduling, solving lifecycle, or review workflow.
+
+## 4. Choose a distinct creative system
+
+Choose compatible IDs from the registry and recent-history exclusions.
+
+Voice families:
+
+- high-energy launch: `energetic-male`, `bright-female`
+- technical explainer: `clean-female`, `calm-male`
+- brand story/case study: `storyteller-male`, `warm-female`
+- benchmark/news: `anchor-female`, `deep-male`
+
+Styles: `editorial`, `swiss`, `industrial`, `luxury`, `vibrant`, `retro`, `futuristic`.
+
+Layouts: `split-proof`, `timeline`, `comparison-field`, `ui-walkthrough`, `kinetic-type`, `full-bleed-case-study`.
+
+Preserve source-media palettes. Brand consistency comes from the approved lockup, type scale, spacing, restrained cyan signature, and CTA—not recoloring every result cyan/indigo.
+
+Generate narration only through Maestro's brokered Fish override. Verify the complete transcript, seven scene beats, final spoken CTA, proper-noun pronunciation, natural pace, and no missing tail. Do not stretch narration merely to fill runtime.
+
+## 5. Build the production kit
+
+Use the brand kit exactly. The first decoded frame names Ace Data Cloud and the capability. The final frame returns to the lockup and approved URLs.
+
+The kit sent to Maestro contains:
+
+- live facts and source URLs;
+- selected IDs and recent-history exclusions;
+- canonical brand source and authored wordmark rules;
+- exact evidence assets with service→asset mapping;
+- evidence-only request plus display request;
+- one clear viewer promise, scene plan, narration, voice/style/layout IDs;
+- explicit forbidden defects;
+- a unique UUID task ID, used for exactly one Maestro submission.
+
+Load Maestro only after the kit is complete. Submit one Pro 16:9 English production unless runtime inputs explicitly request another supported format/language.
+
+## 6. Time-boxed review and delivery
+
+Use exactly 14 evidence frames: decoded frame 0; scene midpoints; and one frame after every transition. Build one contact sheet and read each full-size frame once.
+
+Run initial `/visual-review`. If it finds blockers, perform one concentrated same-project refinement covering all findings, rerender once, inspect only affected frames plus decoded frame 0, then run one confirmation review. Never restart production routing after review and never render a third full version.
+
+Both reviews must answer:
+
+1. Is the canonical A symbol aligned with authored `ACE DATA CLOUD`, without the legacy bitmap `ceData` wordmark?
+2. Can viewers identify the brand and topic within three seconds?
+3. Does the evidence visibly prove this capability's unique advantage rather than a generic result?
+4. Are live API facts, minimal request, input, and result correctly mapped?
+5. Is the topic/demo/style/layout/palette/voice distinct from recent runs?
+6. Is narration complete, natural, correctly pronounced, and matched to the chosen tone?
+7. Are CTA, URLs, safe framing, transitions, and audio technically clean?
+
+After confirmation passes, Maestro writes `output/result.json`; the worker alone uploads. Record one draft video artifact whose summary begins:
+
+`ADC-SPOTLIGHT:v1 | FAMILY_ID=<id> | TOPIC_ID=<id> | DEMO_ID=<id> | STYLE_ID=<id> | LAYOUT_ID=<id> | PALETTE_ID=<id> | VOICE_ID=<id> | ASSET_HASHES=<hashes> | MAESTRO_TASK=<uuid> | SUBMISSION=accepted`
+
+Include live docs/API references and service→asset mapping after the marker. Never claim the asynchronous video is finished from the outer Producer run.

--- a/skills/capability-spotlight-video/references/brand-kit.md
+++ b/skills/capability-spotlight-video/references/brand-kit.md
@@ -1,0 +1,49 @@
+# Ace Data Cloud video brand kit
+
+## Canonical source
+
+Use only:
+
+`https://cdn.acedata.cloud/logo.png`
+
+It is the stable transparent 885×282 RGBA source. Its visible content is approximately x=50–828, y=47–230.
+
+Never use the retired 1600×900 upload `36066a80-7a14-4fd9-a7bc-7722f3be8285`, screenshots, color-key extraction, generated/redrawn logos, or the bitmap `AceData/ceData` wordmark.
+
+## Construct the lockup
+
+The source contains an A symbol plus a legacy wordmark. Crop the **A symbol only** from the transparent source, preserving its pixels and aspect ratio. Author the formal name as live HTML text:
+
+`ACE DATA CLOUD`
+
+Use a flex/grid lockup with separate controllable elements:
+
+- symbol optical box: square; object-fit contain; no CSS distortion;
+- wordmark: uppercase, 600–700 weight, tracking 0.08–0.14em;
+- gap: 0.28–0.38× the symbol's visible width;
+- align optical vertical centers, then adjust the wordmark baseline independently;
+- minimum visible opening symbol width at 1920×1080: 170px;
+- minimum authored wordmark cap height: 72px;
+- lockup clear space: at least 0.5× symbol width on every edge;
+- no black/white rectangular source canvas around the symbol.
+
+Do not place the symbol inline as the letter A inside another bitmap wordmark. The formal name must read exactly `ACE DATA CLOUD`.
+
+## Usage
+
+- Full lockup exactly twice: decoded frame 0/open and final CTA.
+- Middle scenes: authored eyebrow `ACE DATA CLOUD / <CAPABILITY>` only; no logo watermark.
+- Dark background: preserve cyan/blue symbol; wordmark #F8FAFC.
+- Light background: place lockup on a deliberate dark brand field; do not recolor the source symbol.
+- URLs: `https://platform.acedata.cloud` and `https://studio.acedata.cloud` as live HTML text.
+
+## Reviewer geometry checks
+
+At frame 0 and CTA verify:
+
+1. the A symbol is the canonical source crop, not a redraw;
+2. no legacy `AceData` or `ceData` bitmap appears;
+3. symbol and authored wordmark share a convincing optical center and baseline;
+4. gap and clear space are balanced at full resolution;
+5. neither element is stretched, cropped, blurred, or inside a source rectangle;
+6. the lockup is readable before any entrance animation; decoded frame 0 is authoritative.

--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -1,0 +1,144 @@
+# Capability Spotlight topic registry
+
+Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `DOC_QUERY`, `MCP`, `PROMISE`, `DEMOS`, `EVIDENCE`, `CREATIVE`, `LIMITS`.
+
+## TOPIC gpt-image-2-craft
+
+- FAMILY: ai-image
+- SERVICE: openai
+- APIS: `/openai/images/generations`, `/openai/images/edits`
+- DOC_QUERY: `gpt-image-2 image generation edits typography`
+- MCP: OpenAI
+- PROMISE: legible text and faithful edit/composite workflows, not generic text-to-image beauty shots.
+- DEMOS:
+  - `gpt2-editorial-typography`: a representative editorial poster, packaging system, or wayfinding composition with a short exact headline; inspect every character and spacing. Reject ordinary architecture/still life.
+  - `gpt2-faithful-composite`: pass the canonical A symbol plus a real product/screenshot/QR source to the edits endpoint; prove the source remains faithful while the surrounding campaign changes.
+  - `gpt2-consistent-campaign`: edit one accepted hero into 2–3 placements while preserving product, typography, and brand geometry.
+- EVIDENCE: exact source(s), accepted full-resolution result, character/crop checklist, generation/edit request, authored API panel.
+- CREATIVE: styles `editorial,vibrant,swiss`; layouts `kinetic-type,split-proof,comparison-field`; palettes must follow the chosen recipe; voices `energetic-male,bright-female,clean-female`.
+- LIMITS: maximum 3 image calls; typography failure gets one targeted replacement; never redraw the canonical logo.
+
+## TOPIC nano-banana-consistency
+
+- FAMILY: ai-image
+- SERVICE: nano-banana
+- APIS: `/nano-banana/images`
+- DOC_QUERY: `nano banana consistent subject variants`
+- MCP: Nano_Banana
+- PROMISE: one unmistakable subject remains coherent while location, angle, season, or usage changes.
+- DEMOS:
+  - `nano-product-worlds`: one fictional product across four genuinely different commercial environments.
+  - `nano-character-continuity`: one non-real fictional character across four narrative beats with stable face, clothing, and proportions.
+- EVIDENCE: full 2×2 result; per-quadrant consistency matrix; exact request/result mapping.
+- CREATIVE: styles `editorial,warm,pastel`; layouts `comparison-field,full-bleed-case-study`; voices `warm-female,storyteller-male,clean-female`.
+- LIMITS: reject if geometry or identity drifts; environments must differ visibly.
+
+## TOPIC seedream-commercial-detail
+
+- FAMILY: ai-image
+- SERVICE: seedream
+- APIS: `/seedream/images`
+- DOC_QUERY: `seedream high resolution commercial image`
+- MCP: Seedream
+- PROMISE: high-resolution commercial material detail, controlled depth, and art-directed still life.
+- DEMOS:
+  - `seedream-material-macro`: luxury object/material macro with layered natural depth.
+  - `seedream-environmental-campaign`: a bright environmental product scene with useful copy space and precise material rendering.
+- EVIDENCE: full-resolution crop details plus full frame; exact model/size request.
+- CREATIVE: styles `luxury,warm,editorial`; layouts `full-bleed-case-study,split-proof`; voices `warm-female,calm-male,storyteller-male`.
+- LIMITS: do not reuse dark glass/prism studios; no fabricated brand marks.
+
+## TOPIC minimax-h3-multimodal
+
+- FAMILY: ai-video
+- SERVICE: minimax
+- APIS: `/minimax/videos`, `/minimax/tasks`
+- DOC_QUERY: `MiniMax H3 video first last frame multimodal reference`
+- MCP: Minimax
+- PROMISE: H3 combines text with first/last frame, image, video, or audio references for controlled motion.
+- DEMOS:
+  - `h3-first-last-transition`: generate distinct first and last frames, then prove a coherent 6–8 second transition between them.
+  - `h3-reference-performance`: use one reference image plus reference audio or video and show the accepted input→motion output relationship.
+  - `h3-cinematic-t2v`: a camera-specific text-to-video recipe with observable motion, not a static beauty shot.
+- EVIDENCE: actual input references, real accepted MP4, start/middle/end frames, request and task lifecycle.
+- CREATIVE: styles `cinematic,industrial,futuristic`; layouts `timeline,split-proof,full-bleed-case-study`; voices `energetic-male,deep-male,bright-female`.
+- LIMITS: one H3 generation plus one bounded replacement; video is mandatory evidence.
+
+## TOPIC seedance-2-reference-control
+
+- FAMILY: ai-video
+- SERVICE: seedance
+- APIS: `/seedance/videos`, `/seedance/tasks`
+- DOC_QUERY: `Seedance 2.0 reference image audio video character consistency`
+- MCP: Seedance
+- PROMISE: Seedance 2.0 preserves a referenced person/character and can follow audio/video references at high resolution.
+- DEMOS:
+  - `seedance-character-reference`: use a safe fictional/non-private character reference across a new scene; compare identity at start/middle/end.
+  - `seedance-motion-reference`: supply reference video for motion/camera language and show the generated reinterpretation.
+  - `seedance-audio-reference`: pair a character image and safe reference audio; verify motion/audio result without identity claims about real people.
+- EVIDENCE: actual reference media, accepted output MP4, frame/contact sheet, minimal multimodal request, task lifecycle.
+- CREATIVE: styles `cinematic,vibrant,futuristic`; layouts `timeline,comparison-field,full-bleed-case-study`; voices `bright-female,energetic-male,storyteller-male`.
+- LIMITS: never use private/celebrity identity; one generation plus one replacement; video required.
+
+## TOPIC acechat-agent-workspace
+
+- FAMILY: ai-chat-agent
+- SERVICE: aichat
+- APIS: `/aichat2/conversations`, `/aichat2/mcp-servers`, `/aichat2/skills`, `/aichat2/memories`, `/aichat2/artifacts`, `/aichat2/scheduled-tasks`, `/aichat2/realtime`
+- DOC_QUERY: `AceChat aichat2 MCP Skills Memory Scheduled Tasks Realtime`
+- MCP: AceDataCloud
+- PROMISE: a stateful agent workspace combines conversations, tools, MCP, Skills, Memory, Artifacts, schedules, and realtime voice.
+- DEMOS:
+  - `acechat-tool-trace`: run a safe read-only task with one MCP and one Skill; show the real tool trace and resulting artifact.
+  - `acechat-memory-schedule`: demonstrate a real memory/scheduled-task lifecycle using sanitized UI screenshots and authored flow.
+  - `acechat-realtime-workspace`: demonstrate the real realtime/voice connection and one supported tool interaction without fabricated UI.
+- EVIDENCE: faithful live UI capture, sanitized tool trace, public API/docs, real artifact or scheduled run metadata.
+- CREATIVE: styles `swiss,industrial,editorial`; layouts `ui-walkthrough,timeline,split-proof`; voices `clean-female,calm-male,anchor-female`.
+- LIMITS: no account data, tokens, private memory, fake chat messages, or invented UI.
+
+## TOPIC captcha-solving-lifecycle
+
+- FAMILY: captcha
+- SERVICE: hcaptcha,recaptcha,turnstile,image2text
+- APIS: `/captcha/tasks`, `/captcha/recognition/image2text`, `/captcha/recognition/hcaptcha`, `/captcha/token/hcaptcha`, `/captcha/recognition/recaptcha2`, `/captcha/token/recaptcha2`, `/captcha/token/recaptcha3`, `/captcha/token/turnstile`
+- DOC_QUERY: `captcha task recognition hcaptcha recaptcha turnstile image2text`
+- MCP: hCaptcha, reCAPTCHA, Turnstile
+- PROMISE: one authenticated asynchronous lifecycle handles multiple challenge families and returns auditable results.
+- DEMOS:
+  - `captcha-image2text`: use a synthetic/local numeric challenge, submit it, and show the real recognized result.
+  - `captcha-task-lifecycle`: show create→lease/solve→task retrieve→result from a safe owned/test challenge.
+  - `captcha-family-matrix`: compare hCaptcha/reCAPTCHA/Turnstile request shapes and one successful test result without targeting third-party accounts.
+- EVIDENCE: synthetic or owned challenge only, real task IDs redacted in public frames, terminal result, minimal request/lifecycle diagram.
+- CREATIVE: styles `industrial,swiss,futuristic`; layouts `timeline,comparison-field,ui-walkthrough`; voices `calm-male,clean-female,anchor-female`.
+- LIMITS: authorized test use only; no bypass of third-party controls, credential collection, or private site data.
+
+## TOPIC maestro-agent-production
+
+- FAMILY: ai-video-production
+- SERVICE: maestro
+- APIS: `/maestro/videos`, `/maestro/tasks`, `/maestro/estimates`
+- DOC_QUERY: `Maestro AI video production review remix edit extend`
+- MCP: Maestro
+- PROMISE: one brief becomes a reviewed, narrated, branded final production—not merely one generated clip.
+- DEMOS:
+  - `maestro-brief-to-film`: show a real brief→asset manifest→composition→visual review→final MP4 chain.
+  - `maestro-review-refine`: show real initial review blockers, one concentrated refinement, confirmation review, and exact-byte delivery.
+  - `maestro-remix`: use a safe prior task to demonstrate a targeted edit/remix with before/after evidence.
+- EVIDENCE: real sanitized progress, review frames, result manifest, final MP4, actual duration/codec; no self-referential fake process UI.
+- CREATIVE: styles `editorial,swiss,futuristic`; layouts `timeline,ui-walkthrough,comparison-field`; voices `storyteller-male,anchor-female,deep-male`.
+- LIMITS: one parent Maestro task per Spotlight; avoid recursive unbounded video production.
+
+## TOPIC platform-unified-api
+
+- FAMILY: platform
+- SERVICE: acedatacloud
+- APIS: public catalog, docs, model catalog, selected service APIs
+- DOC_QUERY: `Ace Data Cloud services models unified API documentation`
+- MCP: AceDataCloud
+- PROMISE: developers discover and call a broad catalog through consistent authentication, docs, task, and billing conventions.
+- DEMOS:
+  - `platform-live-catalog`: query real services/models/docs, then spotlight three different modalities with live cards and public API paths.
+  - `platform-one-token-workflow`: explain one safe credential pattern across chat/image/video/search without showing private values.
+- EVIDENCE: live catalog responses, model modalities, public docs, authored architecture; no unsupported model-count claims.
+- CREATIVE: styles `swiss,editorial,industrial`; layouts `comparison-field,timeline,ui-walkthrough`; voices `anchor-female,calm-male,energetic-male`.
+- LIMITS: use only live catalog facts; this is an occasional platform overview, not the default fallback.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -1,0 +1,112 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SKILL = ROOT / "skills" / "capability-spotlight-video" / "SKILL.md"
+BRAND = ROOT / "skills" / "capability-spotlight-video" / "references" / "brand-kit.md"
+TOPICS = ROOT / "skills" / "capability-spotlight-video" / "references" / "topic-registry.md"
+
+
+def text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def topic_blocks() -> list[str]:
+    return re.findall(r"(?ms)^## TOPIC .+?(?=^## TOPIC |\Z)", text(TOPICS))
+
+
+def test_skill_declares_runtime_and_series_evidence_contract() -> None:
+    body = text(SKILL)
+    assert "name: capability-spotlight-video" in body
+    assert "{{run_count}}" in body
+    assert "{{date_iso}}" in body
+    assert "maestro_list_tasks(limit=30)" in body
+    for key in (
+        "FAMILY_ID",
+        "TOPIC_ID",
+        "DEMO_ID",
+        "STYLE_ID",
+        "LAYOUT_ID",
+        "PALETTE_ID",
+        "VOICE_ID",
+        "ASSET_HASHES",
+    ):
+        assert key in body
+    assert "ADC-SPOTLIGHT:v1" in body
+    assert "unconstrained randomness" in body
+    assert "one primary capability" in body
+
+
+def test_brand_kit_uses_canonical_transparent_asset_and_authored_name() -> None:
+    body = text(BRAND)
+    assert "https://cdn.acedata.cloud/logo.png" in body
+    assert "A symbol only" in body
+    assert "`ACE DATA CLOUD`" in body
+    assert "optical vertical centers" in body
+    assert "baseline" in body
+    assert "decoded frame 0" in body
+    assert "36066a80-7a14-4fd9-a7bc-7722f3be8285" in body
+    assert "Never use" in body
+    assert "legacy `AceData` or `ceData`" in body
+
+
+def test_registry_covers_broad_platform_families_and_representative_topics() -> None:
+    body = text(TOPICS)
+    blocks = topic_blocks()
+    assert len(blocks) >= 9
+    for topic in (
+        "gpt-image-2-craft",
+        "minimax-h3-multimodal",
+        "seedance-2-reference-control",
+        "acechat-agent-workspace",
+        "captcha-solving-lifecycle",
+        "maestro-agent-production",
+    ):
+        assert f"## TOPIC {topic}" in body
+    families = {re.search(r"(?m)^- FAMILY: (.+)$", block).group(1) for block in blocks}
+    assert {"ai-image", "ai-video", "ai-chat-agent", "captcha", "ai-video-production", "platform"} <= families
+
+
+def test_every_topic_has_multiple_demos_and_live_contract_fields() -> None:
+    required = ("- FAMILY:", "- SERVICE:", "- APIS:", "- DOC_QUERY:", "- MCP:", "- PROMISE:", "- DEMOS:", "- EVIDENCE:", "- CREATIVE:", "- LIMITS:")
+    for block in topic_blocks():
+        for marker in required:
+            assert marker in block, (block.splitlines()[0], marker)
+        demo_ids = re.findall(r"(?m)^  - `([^`]+)`:", block)
+        assert len(demo_ids) >= 2, block.splitlines()[0]
+        assert len(demo_ids) == len(set(demo_ids))
+
+
+def test_registry_demonstrates_unique_capability_strengths() -> None:
+    body = text(TOPICS)
+    assert "typography" in body and "edit/composite" in body
+    assert "first/last frame" in body and "reference audio" in body
+    assert "real tool trace" in body and "Memory" in body and "Scheduled Tasks" in body
+    assert "create→lease/solve→task retrieve→result" in body
+    assert "brief→asset manifest→composition→visual review→final MP4" in body
+    assert "video is mandatory evidence" in body
+
+
+def test_skill_rotates_voice_style_layout_and_keeps_review_bounded() -> None:
+    body = text(SKILL)
+    for voice in ("energetic-male", "bright-female", "clean-female", "calm-male", "storyteller-male", "warm-female", "anchor-female", "deep-male"):
+        assert voice in body
+    assert "last 3 `PALETTE_ID` and `VOICE_ID`" in body
+    assert "14 evidence frames" in body
+    assert "one concentrated same-project refinement" in body
+    assert "Never restart production routing" in body
+    assert "output/result.json" in body
+
+
+def test_public_copy_has_no_supplier_or_secret_leaks() -> None:
+    combined = "\n".join(map(text, (SKILL, BRAND, TOPICS))).lower()
+    for forbidden in (
+        "openai-hk",
+        "bananarouter",
+        "grsai",
+        "cqtai",
+        "acedatacloud_openai",
+        "gpt-image-2-vip",
+        "actual_api_key",
+    ):
+        assert forbidden not in combined


### PR DESCRIPTION
## Summary
- add a recurring Capability Spotlight orchestration skill
- define canonical brand geometry using the transparent Ace symbol plus authored `ACE DATA CLOUD`
- add nine live-evidence topic families and 23 representative demo recipes
- enforce constrained rotation across topic, demo, style, layout, palette, and voice
- add bounded Maestro review and series-level contract tests

## Verification
- `95 passed` (full Skills test suite)
- `git diff --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)