### PR TITLE
fix: bind spotlight to namespaced connector

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   author: acedatacloud
   version: "1.0"
-connections: [acedatacloud]
+connections: [acedatacloud/acedatacloud]
 compatibility: Requires the AceDataCloud connector, AceDataCloud and Maestro MCP servers, and whichever capability MCP is selected for the current spotlight.
 ---
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -18,6 +18,7 @@ def topic_blocks() -> list[str]:
 def test_skill_declares_runtime_and_series_evidence_contract() -> None:
     body = text(SKILL)
     assert "name: capability-spotlight-video" in body
+    assert "connections: [acedatacloud/acedatacloud]" in body
     assert "{{run_count}}" in body
     assert "{{date_iso}}" in body
     assert "maestro_list_tasks(limit=30)" in body


### PR DESCRIPTION
## Summary
- bind Capability Spotlight to the real `acedatacloud/acedatacloud` connector identifier
- add a regression assertion so the installed Skill remains connected and eligible for unattended schedules

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)