### PR TITLE
fix: treat maestro task replay as accepted

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -99,7 +99,9 @@ The kit sent to Maestro contains:
 
 Load Maestro only after the kit is complete. Submit one Pro production matching the requested format/language. For a controlled activation test, submit a 30-second Standard draft instead so orchestration and evidence can finish inside the outer scheduled-run window.
 
-Immediately after Maestro returns an accepted task (or exact-ID idempotent replay), call `publish_artifact` **before any further inspection, waiting, polling, or narration**. Record the accepted Maestro task as a draft with the complete `ADC-SPOTLIGHT:v1` marker and service→asset mapping. The outer Producer must then end; it must not poll Maestro. Artifact recording is part of submission, not a post-production step.
+Immediately after Maestro returns an accepted task, call `publish_artifact` **before any further inspection, waiting, polling, or narration**. The literal tool output `{'code': 'task_already_exists', 'task_id': '<same UUID>'}` is a successful exact-ID idempotent replay, even when the tool wrapper labels it as an error. In that case `<same UUID>` is the one accepted task: do not generate another UUID and do not call `maestro_create_video` again. The next and only allowed tool call is `publish_artifact`, referencing that exact task ID.
+
+Record the accepted Maestro task as a draft with the complete `ADC-SPOTLIGHT:v1` marker and service→asset mapping. The outer Producer must then end; it must not poll Maestro. Artifact recording is part of submission, not a post-production step.
 
 ## 6. Time-boxed review and delivery
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -99,6 +99,10 @@ def test_skill_rotates_voice_style_layout_and_keeps_review_bounded() -> None:
     assert "output/result.json" in body
     assert "30-second Standard draft" in body
     assert "before any further inspection, waiting, polling, or narration" in body
+    assert "{'code': 'task_already_exists', 'task_id': '<same UUID>'}" in body
+    assert "do not generate another UUID" in body
+    assert "do not call `maestro_create_video` again" in body
+    assert "next and only allowed tool call is `publish_artifact`" in body
     assert "The outer Producer must then end" in body
     assert "sandbox-root-qualified project paths" in body
     assert "Verify the manifest/contact sheet exists" in body


### PR DESCRIPTION
## Summary
- define the literal `task_already_exists` tool output as a successful exact-ID replay
- forbid generating a replacement UUID or making a second Maestro call
- require `publish_artifact` as the immediate next tool call using the original task ID

## Evidence
A controlled run interpreted the wrapper error appearance as failure, submitted a second task, and was correctly rejected by the scheduled-run judge.

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)