### PR TITLE
fix: require public Seedance references

### DIFF
--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -76,9 +76,9 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
   - `seedance-character-reference`: use a safe fictional/non-private character reference across a new scene; compare identity at start/middle/end.
   - `seedance-motion-reference`: supply reference video for motion/camera language and show the generated reinterpretation.
   - `seedance-audio-reference`: pair a character image and safe reference audio; verify motion/audio result without identity claims about real people.
-- EVIDENCE: actual reference media, accepted output MP4, frame/contact sheet, minimal multimodal request, task lifecycle.
+- EVIDENCE: actual reference media at a provider-downloadable public HTTPS URL, accepted output MP4, frame/contact sheet, minimal multimodal request, task lifecycle. Remote video APIs must never receive `data:`, `blob:`, or local-file reference URLs; upload references first and verify HTTPS reachability.
 - CREATIVE: styles `cinematic,vibrant,futuristic`; layouts `timeline,comparison-field,full-bleed-case-study`; voices `bright-female,energetic-male,storyteller-male`.
-- LIMITS: never use private/celebrity identity; one generation plus one replacement; video required.
+- LIMITS: never use private/celebrity identity; one generation plus one replacement; video required; reference media must be a public HTTPS URL and `return_last_frame` or other 2.5-only options require a Seedance 2.5 model.
 
 ## TOPIC acechat-agent-workspace
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -98,6 +98,9 @@ def test_registry_demonstrates_unique_capability_strengths() -> None:
     assert "forbidden when only `/openai/images/generations` executed" in body
     assert "requires `/openai/images/edits` in `EXECUTED_APIS`" in body
     assert "first/last frame" in body and "reference audio" in body
+    assert "provider-downloadable public HTTPS URL" in body
+    assert "never receive `data:`, `blob:`, or local-file reference URLs" in body
+    assert "2.5-only options require a Seedance 2.5 model" in body
     assert "real tool trace" in body and "Memory" in body and "Scheduled Tasks" in body
     assert "create→lease/solve→task retrieve→result" in body
     assert "brief→asset manifest→composition→visual review→final MP4" in body


### PR DESCRIPTION
## Summary
- require provider-downloadable public HTTPS reference media for Seedance Spotlights
- forbid data/blob/local reference URLs
- bind Seedance 2.5-only options to a 2.5 model

## Evidence
Three data-URI reference tasks failed. The same Seedance 2.0 workflow succeeded with a public HTTPS reference and returned a real 5.06-second MP4.

## Verification
- `95 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)