### PR TITLE
fix: resume async spotlight evidence

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -63,6 +63,16 @@ The result must prove the topic's distinctive value from pixels, motion, UI, or 
 
 Do not accept a generic beautiful image/clip when the registry calls for typography, editing fidelity, reference consistency, multimodal control, agent tools, memory, scheduling, solving lifecycle, or review workflow.
 
+### Async hero evidence
+
+Before creating generated hero media, query that capability's recent tasks and match the selected `TOPIC_ID`, `DEMO_ID`, model, and normalized request fingerprint:
+
+- reuse a matching completed task's accepted URL/MP4;
+- resume a matching pending task instead of creating a duplicate;
+- create a new task only when no match exists or the prior match is terminal-failed.
+
+After submission, follow the MCP's returned poll interval and poll until terminal. Do not poll once and give up. For activation tests, reserve up to two minutes (for example eight 15-second polls) for hero evidence. If it is still pending after that lease, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact containing the provider task ID, IDs/fingerprint, and no completion claim; end without Maestro. The next run must resume that task. A completed source-prep run does not count as a published Spotlight episode or consume its topic/demo diversity slot.
+
 ## 4. Choose a distinct creative system
 
 Choose compatible IDs from the registry and recent-history exclusions.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -36,6 +36,13 @@ def test_skill_declares_runtime_and_series_evidence_contract() -> None:
     assert "ADC-SPOTLIGHT:v1" in body
     assert "unconstrained randomness" in body
     assert "one primary capability" in body
+    assert "Async hero evidence" in body
+    assert "normalized request fingerprint" in body
+    assert "reuse a matching completed task" in body
+    assert "resume a matching pending task" in body
+    assert "Do not poll once and give up" in body
+    assert "eight 15-second polls" in body
+    assert "ADC-SPOTLIGHT-SOURCE:v1" in body
 
 
 def test_brand_kit_uses_canonical_transparent_asset_and_authored_name() -> None:


### PR DESCRIPTION
## Summary
- reuse completed hero-media tasks by topic/demo/request fingerprint
- resume pending tasks instead of submitting duplicates
- poll generated evidence for a bounded two-minute activation-test lease
- persist a source-prep artifact only when evidence remains pending

## Evidence
A GPT Image 2 hero task finished in 59.7 seconds, but the Producer polled only once and stopped. The result is valid and reusable; the task should not be recreated.

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)