### PR TITLE
feat: upgrade capability spotlight to general campaign planner

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -22,7 +22,7 @@ Read before acting:
 
 Load the AceDataCloud MCP and verify candidates with the public catalog—not memory:
 
-1. `acedatacloud_list_services` / `acedatacloud_get_service`
+1. `acedatacloud_list_services(private=false, limit=300)` / `acedatacloud_get_service` — enumerate the complete current public service catalog, not a hand-maintained shortlist;
 2. `acedatacloud_list_apis` / `acedatacloud_get_api_spec`
 3. `acedatacloud_search_docs` / `acedatacloud_get_doc`
 4. `acedatacloud_list_model_catalog` when the topic names a model
@@ -37,20 +37,42 @@ Extract the last 12 runs' fields:
 
 `FAMILY_ID TOPIC_ID DEMO_ID STYLE_ID LAYOUT_ID PALETTE_ID VOICE_ID ASSET_HASHES EXECUTED_APIS EVIDENCE_URLS`
 
-Select from the topic registry using these rules:
+Do not select from the registry as a closed menu: its anchors are examples, not an allowlist. Build at least one candidate in each mode before choosing:
 
-- no `TOPIC_ID` from the last 8 runs;
-- no `DEMO_ID` from the last 12 runs;
-- a family may appear at most once in the last 3 runs;
-- avoid the last 4 `STYLE_ID` and `LAYOUT_ID`, last 3 `PALETTE_ID` and `VOICE_ID`;
+1. **Single Capability** — one service/model, one distinctive hero result;
+2. **Workflow Campaign** — 2–4 services that produce one visible buyer outcome;
+3. **Platform Story** — unified auth, catalog, SDK, tasks, billing, Agent, or automation proved by real calls/results.
+
+Score every candidate on live truth, unique sales value, hero evidence, executable authorization, compatible assets, price evidence, and recent-history diversity. The highest-scoring eligible candidate wins; do not default to Image or to the easiest service.
+
+Apply these exclusions:
+
+- no `TOPIC_ID` from the last 8 runs for a single-capability episode;
+- no `DEMO_ID` or `HERO_CASE_ID` from the last 12 runs;
+- no recent 6 `WORKFLOW_ID` repeats;
+- avoid the recent 4 `CAMPAIGN_MODE`, `HOOK_ID`, and climax grammar;
+- avoid the last 3 voice families and palettes;
+- the same service may return only with a different buyer, job, hero, and offer;
 - derive a reproducible tiebreaker from `{{date_iso}}:{{run_count}}`; do not use unconstrained randomness;
-- stop when history or live evidence is unavailable—never fall back to a generic image showcase.
+- stop when history, authorization, live pricing, or hero evidence is unavailable—never fall back to a generic showcase.
 
-Write the selected IDs before generating anything.
+Write the selected campaign mode and all marker IDs before generating anything.
 
-## 3. Prove the unique advantage
+## 3. Build and prove the capability graph
 
-Load only the selected capability's MCP/Skill. Execute one registry hero recipe and inspect its full-resolution result.
+For a workflow candidate, build a small runtime capability graph before calling any generation tool.
+
+**Node contract:** service/model, input modality, output modality, sync/async lifecycle, poll API, supported reference roles, authorized MCP/Skill, price payload, and accepted asset.
+
+**Edge contract:** connect nodes only when an actual output can legally become the next input. Prove every edge from an OpenAPI input/output field or an already executed request. Valid patterns include public image URL→image edit/reference video, public video URL→remix/caption/Maestro, text/research→brief/script/voice, audio URL→reference-audio video/production, and tool trace→artifact/automation evidence. Never connect services because their names merely sound compatible.
+
+A workflow uses **2–4 services** and sells one final outcome, not a logo parade. Each step must contribute to the same hero result and carry request/task/result evidence. A platform story needs at least two real cross-modal calls/results; a catalog card alone is not a hero.
+
+aichat2 supports dynamic `load_mcp_server`, but unattended authorization is bounded. Load only the selected **2–4 MCP servers** from the current authorized pool; do not preload every schema or claim an unconnected service executed. A service outside the execution pool is eligible only when a real accepted public artifact already exists and its provenance is explicit.
+
+## 4. Prove the unique advantage
+
+Load only the selected capability MCPs/Skills. Execute or reuse the selected hero recipe and inspect every final asset at full resolution.
 
 The result must prove the topic's distinctive value from pixels, motion, UI, or a real task trace:
 
