### PR TITLE
fix: require Spotlight Maestro marker prefix

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -155,7 +155,7 @@ Preflight all nine questions before loading Maestro:
 8. Does the narration sound like a sales performance rather than documentation?
 9. Are hook, case, pacing, and voice visibly different from recent episodes?
 
-If any answer is no, revise the blueprint before Maestro. **No real hero evidence means no Maestro submission.** Include the complete blueprint in the Maestro production brief and in the draft artifact metadata so the episode is auditable before asynchronous rendering.
+If any answer is no, revise the blueprint before Maestro. **No real hero evidence means no Maestro submission.** The exact Maestro prompt must begin with `ADC-SPOTLIGHT:v1` as its first line, with no title, explanation, or Markdown fence before it. Put the complete blueprint verbatim from the second line onward, and include it in the draft artifact metadata so the episode is auditable before asynchronous rendering.
 
 ## 5. Choose a distinct creative system
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -245,6 +245,9 @@ def test_skill_is_a_general_runtime_campaign_planner() -> None:
     assert "dynamic `load_mcp_server`" in body
     assert "2–4 MCP servers" in body
     assert "No real hero evidence" in body
+    assert "exact Maestro prompt must begin with `ADC-SPOTLIGHT:v1` as its first line" in body
+    assert "no title, explanation, or Markdown fence before it" in body
+    assert "complete blueprint verbatim from the second line onward" in body
 
 
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:


### PR DESCRIPTION
## Root cause
Three independent Standard Spotlight runs ended at ~2700 seconds with `timed_out=True` and no `output/result.json`. The existing Maestro extension applies only when the production prompt begins with `ADC-SPOTLIGHT:v1`; Blueprint v2 prompts began with Markdown headings instead.

Affected tasks:
- `bf2876d1-9a10-4042-82e7-84d8e3e3aefd`
- `4e2926cc-bd13-46e6-9b6c-5c13fc19dbb3`
- `6385fe74-5e09-4da2-bb43-92d8fb79111f`

## Fix
Require the exact marker as the first Maestro prompt line, followed by the complete Blueprint v2 verbatim. No Maestro implementation changes.

## Verification
- `pytest -q tests/test_capability_spotlight_video.py` — 12 passed
- corrected live request accepted as task `b339cf94-6257-451f-9db0-fb56dac338fb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)