### PR TITLE
fix: bind spotlight demos to executed evidence

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -35,7 +35,7 @@ Read `{{run_count}}`, `{{date_iso}}`, and `{{last_output}}`. Call `maestro_list_
 
 Extract the last 12 runs' fields:
 
-`FAMILY_ID TOPIC_ID DEMO_ID STYLE_ID LAYOUT_ID PALETTE_ID VOICE_ID ASSET_HASHES`
+`FAMILY_ID TOPIC_ID DEMO_ID STYLE_ID LAYOUT_ID PALETTE_ID VOICE_ID ASSET_HASHES EXECUTED_APIS EVIDENCE_URLS`
 
 Select from the topic registry using these rules:
 
@@ -114,7 +114,7 @@ Immediately after Maestro returns an accepted task, call `publish_artifact` **be
 
 Record the accepted Maestro task as a draft. The artifact **summary itself** must begin verbatim with the complete marker below; putting IDs only in tags does not satisfy history evidence:
 
-`ADC-SPOTLIGHT:v1 | FAMILY_ID=<id> | TOPIC_ID=<id> | DEMO_ID=<id> | STYLE_ID=<id> | LAYOUT_ID=<id> | PALETTE_ID=<id> | VOICE_ID=<id> | ASSET_HASHES=<hashes> | MAESTRO_TASK=<uuid> | SUBMISSION=accepted`
+`ADC-SPOTLIGHT:v1 | FAMILY_ID=<id> | TOPIC_ID=<id> | DEMO_ID=<id> | STYLE_ID=<id> | LAYOUT_ID=<id> | PALETTE_ID=<id> | VOICE_ID=<id> | ASSET_HASHES=<hashes> | EXECUTED_APIS=<public paths> | EVIDENCE_URLS=<accepted URLs> | MAESTRO_TASK=<uuid> | SUBMISSION=accepted`
 
 Follow the marker with live docs/API references and service→asset mapping. The outer Producer must then end; it must not poll Maestro. Artifact recording is part of submission, not a post-production step.
 

--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -12,9 +12,9 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - PROMISE: legible text and faithful edit/composite workflows, not generic text-to-image beauty shots.
 - DEMOS:
   - `gpt2-editorial-typography`: a representative editorial poster, packaging system, or wayfinding composition with a short exact headline; inspect every character and spacing. Reject ordinary architecture/still life.
-  - `gpt2-faithful-composite`: pass the canonical A symbol plus a real product/screenshot/QR source to the edits endpoint; prove the source remains faithful while the surrounding campaign changes.
+  - `gpt2-faithful-composite`: pass a real product/screenshot/QR source to `/openai/images/edits`; both the source URL and the accepted edits output URL are mandatory. This demo ID is forbidden when only `/openai/images/generations` executed—use `gpt2-editorial-typography` instead. Prove the source remains faithful while the surrounding campaign changes.
   - `gpt2-consistent-campaign`: edit one accepted hero into 2–3 placements while preserving product, typography, and brand geometry.
-- EVIDENCE: exact source(s), accepted full-resolution result, character/crop checklist, generation/edit request, authored API panel.
+- EVIDENCE: exact source(s), accepted full-resolution result, character/crop checklist, executed API path(s), accepted evidence URL(s), and authored API panel. `gpt2-faithful-composite` specifically requires `/openai/images/edits` in `EXECUTED_APIS` and its accepted output in `EVIDENCE_URLS`.
 - CREATIVE: styles `editorial,vibrant,swiss`; layouts `kinetic-type,split-proof,comparison-field`; palettes must follow the chosen recipe; voices `energetic-male,bright-female,clean-female`.
 - LIMITS: maximum 3 image calls; typography failure gets one targeted replacement; never redraw the canonical logo.
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -31,6 +31,8 @@ def test_skill_declares_runtime_and_series_evidence_contract() -> None:
         "PALETTE_ID",
         "VOICE_ID",
         "ASSET_HASHES",
+        "EXECUTED_APIS",
+        "EVIDENCE_URLS",
     ):
         assert key in body
     assert "ADC-SPOTLIGHT:v1" in body
@@ -92,6 +94,9 @@ def test_every_topic_has_multiple_demos_and_live_contract_fields() -> None:
 def test_registry_demonstrates_unique_capability_strengths() -> None:
     body = text(TOPICS)
     assert "typography" in body and "edit/composite" in body
+    assert "both the source URL and the accepted edits output URL are mandatory" in body
+    assert "forbidden when only `/openai/images/generations` executed" in body
+    assert "requires `/openai/images/edits` in `EXECUTED_APIS`" in body
     assert "first/last frame" in body and "reference audio" in body
     assert "real tool trace" in body and "Memory" in body and "Scheduled Tasks" in body
     assert "create→lease/solve→task retrieve→result" in body


### PR DESCRIPTION
## Summary
- add `EXECUTED_APIS` and `EVIDENCE_URLS` to every series marker
- require a real `/openai/images/edits` output for `gpt2-faithful-composite`
- forbid labeling a generation-only example as a faithful-edit demo

## Evidence
A generated GPT source was real, but the right-hand edit was only an illustrative duplicate. The demo label therefore overstated what executed.

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)