@@ -74,16 +96,77 @@ Before creating generated hero media, the first capability-specific tool call MU
 
 After submission, follow the MCP's returned poll interval and poll until terminal. Do not poll once and give up. For activation tests, reserve up to two minutes (for example eight 15-second polls) for hero evidence. If it is still pending after that lease, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact containing the provider task ID, IDs/fingerprint, and no completion claim; end without Maestro. The next run must resume that task. A completed source-prep run does not count as a published Spotlight episode or consume its topic/demo diversity slot.
 
-## 4. Choose a distinct creative system
+## 4. Write the sales blueprint before Maestro
+
+This is a **product sales video**, not an API walkthrough or an internal evidence reel. Before loading Maestro, write the complete human-readable plan below. Do not call Maestro until the complete blueprint passes the preflight at the end of this section.
+
+```text
+SPOTLIGHT-SALES-BLUEPRINT:v2
+CAMPAIGN_MODE: single | workflow | platform
+PRODUCTS: <1–4 service/model ids>
+FINAL_OUTCOME: <one thing the buyer gets>
+AUDIENCE: <specific buyer in a specific work context>
+ONE-LINE VALUE: <the outcome they are buying>
+PAIN: <one concrete current frustration>
+HOOK: <the first spoken and on-screen line>
+BASIC_INTRO: <what it is, for whom, and the outcome>
+HERO CASE: <one real representative accepted example>
+UNIQUE ADVANTAGE: <the visibly provable reason to choose this capability/workflow/platform>
+WORKFLOW: <ordered service/input/output/evidence edges, or N/A>
+PRICE: <real quote(s), unit, source, request payload, and verification time>
+OFFER: <what is easy or valuable about starting now>
+CTA: <action plus destination>
+TONE: <emotional arc>
+VOICE: <voice id plus performance direction>
+```
+
+Then write a scene-by-scene storyboard. Every scene includes its time range, sales purpose, exact asset role/URL, on-screen copy, verbatim narration, transition/pacing, and the claim its pixels prove.
+
+Use this 30-second persuasion sequence:
+
+- **0–3 seconds — Hook:** Ace Data Cloud is visible immediately while a concrete pain, desire, or striking real result earns attention. Never use a slow logo intro or open by reading the product name.
+- **3–7 seconds — Basic introduction:** one sentence says what the product is, who it is for, and the outcome it creates. Do not read a feature menu.
+- **7–17 seconds — Hero case:** the real accepted output dominates the frame and creates the visual climax. Show input→result, ordinary→distinctive, or blocked→completed according to the topic playbook.
+- **17–22 seconds — Three advantages:** at most three short, concrete benefits supported by the hero pixels or real workflow.
+- **22–26 seconds — Integration and price:** show one minimal call or one-token workflow plus one understandable live price anchor.
+- **26–30 seconds — Offer and CTA:** give a specific action and destination; the voice finishes with an action verb rather than reading URLs.
+
+The complete narration is **65–80 English words**, written before submission. Use short sentences, pauses, and emphasis. Its emotional arc is pain/recognition → discovery → excited reveal → confident price → decisive action. Never say `accepted output`, `decoded-pixel proof`, `evidence bundle`, or other internal review language in customer-facing copy. Do not stretch neutral documentation prose across the runtime.
+
+Map every supplied URL so Maestro never guesses:
+
+```text
+ASSET 1 — PAIN / BEFORE — <real URL, or explicitly AUTHOR-RENDERED PAIN with no fake product/UI claim>
+ASSET 2 — HERO ACCEPTED OUTPUT — <mandatory accepted URL and why it proves the advantage>
+ASSET 3 — DETAIL / COMPARISON — <real URL or declared decoded derivative with exact crop/state>
+```
+
+Pricing is evidence, not ad-lib copy. Prefer the actual hero call's returned Credit cost. Otherwise evaluate the topic's explicit `PRICE_SCENARIOS` payload against live pricing. Convert Credits to USD only when the current package rate is available and recorded in the blueprint. If a dynamic price cannot be evaluated, display Credits or `See live pricing`; never guess dollars, a discount, or a competitor comparison.
+
+Preflight all nine questions before loading Maestro:
+
+1. Does the first line create a concrete pain or desire within three seconds?
+2. Does one sentence explain the product, buyer, and outcome?
+3. Is the hero case distinctive to this service rather than generically attractive?
+4. Is there one visible climax that works without narration?
+5. Are all three advantages demonstrated by this case?
+6. Is the price real, current, understandable, and bound to the demo request?
+7. Does the CTA say what to do and where?
+8. Does the narration sound like a sales performance rather than documentation?
+9. Are hook, case, pacing, and voice visibly different from recent episodes?
+
+If any answer is no, revise the blueprint before Maestro. **No real hero evidence means no Maestro submission.** Include the complete blueprint in the Maestro production brief and in the draft artifact metadata so the episode is auditable before asynchronous rendering.
+
+## 5. Choose a distinct creative system
 
 Choose compatible IDs from the registry and recent-history exclusions.
 
 Voice families:
 
