### PR TITLE
feat(spotlight): add Seedance image-reference demo

### DIFF
--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -74,6 +74,7 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - PROMISE: Seedance 2.0 preserves a referenced person/character and can follow audio/video references at high resolution.
 - DEMOS:
   - `seedance-character-reference`: use a safe fictional/non-private character reference across a new scene; compare identity at start/middle/end.
+  - `seedance-image-reference-control`: use a public fictional product/interface image as `reference_image`; prove visible structure/text treatment remains recognizable while the accepted MP4 adds requested camera motion. Show the exact reference URL, request, and start/middle/end decoded output frames; do not claim person/character identity or motion-reference input.
   - `seedance-motion-reference`: supply reference video for motion/camera language and show the generated reinterpretation.
   - `seedance-audio-reference`: pair a character image and safe reference audio; verify motion/audio result without identity claims about real people.
 - EVIDENCE: actual reference media at a provider-downloadable public HTTPS URL, accepted output MP4, frame/contact sheet, minimal multimodal request, task lifecycle. Remote video APIs must never receive `data:`, `blob:`, or local-file reference URLs; upload references first and verify HTTPS reachability.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -112,6 +112,10 @@ def test_registry_demonstrates_unique_capability_strengths() -> None:
     assert "script, labels, and narration must all agree with the inventory" in body
     assert "first/last frame" in body and "reference audio" in body
     assert "provider-downloadable public HTTPS URL" in body
+    assert "`seedance-image-reference-control`" in body
+    assert "public fictional product/interface image as `reference_image`" in body
+    assert "start/middle/end decoded output frames" in body
+    assert "do not claim person/character identity or motion-reference input" in body
     assert "never receive `data:`, `blob:`, or local-file reference URLs" in body
     assert "2.5-only options require a Seedance 2.5 model" in body
     assert "real tool trace" in body and "Memory" in body and "Scheduled Tasks" in body


### PR DESCRIPTION
## Summary
- add an accurate Seedance image-reference control demo
- bind claims to reference_image + accepted MP4 evidence
- forbid person-identity or motion-reference overclaiming

## Live evidence
Task `1cd27d35-1bdf-4dca-a0fc-e21269dfa1e8` used a public fictional dashboard `reference_image` and returned a real 5.062-second 1280×720 H.264/AAC MP4.

## Verification
- full Skills suite — 275 passed
- Ruff passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)