### PR TITLE
fix(spotlight): remove retired Maestro endpoint

### DIFF
--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -117,7 +117,7 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 
 - FAMILY: ai-video-production
 - SERVICE: maestro
-- APIS: `/maestro/videos`, `/maestro/tasks`, `/maestro/estimates`
+- APIS: `/maestro/videos`, `/maestro/tasks`
 - DOC_QUERY: `Maestro AI video production review remix edit extend`
 - MCP: Maestro
 - PROMISE: one brief becomes a reviewed, narrated, branded final production—not merely one generated clip.


### PR DESCRIPTION
## Contract node
Skill projection of the Maestro public API.

## Changes
Remove the retired `/maestro/estimates` claim; the live implementation exposes `/maestro/videos` and `/maestro/tasks`.

## Evidence
86 Skills tests passed; workspace search confirms the retired path is absent; diff check passed.

## Rollout / rollback
Content-only change; revert safely.

## Dependencies
The stale production API relation is retired by https://github.com/AceDataCloud/PlatformBackend/pull/1518

## Out of scope
No change to the active Maestro video/task workflow. Adversarial review was not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)