-- high-energy launch: `energetic-male`, `bright-female`
-- technical explainer: `clean-female`, `calm-male`
-- brand story/case study: `storyteller-male`, `warm-female`
-- benchmark/news: `anchor-female`, `deep-male`
+- high-energy launch: `energetic-male`, `bright-female` — urgent hook, visible smile on reveal, decisive CTA;
+- premium product desire: `storyteller-male`, `warm-female` — intimate pain, sensory reveal, confident offer;
+- technical confidence: `clean-female`, `calm-male`, `anchor-female` — crisp mechanism, energized hero, slower price;
+- benchmark/news: `anchor-female`, `deep-male` — use only when a verified metric is the hook, never as the default documentary cadence.
 
 Styles: `editorial`, `swiss`, `industrial`, `luxury`, `vibrant`, `retro`, `futuristic`.
 
@@ -93,18 +176,21 @@ Preserve source-media palettes. Brand consistency comes from the approved lockup
 
 Generate narration only through Maestro's brokered Fish override. Verify the complete transcript, seven scene beats, final spoken CTA, proper-noun pronunciation, natural pace, and no missing tail. Do not stretch narration merely to fill runtime.
 
-## 5. Build the production kit
+## 6. Build the production kit
 
 Use the brand kit exactly. The first decoded frame names Ace Data Cloud and the capability. The final frame returns to the lockup and approved URLs.
 
 The kit sent to Maestro contains:
 
 - live facts and source URLs;
+- for workflow mode, every ordered step's service, input, output, API/task ID, accepted URL, and the OpenAPI/request proof for each edge;
+- for platform mode, at least two real cross-modal calls/results rather than catalog-only cards;
 - selected IDs and recent-history exclusions;
 - canonical brand source and authored wordmark rules;
 - exact evidence assets with service→asset mapping;
 - evidence-only request plus display request;
-- one clear viewer promise, scene plan, narration, voice/style/layout IDs;
+- the complete `SPOTLIGHT-SALES-BLUEPRINT:v2`, including hook, pain, basic introduction, hero case, three advantages, price proof, offer, CTA, storyboard, and verbatim narration;
+- one clear viewer promise plus voice performance/style/layout IDs;
 - explicit forbidden defects;
 - a unique UUID task ID, used for exactly one Maestro submission.
 
@@ -118,7 +204,7 @@ Record the accepted Maestro task as a draft. The artifact **summary itself** mus
 
 Follow the marker with live docs/API references and service→asset mapping. The outer Producer must then end; it must not poll Maestro. Artifact recording is part of submission, not a post-production step.
 
-## 6. Time-boxed review and delivery
+## 7. Time-boxed review and delivery
 
 Use exactly 14 evidence frames from the final MP4: extract decoded frame 0 explicitly at `-ss 0`, scene midpoints, and one frame after every transition. Build one contact sheet and read each full-size frame once. Frame 0 must already show the complete approved lockup and topic without relying on an entrance animation. Every sampled midpoint and boundary must contain sharp, meaningful scene content—no black/near-black gap, blurred placeholder, empty panel, or source-loading frame.
 

--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -1,6 +1,31 @@
-# Capability Spotlight topic registry
+# Capability Spotlight campaign anchor library
 
-Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `DOC_QUERY`, `MCP`, `PROMISE`, `DEMOS`, `EVIDENCE`, `CREATIVE`, `LIMITS`.
+## General derivation rubric
+
+This file is an **Anchor library — examples, not an allowlist**. The runtime planner may select any live public Ace Data Cloud service, model, Agent, deployment product, cross-service workflow, or platform story when it has authorized execution or real accepted evidence.
+
+For an unlisted capability, derive and verify all of the following from the live service, model catalog, docs, OpenAPI, pricing, and accepted output:
+
+- buyer/job-to-be-done and specific work context;
+- current pain that can be visualized without fabricating a competitor result;
+- observable mechanism and input→output lifecycle;
+- unique differentiator visible in pixels, motion, audio, structured result, or a real task trace;
+- hero recipe and the exact accepted evidence required;
+- price scenario bound to a concrete request payload;
+- CTA destination and a forbidden generic case.
+
+Run the portability test: if the value proposition could be copied unchanged onto another AI service, it is not distinctive enough—derive a sharper angle or reject the candidate.
+
+For workflow mode, prove every service edge from OpenAPI fields or an executed request. Representative campaign families include:
+
+- **Campaign launch:** Search/research → copy/brief → image → reference video → Maestro;
+- **Product-to-video:** reference image → variants/refinement → controlled motion → voice/music → final production;
+- **Agent automation:** AceChat + MCP/Skill → artifact → Memory/Scheduled Task → delivered result;
+- **Content engine:** Search/WebExtrator → structured insight → image/audio/video campaign asset;
+- **Audio-led campaign:** lyrics/music/voice → visual or cover → video/production;
+- **Platform integration:** one token → multiple real modality calls → one SDK/task/billing story.
+
+Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `DOC_QUERY`, `MCP`, `PROMISE`, sales fields, `DEMOS`, `EVIDENCE`, `CREATIVE`, `LIMITS`.
 
 ## TOPIC gpt-image-2-craft
 
@@ -10,6 +35,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `gpt-image-2 image generation edits typography`
 - MCP: OpenAI
 - PROMISE: legible text and faithful edit/composite workflows, not generic text-to-image beauty shots.
+- AUDIENCE: design teams, campaign marketers, and API developers shipping customer-visible creative.
+- PAIN: AI posters should not make a team fix every headline, grid, and product detail by hand.
+- BASIC_INTRO: GPT Image 2 generates and edits production-ready visual creative where typography and composition matter.
+- HERO_CASES: oversized editorial poster reveal; faithful source→campaign composite with a decoded before/after inventory.
+- UNIQUE_ADVANTAGES: readable headline hierarchy; controlled spacing and layout; faithful edit/composite behavior.
+- PRICE_SCENARIOS: quote one exact model+size+quality+n generation or one exact edit payload; bind the displayed unit price to that payload.
+- HOOKS: `AI posters shouldn’t make you fix every headline.`; `The prompt said premium. The typography should too.`
+- CTA: `EXPLORE GPT IMAGE 2 API` → `platform.acedata.cloud/documents/gpt-image-2`.
+- TONE: energetic creative-director launch; punch the failure, pause on the poster reveal, confident price, decisive CTA.
+- FORBIDDEN_GENERIC_CASES: ordinary architecture or still-life beauty shot; feature-list narration; unverified removal/edit claim.
 - DEMOS:
   - `gpt2-editorial-typography`: a representative editorial poster, packaging system, or wayfinding composition with a short exact headline; inspect every character and spacing. Reject ordinary architecture/still life.
   - `gpt2-faithful-composite`: pass a real product/screenshot/QR source to `/openai/images/edits`; both the source URL and the accepted edits output URL are mandatory. This demo ID is forbidden when only `/openai/images/generations` executed—use `gpt2-editorial-typography` instead. Inspect both accepted images at full resolution before scripting. Record `present before`, `present after`, and `visibly changed` from decoded pixels—not prompt prose, URL order, dimensions, or filenames—and bind each row to the exact source/output URL. Only claim differences that this comparison proves. An element still visible in the accepted edit cannot be called removed, replaced, or omitted; an element absent from the labeled frame cannot be called present.
@@ -26,6 +61,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `nano banana consistent subject variants`
 - MCP: Nano_Banana
 - PROMISE: one unmistakable subject remains coherent while location, angle, season, or usage changes.
+- AUDIENCE: brand teams and creators building multi-placement campaigns from one approved subject.
+- PAIN: campaign variations lose the product geometry or character identity from frame to frame.
+- BASIC_INTRO: Nano Banana turns one approved subject into a coherent campaign family across visibly different scenes.
+- HERO_CASES: 2×2 campaign consistency wall across four environments; four-beat fictional character continuity reveal.
+- UNIQUE_ADVANTAGES: subject consistency; editable variations; campaign-scale reuse from one reference.
+- PRICE_SCENARIOS: quote one exact model+count+reference payload and show the per-generation unit.
+- HOOKS: `One campaign. Four worlds. Same product.`; `Your character should not change actors between frames.`
+- CTA: `BUILD A CONSISTENT CAMPAIGN` → `studio.acedata.cloud`.
+- TONE: playful visual launch; rapid variant build, satisfying 2×2 lock, upbeat CTA.
+- FORBIDDEN_GENERIC_CASES: four unrelated pretty images; tiny subject; no side-by-side consistency proof.
 - DEMOS:
   - `nano-product-worlds`: one fictional product across four genuinely different commercial environments.
   - `nano-character-continuity`: one non-real fictional character across four narrative beats with stable face, clothing, and proportions.
