### PR TITLE
fix: list spotlight evidence before create

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -65,11 +65,12 @@ Do not accept a generic beautiful image/clip when the registry calls for typogra
 
 ### Async hero evidence
 
-Before creating generated hero media, query that capability's recent tasks and match the selected `TOPIC_ID`, `DEMO_ID`, model, and normalized request fingerprint:
+Before creating generated hero media, the first capability-specific tool call MUST be that provider's `list_tasks`/batch-list tool with a 24-hour `created_at_min` window (or the closest supported recent-task filter). Do not call generate/create before this lookup. Compare each candidate's stored request fields—model, prompt, size/resolution, quality, count/duration, input/reference URLs, and action—against the normalized request fingerprint for the selected `TOPIC_ID` and `DEMO_ID`.
 
-- reuse a matching completed task's accepted URL/MP4;
-- resume a matching pending task instead of creating a duplicate;
-- create a new task only when no match exists or the prior match is terminal-failed.
+- reuse a matching completed task's accepted URL/MP4 and do not call generate/create;
+- resume a matching pending task by ID instead of creating a duplicate;
+- create a new task only when the list call proves no match exists or the prior match is terminal-failed;
+- if the provider has no list tool, use a `SOURCE_TASK` ID from the current task's `last_output`; do not pretend artifacts from other scheduled tasks are visible.
 
 After submission, follow the MCP's returned poll interval and poll until terminal. Do not poll once and give up. For activation tests, reserve up to two minutes (for example eight 15-second polls) for hero evidence. If it is still pending after that lease, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact containing the provider task ID, IDs/fingerprint, and no completion claim; end without Maestro. The next run must resume that task. A completed source-prep run does not count as a published Spotlight episode or consume its topic/demo diversity slot.
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -37,9 +37,13 @@ def test_skill_declares_runtime_and_series_evidence_contract() -> None:
     assert "unconstrained randomness" in body
     assert "one primary capability" in body
     assert "Async hero evidence" in body
-    assert "normalized request fingerprint" in body
+    assert "first capability-specific tool call MUST be that provider's" in body
+    assert "list_tasks" in body or "batch-list" in body
+    assert "24-hour" in body
+    assert "Do not call generate/create before this lookup" in body
     assert "reuse a matching completed task" in body
-    assert "resume a matching pending task" in body
+    assert "do not call generate/create" in body
+    assert "resume a matching pending task by ID" in body
     assert "Do not poll once and give up" in body
     assert "eight 15-second polls" in body
     assert "ADC-SPOTLIGHT-SOURCE:v1" in body


### PR DESCRIPTION
## Summary
- require provider recent-task lookup as the first capability-specific tool call
- match full stored request fields before creating hero media
- reuse completed tasks and resume pending tasks by ID
- fall back to same-task `last_output` only when no provider list tool exists

## Evidence
Two GPT Image hero tasks completed successfully in about one minute each, but separate Producer runs created new tasks because they never called `openai_list_tasks` first.

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)