@@ -41,6 +86,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `seedream high resolution commercial image`
 - MCP: Seedream
 - PROMISE: high-resolution commercial material detail, controlled depth, and art-directed still life.
+- AUDIENCE: ecommerce, packaging, and premium-brand teams that need campaign-ready product imagery.
+- PAIN: “Good enough” AI imagery does not sell premium products when materials, depth, and copy space feel generic.
+- BASIC_INTRO: Seedream creates art-directed commercial images with controlled material detail, depth, and usable composition.
+- HERO_CASES: full campaign image→ceramic/textile macro push; environmental product scene→copy-space and material callouts.
+- UNIQUE_ADVANTAGES: visible fine material texture; natural depth and lighting; deliberate commercial copy space.
+- PRICE_SCENARIOS: quote one exact model+output_pixels+count payload; show Credits when dynamic USD cannot be evaluated.
+- HOOKS: `“Good enough” imagery doesn’t sell premium products.`; `Zoom in. The material should still sell the story.`
+- CTA: `TRY SEEDREAM IN THE STUDIO` → `studio.acedata.cloud`.
+- TONE: premium and sensory; restrained pain, luxurious full-screen reveal, warm confident price, inviting CTA.
+- FORBIDDEN_GENERIC_CASES: generic dark glass; purposeless still life; tiny product; empty proof cards; claims not visible in the crop.
 - DEMOS:
   - `seedream-material-macro`: luxury object/material macro with layered natural depth.
   - `seedream-environmental-campaign`: a bright environmental product scene with useful copy space and precise material rendering.
@@ -56,6 +111,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `MiniMax H3 video first last frame multimodal reference`
 - MCP: Minimax
 - PROMISE: H3 combines text with first/last frame, image, video, or audio references for controlled motion.
+- AUDIENCE: video teams that need a planned transition or performance rather than an uncontrolled text-to-video clip.
+- PAIN: a strong first frame is wasted when the generated movement cannot land on the intended final beat.
+- BASIC_INTRO: MiniMax H3 combines text and multimodal references to control the beginning, movement, and destination of a shot.
+- HERO_CASES: first→last frame cinematic transition; reference performance with observable source→motion relationship.
+- UNIQUE_ADVANTAGES: multimodal control; coherent transition endpoints; camera-specific motion.
+- PRICE_SCENARIOS: quote one exact model+duration+resolution+reference payload.
+- HOOKS: `A transition needs a destination—not a surprise ending.`; `Direct the first frame. Direct the last. Let motion connect them.`
+- CTA: `DIRECT YOUR NEXT SHOT` → `studio.acedata.cloud`.
+- TONE: cinematic tension and release; hold endpoints, accelerate through motion, land confidently.
+- FORBIDDEN_GENERIC_CASES: attractive but unrelated text-to-video; no endpoint comparison; static beauty shot.
 - DEMOS:
   - `h3-first-last-transition`: generate distinct first and last frames, then prove a coherent 6–8 second transition between them.
   - `h3-reference-performance`: use one reference image plus reference audio or video and show the accepted input→motion output relationship.
@@ -72,6 +137,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `Seedance 2.0 reference image audio video character consistency`
 - MCP: Seedance
 - PROMISE: Seedance 2.0 preserves a referenced person/character and can follow audio/video references at high resolution.
+- AUDIENCE: product, campaign, and creative-development teams turning approved frames into controlled motion.
+- PAIN: turning a static design into video often loses the structure, text treatment, subject, or visual language already approved.
+- BASIC_INTRO: Seedance adds cinematic movement while using image, video, or audio references to control what must remain recognizable.
+- HERO_CASES: reference dashboard freeze→camera-motion reveal→structure comparison; safe fictional character or motion-reference transformation.
+- UNIQUE_ADVANTAGES: reference control; purposeful camera motion; recognizable visual structure across the shot.
+- PRICE_SCENARIOS: quote one exact model+resolution+duration+reference payload; never quote a default duration for a different model.
+- HOOKS: `You already designed the frame. Now make it move—without losing it.`; `Motion should add energy, not erase approval.`
+- CTA: `GENERATE YOUR FIRST VIDEO` → `studio.acedata.cloud`.
+- TONE: cinematic product launch; stillness on the hook, explosive motion reveal, confident technical beat, strong CTA.
+- FORBIDDEN_GENERIC_CASES: unreferenced cinematic clip; “cinematic motion” as the only benefit; person identity claim without proof.
 - DEMOS:
   - `seedance-character-reference`: use a safe fictional/non-private character reference across a new scene; compare identity at start/middle/end.
   - `seedance-image-reference-control`: use a public fictional product/interface image as `reference_image`; prove visible structure/text treatment remains recognizable while the accepted MP4 adds requested camera motion. Show the exact reference URL, request, and start/middle/end decoded output frames; do not claim person/character identity or motion-reference input.
@@ -89,6 +164,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `AceChat aichat2 MCP Skills Memory Scheduled Tasks Realtime`
 - MCP: AceDataCloud
 - PROMISE: a stateful agent workspace combines conversations, tools, MCP, Skills, Memory, Artifacts, schedules, and realtime voice.
+- AUDIENCE: developers and operators who need an agent to execute repeatable work, not merely answer a chat message.
+- PAIN: A chat box answers; it does not remember the workflow, call the right systems, deliver an artifact, and run again tomorrow.
+- BASIC_INTRO: AceChat is a stateful agent workspace that combines live tools, MCP, Skills, Memory, Artifacts, Scheduled Tasks, and realtime voice.
+- HERO_CASES: one real tool trace that produces an artifact; memory→schedule→completed run lifecycle with sanitized evidence.
+- UNIQUE_ADVANTAGES: real MCP/Skill execution; persistent context and memory; artifacts and scheduled automation in one workspace.
+- PRICE_SCENARIOS: show the actual model/tool call Credits when returned; otherwise use `See live pricing` and never invent a flat workspace price.
+- HOOKS: `A chat box answers. A workspace gets the work done.`; `If the work repeats tomorrow, the agent should remember.`
+- CTA: `OPEN ACECHAT` → `studio.acedata.cloud`.
+- TONE: sharp technical confidence; rapid tool expansion, satisfying artifact result, calm automation proof, decisive CTA.
+- FORBIDDEN_GENERIC_CASES: fake chat bubbles; feature-list narration; invented UI; private memory or token; tool trace without a result.
 - DEMOS:
   - `acechat-tool-trace`: run a safe read-only task with one MCP and one Skill; show the real tool trace and resulting artifact.
   - `acechat-memory-schedule`: demonstrate a real memory/scheduled-task lifecycle using sanitized UI screenshots and authored flow.
@@ -105,6 +190,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `captcha task recognition hcaptcha recaptcha turnstile image2text`
 - MCP: hCaptcha, reCAPTCHA, Turnstile
 - PROMISE: one authenticated asynchronous lifecycle handles multiple challenge families and returns auditable results.
+- AUDIENCE: authorized QA, automation, and operations teams handling owned/test challenge workflows.
+- PAIN: challenge handling blocks a workflow when submission, solving, polling, and result retrieval are fragmented or opaque.
+- BASIC_INTRO: Ace Data Cloud exposes an auditable asynchronous create→solve→result lifecycle across supported challenge families.
+- HERO_CASES: synthetic image2text timer from create to result; owned test challenge moving through leased/solved/retrieved states.
+- UNIQUE_ADVANTAGES: one lifecycle; explicit task state; auditable result retrieval without blocking the caller.
+- PRICE_SCENARIOS: quote the exact owned/test recognition endpoint payload; task polling is shown as free only when the live rule proves zero.
+- HOOKS: `A blocked workflow should not become a blind workflow.`; `Create. Solve. Retrieve. Keep the caller moving.`
+- CTA: `EXPLORE CAPTCHA APIS` → `platform.acedata.cloud`.
+- TONE: urgent operations problem→fast timer resolution→calm auditable close; never celebratory bypass language.
+- FORBIDDEN_GENERIC_CASES: third-party bypass framing; credential collection; fake token; feature matrix with no real task lifecycle.
 - DEMOS:
   - `captcha-image2text`: use a synthetic/local numeric challenge, submit it, and show the real recognized result.
   - `captcha-task-lifecycle`: show create→lease/solve→task retrieve→result from a safe owned/test challenge.
@@ -121,6 +216,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `Maestro AI video production review remix edit extend`
 - MCP: Maestro
 - PROMISE: one brief becomes a reviewed, narrated, branded final production—not merely one generated clip.
+- AUDIENCE: marketing and product teams coordinating script, assets, voice, editing, review, and delivery.
+- PAIN: a product video stalls across disconnected script, asset, voice, editing, and review tools before anyone gets a finished film.
+- BASIC_INTRO: Maestro turns one production brief into script, assets, narration, composition, independent review, and a delivered video project.
+- HERO_CASES: fragmented script, assets, voice, review, and final film steps collapse into one real delivered production; initial review blockers→one refinement→confirmed final bytes.
+- UNIQUE_ADVANTAGES: complete production pipeline; built-in independent review; editable/reusable project and final deliverables.
+- PRICE_SCENARIOS: quote the exact quality+duration+aspect+language request; show actual delivered-duration billing and failed-task zero charge only when live rules/docs verify it.
+- HOOKS: `A brief is not a video. Five disconnected tools are not a workflow.`; `Script, assets, voice, review, final film—one production brief.`
+- CTA: `CREATE WITH MAESTRO` → `studio.acedata.cloud`.
+- TONE: controlled overwhelm→rapid workflow collapse→emotional final-film payoff→confident offer.
+- FORBIDDEN_GENERIC_CASES: self-referential process cards with no final film; proof checklist as the whole story; recursive Maestro production.
 - DEMOS:
   - `maestro-brief-to-film`: show a real brief→asset manifest→composition→visual review→final MP4 chain.
   - `maestro-review-refine`: show real initial review blockers, one concentrated refinement, confirmation review, and exact-byte delivery.
@@ -137,6 +242,16 @@ Every topic block must keep this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `
 - DOC_QUERY: `Ace Data Cloud services models unified API documentation`
 - MCP: AceDataCloud
 - PROMISE: developers discover and call a broad catalog through consistent authentication, docs, task, and billing conventions.
+- AUDIENCE: developers integrating multiple AI modalities without maintaining separate credentials, SDKs, and billing systems.
+- PAIN: every new model adds another credential, request shape, polling loop, SDK, and bill to maintain.
+- BASIC_INTRO: Ace Data Cloud gives developers one token, one catalog, consistent task patterns, unified billing, and official SDK workflows across modalities.
+- HERO_CASES: one token drives a real image→video→chat workflow; fragmented integration cards collapse into one SDK path and delivered results.
+- UNIQUE_ADVANTAGES: one authentication layer; discoverable live catalog; consistent SDK/task/billing conventions.
+- PRICE_SCENARIOS: quote each showcased call from its real response or use `See live pricing`; never collapse unlike modalities into a fake single flat price.
+- HOOKS: `Every new model should not add another integration project.`; `One token. One catalog. Build across modalities.`
+- CTA: `EXPLORE THE API CATALOG` → `platform.acedata.cloud/models`.
+- TONE: developer overwhelm→clean consolidation→fast multi-modal result→confident platform CTA.
+- FORBIDDEN_GENERIC_CASES: pure catalog-card walkthrough; unsupported model counts; generic architecture diagram with no real calls/results.
 - DEMOS:
   - `platform-live-catalog`: query real services/models/docs, then spotlight three different modalities with live cards and public API paths.
   - `platform-one-token-workflow`: explain one safe credential pattern across chat/image/video/search without showing private values.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -128,7 +128,7 @@ def test_skill_rotates_voice_style_layout_and_keeps_review_bounded() -> None:
     body = text(SKILL)
     for voice in ("energetic-male", "bright-female", "clean-female", "calm-male", "storyteller-male", "warm-female", "anchor-female", "deep-male"):
         assert voice in body
-    assert "last 3 `PALETTE_ID` and `VOICE_ID`" in body
+    assert "last 3 voice families and palettes" in body
     assert "14 evidence frames" in body
     assert "one concentrated same-project refinement" in body
     assert "Never restart production routing" in body
@@ -150,6 +150,116 @@ def test_skill_rotates_voice_style_layout_and_keeps_review_bounded() -> None:
     assert "The outer Producer must then end" in body
     assert "sandbox-root-qualified project paths" in body
     assert "Verify the manifest/contact sheet exists" in body
+
+
+def test_skill_requires_sales_blueprint_before_maestro() -> None:
+    body = text(SKILL)
+    assert "SPOTLIGHT-SALES-BLUEPRINT:v2" in body
+    for field in (
+        "CAMPAIGN_MODE",
+        "PRODUCTS",
+        "FINAL_OUTCOME",
+        "AUDIENCE",
+        "ONE-LINE VALUE",
+        "PAIN",
+        "HOOK",
+        "HERO CASE",
+        "UNIQUE ADVANTAGE",
+        "PRICE",
+        "OFFER",
+        "CTA",
+        "TONE",
+        "VOICE",
+    ):
+        assert f"{field}:" in body
+    assert "Do not call Maestro until the complete blueprint passes" in body
+    assert "0–3 seconds" in body and "3–7 seconds" in body
+    assert "7–17 seconds" in body and "17–22 seconds" in body
+    assert "22–26 seconds" in body and "26–30 seconds" in body
+    assert "65–80 English words" in body
+    assert "accepted output" in body
+    assert "decoded-pixel proof" in body
+    assert "internal review language" in body
+    assert "ASSET 1 — PAIN / BEFORE" in body
+    assert "ASSET 2 — HERO ACCEPTED OUTPUT" in body
+    assert "ASSET 3 — DETAIL / COMPARISON" in body
+    assert "dynamic price cannot be evaluated" in body
+    assert "See live pricing" in body
+
+
+def test_every_topic_has_a_service_specific_sales_playbook() -> None:
+    required = (
+        "- AUDIENCE:",
+        "- PAIN:",
+        "- BASIC_INTRO:",
+        "- HERO_CASES:",
+        "- UNIQUE_ADVANTAGES:",
+        "- PRICE_SCENARIOS:",
+        "- HOOKS:",
+        "- CTA:",
+        "- TONE:",
+        "- FORBIDDEN_GENERIC_CASES:",
+    )
+    for block in topic_blocks():
+        for marker in required:
+            assert marker in block, (block.splitlines()[0], marker)
+        assert len(re.findall(r"(?m)^  - `[^`]+`:", block)) >= 2
+
+
+def test_sales_playbooks_name_distinct_product_drama() -> None:
+    body = text(TOPICS)
+    for phrase in (
+        "fix every headline",
+        "premium products",
+        "make it move—without losing it",
+        "campaign consistency wall",
+        "A chat box answers",
+        "create→solve→result",
+        "script, assets, voice, review, and final film",
+        "one token",
+    ):
+        assert phrase in body
+    assert "ordinary architecture or still-life beauty shot" in body
+    assert "fake chat bubbles" in body
+    assert "pure catalog-card walkthrough" in body
+
+
+def test_skill_is_a_general_runtime_campaign_planner() -> None:
+    body = text(SKILL)
+    assert "acedatacloud_list_services(private=false, limit=300)" in body
+    assert "Single Capability" in body
+    assert "Workflow Campaign" in body
+    assert "Platform Story" in body
+    assert "at least one candidate in each mode" in body
+    assert "SPOTLIGHT-SALES-BLUEPRINT:v2" in body
+    for field in ("CAMPAIGN_MODE", "PRODUCTS", "FINAL_OUTCOME", "BASIC_INTRO", "WORKFLOW"):
+        assert f"{field}:" in body
+    assert "capability graph" in body
+    assert "Node contract" in body
+    assert "Edge contract" in body
+    assert "2–4 services" in body
+    assert "OpenAPI" in body and "input/output" in body
+    assert "examples, not an allowlist" in body
+    assert "recent 6 `WORKFLOW_ID`" in body
+    assert "recent 4 `CAMPAIGN_MODE`, `HOOK_ID`, and climax grammar" in body
+    assert "dynamic `load_mcp_server`" in body
+    assert "2–4 MCP servers" in body
+    assert "No real hero evidence" in body
+
+
+def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:
+    body = text(TOPICS)
+    assert "Anchor library — examples, not an allowlist" in body
+    assert "General derivation rubric" in body
+    for field in ("buyer/job-to-be-done", "current pain", "observable mechanism", "hero recipe", "price scenario"):
+        assert field in body
+    assert "could be copied unchanged onto another AI service" in body
+    assert "Campaign launch" in body
+    assert "Product-to-video" in body
+    assert "Agent automation" in body
+    assert "Content engine" in body
+    assert "Audio-led campaign" in body
+    assert "Platform integration" in body
 
 
 def test_public_copy_has_no_supplier_or_secret_leaks() -> None:


### PR DESCRIPTION
## Summary
- discover campaigns dynamically across the live Ace Data Cloud catalog instead of a fixed three-service allowlist
- support single-capability, cross-service workflow, and platform-story campaigns
- require Sales Blueprint v2, proven workflow edges, runtime evidence gates, and diversity controls
- bound unattended execution to an authorized 10-MCP pool

## Scope
Prompt, reference material, and contract tests only. No Maestro code, templates, reviewer, or worker implementation changed.

## Verification
- capability spotlight contract tests: 12 passed
- six offline Blueprint v2 review samples cover all three campaign modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)