### PR TITLE
feat: route diverse Spotlight films through general-video

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -1,225 +1,189 @@
 ---
 name: capability-spotlight-video
-description: Produce a recurring Ace Data Cloud Capability Spotlight series. Each run selects one live, evidence-rich platform capability, creates a representative demo that proves its unique strength, and hands a branded, non-repetitive production kit to Maestro. Use for scheduled Ace Data Cloud product videos that must rotate across image, video, chat/agent, CAPTCHA, audio, web/data, identity, and end-to-end production capabilities.
+description: Plan and submit a recurring series of diverse, premium Ace Data Cloud sales films. Each run discovers live capabilities, proves a real buyer outcome, assembles a rich provenance-bound material set, chooses a structurally distinct creative genome, and routes a freeform Pro production through Maestro general-video.
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "1.0"
+  version: "4.0"
 connections: [acedatacloud/acedatacloud]
-compatibility: Requires the AceDataCloud connector, AceDataCloud and Maestro MCP servers, and whichever capability MCP is selected for the current spotlight.
+compatibility: Requires the AceDataCloud connector, Maestro MCP, and only the capability MCPs authorized for the selected campaign.
 ---
 
-# Ace Data Cloud Capability Spotlight
+# Ace Data Cloud Campaign Film Director
 
-Create **one deep, evidence-led capability video per run**. Do not make a broad platform montage and do not default to Image APIs.
+Create one **premium, product-specific sales film** per production run. The series must vary in subject, visual world, film structure, camera language, rhythm, transitions, sound, voice, and material mix—not merely palette or labels.
 
-Read before acting:
+Read first:
 
 - [brand kit](references/brand-kit.md)
 - [topic registry](references/topic-registry.md)
 
 ## 1. Discover live truth
 
-Load the AceDataCloud MCP and verify candidates with the public catalog—not memory:
+Load the AceDataCloud MCP and verify candidates from live public sources:
 
-1. `acedatacloud_list_services(private=false, limit=300)` / `acedatacloud_get_service` — enumerate the complete current public service catalog, not a hand-maintained shortlist;
-2. `acedatacloud_list_apis` / `acedatacloud_get_api_spec`
-3. `acedatacloud_search_docs` / `acedatacloud_get_doc`
-4. `acedatacloud_list_model_catalog` when the topic names a model
+1. `acedatacloud_list_services(private=false, limit=300)` and `acedatacloud_get_service`;
+2. `acedatacloud_list_apis` and `acedatacloud_get_api_spec`;
+3. `acedatacloud_search_docs` and `acedatacloud_get_doc`;
+4. `acedatacloud_list_model_catalog` when models matter.
 
-A candidate is eligible only when its service/API is live, public documentation is readable, and this run can produce or capture its required evidence. Never expose provider routing, supplier names, private IDs, signed URLs, account data, or real credentials.
+A candidate is eligible only when the public service/API/docs are live and this run can execute or reuse every material required for a convincing film. Never expose private routing/source details, private IDs, signed URLs, account data, or credentials.
 
-## 2. Select a non-repeating spotlight
+## 2. Generate candidates and maximize creative distance
 
-Read `{{run_count}}`, `{{date_iso}}`, and `{{last_output}}`. Call `maestro_list_tasks(limit=30)` and inspect recent Capability Spotlight artifact markers when available.
+Read `{{run_count}}`, `{{date_iso}}`, `{{last_output}}`, `{{creative_policy}}`, and `{{format}}`. Call `maestro_list_tasks(limit=30)` and inspect recent `ADC-SPOTLIGHT:v1` artifact summaries when available.
 
-Extract the last 12 runs' fields:
+Build at least one eligible candidate in every mode before choosing:
 
-`FAMILY_ID TOPIC_ID DEMO_ID STYLE_ID LAYOUT_ID PALETTE_ID VOICE_ID ASSET_HASHES EXECUTED_APIS EVIDENCE_URLS`
+1. **Single Capability** — one product/model, one distinctive buyer outcome;
+2. **Workflow Campaign** — 2–4 services producing one visible outcome;
+3. **Platform Story** — platform value proved through real cross-modal results or product lifecycles.
 
-Do not select from the registry as a closed menu: its anchors are examples, not an allowlist. Build at least one candidate in each mode before choosing:
+For each candidate write a complete Creative Genome:
 
-1. **Single Capability** — one service/model, one distinctive hero result;
-2. **Workflow Campaign** — 2–4 services that produce one visible buyer outcome;
-3. **Platform Story** — unified auth, catalog, SDK, tasks, billing, Agent, or automation proved by real calls/results.
+`CAMPAIGN_MODE FILM_ARCHETYPE VISUAL_WORLD SHOT_GRAMMAR RHYTHM_PATTERN OPENING_DEVICE CLIMAX_DEVICE TRANSITION_SYSTEM BRAND_BEHAVIOR VOICE_ID SOUND_WORLD PALETTE_FAMILY TYPE_SYSTEM MATERIAL_MIX`
 
-Score every candidate on live truth, unique sales value, hero evidence, executable authorization, compatible assets, price evidence, and recent-history diversity. The highest-scoring eligible candidate wins; do not default to Image or to the easiest service.
+Score live truth, sales specificity, hero strength, authorization, price proof, material richness, and **creative distance**. Apply these exclusions from the last 12 artifacts:
 
-Apply these exclusions:
+- no recent 8 `TOPIC_ID`, buyer job, or `HERO_CASE_ID` repeat;
+- no recent 6 `FILM_ARCHETYPE` or `OPENING_DEVICE` repeat;
+- no recent 5 visual-world or shot-grammar repeat;
+- no recent 4 campaign-mode, climax-device, or rhythm-pattern repeat;
+- no recent 3 transition-system, voice-family, sound-world, or palette-family repeat;
+- a returning service must change at least four of buyer, job, hero, archetype, visual world, and offer.
 
-- no `TOPIC_ID` from the last 8 runs for a single-capability episode;
-- no `DEMO_ID` or `HERO_CASE_ID` from the last 12 runs;
-- no recent 6 `WORKFLOW_ID` repeats;
-- avoid the recent 4 `CAMPAIGN_MODE`, `HOOK_ID`, and climax grammar;
-- avoid the last 3 voice families and palettes;
-- the same service may return only with a different buyer, job, hero, and offer;
-- derive a reproducible tiebreaker from `{{date_iso}}:{{run_count}}`; do not use unconstrained randomness;
-- stop when history, authorization, live pricing, or hero evidence is unavailable—never fall back to a generic showcase.
+Use `date_iso:run_count` only as a deterministic tiebreaker; do not use unconstrained randomness. `creative_policy` influences scoring but never becomes a fixed shot template:
 
-Write the selected campaign mode and all marker IDs before generating anything.
+- `auto-diverse`: maximize distance from recent work;
+- `brand-anthem`: prefer platform desire and brand-led payoff;
+- `product-cinematic`: prefer one product and sensorial/cinematic proof;
+- `workflow-story`: prefer a visible multi-step transformation.
 
-## 3. Build and prove the capability graph
+Stop rather than fall back to a generic showcase when history, authorization, real hero evidence, pricing, or rich materials are unavailable.
 
-For a workflow candidate, build a small runtime capability graph before calling any generation tool.
+## 3. Prove workflow edges and real outcomes
 
-**Node contract:** service/model, input modality, output modality, sync/async lifecycle, poll API, supported reference roles, authorized MCP/Skill, price payload, and accepted asset.
+For workflow candidates, build a runtime capability graph before generation.
 
-**Edge contract:** connect nodes only when an actual output can legally become the next input. Prove every edge from an OpenAPI input/output field or an already executed request. Valid patterns include public image URL→image edit/reference video, public video URL→remix/caption/Maestro, text/research→brief/script/voice, audio URL→reference-audio video/production, and tool trace→artifact/automation evidence. Never connect services because their names merely sound compatible.
+**Node contract:** service/model, input/output modality, sync/async lifecycle, poll API, reference roles, authorized MCP, price payload, and accepted asset.
 
-A workflow uses **2–4 services** and sells one final outcome, not a logo parade. Each step must contribute to the same hero result and carry request/task/result evidence. A platform story needs at least two real cross-modal calls/results; a catalog card alone is not a hero.
+**Edge contract:** every output must legally become the next input, proved by OpenAPI or an executed request. Never combine services because their names sound compatible. A workflow uses 2–4 services and sells one outcome, not a logo parade. A platform story requires at least three real results or product surfaces across three modalities/lifecycles; catalog cards alone are forbidden.
 
-aichat2 supports dynamic `load_mcp_server`, but unattended authorization is bounded. Load only the selected **2–4 MCP servers** from the current authorized pool; do not preload every schema or claim an unconnected service executed. A service outside the execution pool is eligible only when a real accepted public artifact already exists and its provenance is explicit.
+Load only the selected 2–4 MCP servers from the authorized pool. A capability outside that pool is eligible only when a public accepted artifact already exists with explicit provenance.
 
-## 4. Prove the unique advantage
+## 4. Reuse tasks before spending
 
-Load only the selected capability MCPs/Skills. Execute or reuse the selected hero recipe and inspect every final asset at full resolution.
+For generated hero media, the first capability-specific call MUST be the provider's `list_tasks`/batch list with a 24-hour `created_at_min` window or closest equivalent. Do not generate before this lookup.
 
-The result must prove the topic's distinctive value from pixels, motion, UI, or a real task trace:
+- reuse a matching completed request and accepted public URL;
+- resume a matching pending task by ID;
+- create only when no match exists or the match terminal-failed;
+- with no list tool, resume only a `SOURCE_TASK` from this task's `last_output`.
 
-- generated media topics MUST execute the selected live capability and use its actual accepted output URL/MP4 as the primary visual evidence; an authored mock, illustrative example, prompt-only panel, or "not executed" disclosure can be supporting context but never satisfies the hero proof;
-- product topics use faithful live screenshots or real interaction evidence;
-- API panels are authored HTML, never screenshots of docs;
-- full `safe_request_json` stays evidence-only;
-- on-screen `display_request_json` is valid, minimal 4–7-line JSON with `Bearer $ACEDATACLOUD_API_KEY` only;
-- one video teaches one primary capability plus at most two supporting proofs.
+Poll according to the returned interval until terminal. For activation/source preparation, reserve up to two minutes (for example eight 15-second polls). If still pending, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact with task ID and fingerprint, make no completion claim, and end without Maestro.
 
-Do not accept a generic beautiful image/clip when the registry calls for typography, editing fidelity, reference consistency, multimodal control, agent tools, memory, scheduling, solving lifecycle, or review workflow.
+Inspect every selected asset at full resolution. Generated media MUST use a real accepted result. Product/Agent/deployment stories use faithful, sanitized screenshots or lifecycle evidence. Full request JSON is evidence-only; customer-facing frames never contain internal review or provenance language.
 
-### Async hero evidence
+## 5. Require a rich material plan
 
-Before creating generated hero media, the first capability-specific tool call MUST be that provider's `list_tasks`/batch-list tool with a 24-hour `created_at_min` window (or the closest supported recent-task filter). Do not call generate/create before this lookup. Compare each candidate's stored request fields—model, prompt, size/resolution, quality, count/duration, input/reference URLs, and action—against the normalized request fingerprint for the selected `TOPIC_ID` and `DEMO_ID`.
+Record provenance privately, but never place labels such as `accepted output`, `decoded proof`, `evidence bundle`, task hash, or review gate in the film.
 
-- reuse a matching completed task's accepted URL/MP4 and do not call generate/create;
-- resume a matching pending task by ID instead of creating a duplicate;
-- create a new task only when the list call proves no match exists or the prior match is terminal-failed;
-- if the provider has no list tool, use a `SOURCE_TASK` ID from the current task's `last_output`; do not pretend artifacts from other scheduled tasks are visible.
+### Single Capability
 
-After submission, follow the MCP's returned poll interval and poll until terminal. Do not poll once and give up. For activation tests, reserve up to two minutes (for example eight 15-second polls) for hero evidence. If it is still pending after that lease, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact containing the provider task ID, IDs/fingerprint, and no completion claim; end without Maestro. The next run must resume that task. A completed source-prep run does not count as a published Spotlight episode or consume its topic/demo diversity slot.
+Require at least four useful visual roles: real input/before, accepted hero, two real details/alternates/decoded derivatives, and optionally product context/UI/brand environment. One unchanged still may not be stretched through the film. If the material cannot support varied compositions, choose another candidate.
 
-## 4. Write the sales blueprint before Maestro
+### Workflow Campaign
 
-This is a **product sales video**, not an API walkthrough or an internal evidence reel. Before loading Maestro, write the complete human-readable plan below. Do not call Maestro until the complete blueprint passes the preflight at the end of this section.
+Require 5–8 roles covering 2–4 real stages. Every stage has real input/output/task evidence and pushes the same final outcome. The final result is the hero.
+
+### Platform Story
+
+Require at least three distinct modalities or product surfaces and three real results. At least one role must contain real motion or a real UI/task lifecycle. A catalog-only slideshow is forbidden.
+
+### Audio, Agent, and Deployment
+
+- audio: real audio/result, waveform or timing data, cover/lyrics/context, and an audio-reactive visual world;
+- Agent: real tool trace, delivered artifact/result, and memory/schedule lifecycle—never fake chat bubbles;
+- deployment: real sanitized configuration/status/lifecycle screens; without them the candidate is ineligible.
+
+## 6. Write Sales Blueprint v3
+
+Before Maestro, write:
 
 ```text
-SPOTLIGHT-SALES-BLUEPRINT:v2
+ACE-DATA-CLOUD-SALES-BLUEPRINT:v3
 CAMPAIGN_MODE: single | workflow | platform
-PRODUCTS: <1–4 service/model ids>
-FINAL_OUTCOME: <one thing the buyer gets>
-AUDIENCE: <specific buyer in a specific work context>
-ONE-LINE VALUE: <the outcome they are buying>
-PAIN: <one concrete current frustration>
-HOOK: <the first spoken and on-screen line>
-BASIC_INTRO: <what it is, for whom, and the outcome>
-HERO CASE: <one real representative accepted example>
-UNIQUE ADVANTAGE: <the visibly provable reason to choose this capability/workflow/platform>
-WORKFLOW: <ordered service/input/output/evidence edges, or N/A>
-PRICE: <real quote(s), unit, source, request payload, and verification time>
-OFFER: <what is easy or valuable about starting now>
-CTA: <action plus destination>
-TONE: <emotional arc>
-VOICE: <voice id plus performance direction>
+PRODUCTS: <1–4 services/models>
+FINAL_OUTCOME: <one buyer result>
+AUDIENCE: <specific buyer/context>
+PAIN: <concrete frustration>
+PROMISE: <the outcome being sold>
+HERO_CASE: <real representative result>
+UNIQUE_ADVANTAGE: <visible differentiator>
+WORKFLOW: <ordered proven edges, or N/A>
+PRICE: <payload-bound live proof>
+OFFER: <why start now>
+CTA: <action + destination>
+FILM_ARCHETYPE / VISUAL_WORLD / SHOT_GRAMMAR / RHYTHM_PATTERN
+OPENING_DEVICE / CLIMAX_DEVICE / TRANSITION_SYSTEM
+MATERIAL_MIX: <role→URL map with private provenance>
+BRAND_BEHAVIOR / VOICE / SOUND_WORLD / COLOR_LOGIC / TYPE_SYSTEM
+FORBIDDEN_REPETITIONS / QUALITY_GATES
 ```
 
-Then write a scene-by-scene storyboard. Every scene includes its time range, sales purpose, exact asset role/URL, on-screen copy, verbatim narration, transition/pacing, and the claim its pixels prove.
+Do **not** write a fixed six-scene or fixed timestamp storyboard. Describe emotional beats, hero moments, material roles, and 3–6 measurable quality gates; the general-video Director owns scene count, timing, layouts, and transitions.
 
-Use this 30-second persuasion sequence:
+The Blueprint must still answer: who buys, what changes, why this product is distinctive, which real result proves it, what it costs, and what to do next. Integration/price appears only when it advances the sale. Narration length follows the selected format and must finish before the CTA hold.
 
-- **0–3 seconds — Hook:** Ace Data Cloud is visible immediately while a concrete pain, desire, or striking real result earns attention. Never use a slow logo intro or open by reading the product name.
-- **3–7 seconds — Basic introduction:** one sentence says what the product is, who it is for, and the outcome it creates. Do not read a feature menu.
-- **7–17 seconds — Hero case:** the real accepted output dominates the frame and creates the visual climax. Show input→result, ordinary→distinctive, or blocked→completed according to the topic playbook.
-- **17–22 seconds — Three advantages:** at most three short, concrete benefits supported by the hero pixels or real workflow.
-- **22–26 seconds — Integration and price:** show one minimal call or one-token workflow plus one understandable live price anchor.
-- **26–30 seconds — Offer and CTA:** give a specific action and destination; the voice finishes with an action verb rather than reading URLs.
+## 7. Choose a professional, product-derived creative world
 
-The complete narration is **65–80 English words**, written before submission. Use short sentences, pauses, and emphasis. Its emotional arc is pain/recognition → discovery → excited reveal → confident price → decisive action. Never say `accepted output`, `decoded-pixel proof`, `evidence bundle`, or other internal review language in customer-facing copy. Do not stretch neutral documentation prose across the runtime.
+The registry is an anchor library—examples, not an allowlist. Derive a concrete world from the product's meaning, not a generic cyan dashboard.
 
-Map every supplied URL so Maestro never guesses:
+Film archetype vocabulary includes brand anthem, product reveal, workflow transformation, launch trailer, kinetic manifesto, cinematic UI demo, before/after case film, multi-modal montage, metric-to-human payoff, and visual poem.
 
-```text
-ASSET 1 — PAIN / BEFORE — <real URL, or explicitly AUTHOR-RENDERED PAIN with no fake product/UI claim>
-ASSET 2 — HERO ACCEPTED OUTPUT — <mandatory accepted URL and why it proves the advantage>
-ASSET 3 — DETAIL / COMPARISON — <real URL or declared decoded derivative with exact crop/state>
-```
+Shot grammar includes macro→wide, match cuts, continuous camera, split-screen convergence, kinetic-type slam, parallax editorial, UI depth flythrough, and object-led transitions.
 
-Pricing is evidence, not ad-lib copy. Prefer the actual hero call's returned Credit cost. Otherwise evaluate the topic's explicit `PRICE_SCENARIOS` payload against live pricing. Convert Credits to USD only when the current package rate is available and recorded in the blueprint. If a dynamic price cannot be evaluated, display Credits or `See live pricing`; never guess dollars, a discount, or a competitor comparison.
+Rhythm includes cold-open burst, fast-fast-slow-climax, crescendo montage, tension→release, precision pulse, and luxury restraint.
 
-Preflight all nine questions before loading Maestro:
+Preserve source-media palettes. Ace identity remains canonical, but its **behavior varies**: energy rail, mask, registration system, spatial frame, light, typographic cadence, or audio sting. Do not default to the same corner watermark, cyan UI frame, centered title card, evidence card, or proof checklist.
 
-1. Does the first line create a concrete pain or desire within three seconds?
-2. Does one sentence explain the product, buyer, and outcome?
-3. Is the hero case distinctive to this service rather than generically attractive?
-4. Is there one visible climax that works without narration?
-5. Are all three advantages demonstrated by this case?
-6. Is the price real, current, understandable, and bound to the demo request?
-7. Does the CTA say what to do and where?
-8. Does the narration sound like a sales performance rather than documentation?
-9. Are hook, case, pacing, and voice visibly different from recent episodes?
+## 8. Route production through Maestro general-video
 
-If any answer is no, revise the blueprint before Maestro. **No real hero evidence means no Maestro submission.** The exact Maestro prompt must begin with `ADC-SPOTLIGHT:v1` as its first line, with no title, explanation, or Markdown fence before it. Put the complete blueprint verbatim from the second line onward, and include it in the draft artifact metadata so the episode is auditable before asynchronous rendering.
+The Maestro production prompt begins with the non-routing line:
 
-## 5. Choose a distinct creative system
+`ACE-DATA-CLOUD-BRAND-FILM:v1`
 
-Choose compatible IDs from the registry and recent-history exclusions.
+It MUST NOT contain `ADC-SPOTLIGHT:v1`; that marker is reserved for the outer artifact summary. Explicitly require:
 
-Voice families:
+- `scenario=auto`, `quality=pro`, and route to `/general-video`;
+- never use `spotlight_prepare.py`, `spotlight_renderer.py`, or the fixed six-scene Spotlight template;
+- read general-video's `house-style.md` and `video-composition.md`;
+- write a one-sentence concept angle, embedded font pairing, and foreground-density plan;
+- run prompt expansion for multi-scene work;
+- name the rhythm pattern and build hero layouts before animation;
+- use modular sub-compositions for 3+ hard cuts and intentional transition recipes;
+- use Fish narration timing and a product-appropriate real music/SFX world;
+- honor the Blueprint's Creative Genome and material-role map without displaying private provenance.
 
-- high-energy launch: `energetic-male`, `bright-female` — urgent hook, visible smile on reveal, decisive CTA;
-- premium product desire: `storyteller-male`, `warm-female` — intimate pain, sensory reveal, confident offer;
-- technical confidence: `clean-female`, `calm-male`, `anchor-female` — crisp mechanism, energized hero, slower price;
-- benchmark/news: `anchor-female`, `deep-male` — use only when a verified metric is the hook, never as the default documentary cadence.
+Formal production uses **Pro**, never Standard as a quality proxy. Choose format from `{{format}}`; `auto-diverse` must also avoid the recent three formats and fit the content/channel.
 
-Styles: `editorial`, `swiss`, `industrial`, `luxury`, `vibrant`, `retro`, `futuristic`.
+Immediately after Maestro accepts the unique UUID task, call `publish_artifact` before waiting or polling. Exact-ID `task_already_exists` is a successful idempotent replay: do not generate another UUID or resubmit.
 
-Layouts: `split-proof`, `timeline`, `comparison-field`, `ui-walkthrough`, `kinetic-type`, `full-bleed-case-study`.
+The artifact summary—not the Maestro prompt—begins:
 
-Preserve source-media palettes. Brand consistency comes from the approved lockup, type scale, spacing, restrained cyan signature, and CTA—not recoloring every result cyan/indigo.
+`ADC-SPOTLIGHT:v1 | BLUEPRINT=v3 | FAMILY_ID=<id> | TOPIC_ID=<id> | DEMO_ID=<id> | WORKFLOW_ID=<id-or-na> | FILM_ARCHETYPE=<id> | VISUAL_WORLD=<id> | SHOT_GRAMMAR=<id> | RHYTHM_PATTERN=<id> | OPENING_DEVICE=<id> | CLIMAX_DEVICE=<id> | TRANSITION_SYSTEM=<id> | STYLE_ID=<id> | PALETTE_ID=<id> | VOICE_ID=<id> | SOUND_WORLD=<id> | FORMAT=<id> | ASSET_HASHES=<hashes> | EXECUTED_APIS=<paths> | EVIDENCE_URLS=<urls> | MAESTRO_TASK=<uuid> | SUBMISSION=accepted`
 
-Generate narration only through Maestro's brokered Fish override. Verify the complete transcript, seven scene beats, final spoken CTA, proper-noun pronunciation, natural pace, and no missing tail. Do not stretch narration merely to fill runtime.
+Follow it with the complete Blueprint and role→asset provenance. The outer task ends after `recorded=true`; it must not claim the asynchronous film is complete.
 
-## 6. Build the production kit
+## 9. Professional review contract
 
-Use the brand kit exactly. The first decoded frame names Ace Data Cloud and the capability. The final frame returns to the lockup and approved URLs.
+The Blueprint defines archetype-specific gates plus these invariants:
 
-The kit sent to Maestro contains:
+- decoded frame 0 contains clear brand or product desire—not blank/loading/disclaimer;
+- real hero material is visually dominant, not reduced to evidence cards;
+- composition variety and pacing match this run's genome;
+- no static material is dragged beyond the limit appropriate to the archetype;
+- customer copy contains no internal review language, private sourcing facts or invented claims;
+- narration/audio are complete and the CTA is readable.
 
-- live facts and source URLs;
-- for workflow mode, every ordered step's service, input, output, API/task ID, accepted URL, and the OpenAPI/request proof for each edge;
-- for platform mode, at least two real cross-modal calls/results rather than catalog-only cards;
-- selected IDs and recent-history exclusions;
-- canonical brand source and authored wordmark rules;
-- exact evidence assets with service→asset mapping;
-- evidence-only request plus display request;
-- the complete `SPOTLIGHT-SALES-BLUEPRINT:v2`, including hook, pain, basic introduction, hero case, three advantages, price proof, offer, CTA, storyboard, and verbatim narration;
-- one clear viewer promise plus voice performance/style/layout IDs;
-- explicit forbidden defects;
-- a unique UUID task ID, used for exactly one Maestro submission.
-
-Load Maestro only after the kit is complete. Submit one Pro production matching the requested format/language. A controlled activation test may reduce only duration and SKU to a 30-second Standard draft; it MUST still use a real accepted capability output, run final-MP4 pixel/audio inspection, execute both the initial and final-byte confirmation reviews, and satisfy every brand/evidence gate. Never disable inner review or replace live hero evidence with a mock merely to make the test faster.
-
-Immediately after Maestro returns an accepted task, call `publish_artifact` **before any further inspection, waiting, polling, or narration**. The literal tool output `{'code': 'task_already_exists', 'task_id': '<same UUID>'}` is a successful exact-ID idempotent replay, even when the tool wrapper labels it as an error. In that case `<same UUID>` is the one accepted task: do not generate another UUID and do not call `maestro_create_video` again. The next and only allowed tool call is `publish_artifact`, referencing that exact task ID.
-
-Record the accepted Maestro task as a draft. The artifact **summary itself** must begin verbatim with the complete marker below; putting IDs only in tags does not satisfy history evidence:
-
-`ADC-SPOTLIGHT:v1 | FAMILY_ID=<id> | TOPIC_ID=<id> | DEMO_ID=<id> | STYLE_ID=<id> | LAYOUT_ID=<id> | PALETTE_ID=<id> | VOICE_ID=<id> | ASSET_HASHES=<hashes> | EXECUTED_APIS=<public paths> | EVIDENCE_URLS=<accepted URLs> | MAESTRO_TASK=<uuid> | SUBMISSION=accepted`
-
-Follow the marker with live docs/API references and service→asset mapping. The outer Producer must then end; it must not poll Maestro. Artifact recording is part of submission, not a post-production step.
-
-## 7. Time-boxed review and delivery
-
-Use exactly 14 evidence frames from the final MP4: extract decoded frame 0 explicitly at `-ss 0`, scene midpoints, and one frame after every transition. Build one contact sheet and read each full-size frame once. Frame 0 must already show the complete approved lockup and topic without relying on an entrance animation. Every sampled midpoint and boundary must contain sharp, meaningful scene content—no black/near-black gap, blurred placeholder, empty panel, or source-loading frame.
-
-Evidence paths passed to `/visual-review` must be **sandbox-root-qualified project paths** such as `<project>/review/current`, never paths relative to the nested project directory. Verify the manifest/contact sheet exists at that exact path before invoking review; a missing-path review is a failed preflight, not a reason to consume another render.
-
-Make an actual `Skill` call with `skill="visual-review"` and the absolute initial evidence directory. If it finds blockers, perform one concentrated same-project refinement covering all findings and rerender once. Then rebuild or verify evidence from the final MP4 bytes and make a second actual `Skill` call with the absolute confirmation evidence directory. The confirmation call is mandatory even when the initial review finds no blockers and the MP4 does not change. Never restart production routing after review and never render a third full version.
-
-Both reviews must answer:
-
-1. Is the canonical A symbol aligned with authored `ACE DATA CLOUD`, without the legacy bitmap `ceData` wordmark?
-2. Can viewers identify the brand and topic within three seconds?
-3. Does the evidence visibly prove this capability's unique advantage rather than a generic result?
-4. Are live API facts, minimal request, input, and result correctly mapped?
-5. Is the topic/demo/style/layout/palette/voice distinct from recent runs?
-6. Is narration complete, natural, correctly pronounced, and matched to the chosen tone?
-7. Are CTA, URLs, safe framing, transitions, and audio technically clean?
-
-After confirmation passes, Maestro writes `output/result.json`; the worker alone uploads. The draft artifact was already recorded by the outer Producer immediately after accepted submission. Never defer artifact recording until Maestro finishes and never claim the asynchronous video is finished from the outer Producer run.
+Make an actual `Skill` call with `skill="visual-review"` against complete initial evidence. Fix blockers in one concentrated pass. Rebuild evidence from the exact final MP4 bytes and make a second actual confirmation call even when no initial blocker exists. The Reviewer receives the Blueprint, Creative Genome, role map, and evidence and judges whether this film fulfilled **its chosen director language**, not whether it resembles previous episodes.

--- a/skills/capability-spotlight-video/references/brand-kit.md
+++ b/skills/capability-spotlight-video/references/brand-kit.md
@@ -48,3 +48,15 @@ At frame 0 and CTA verify:
 4. gap and clear space are balanced at full resolution;
 5. neither element is stretched, cropped, blurred, or inside a source rectangle;
 6. the lockup is readable before any entrance animation; decoded frame 0 is authoritative.
+
+## Identity stays fixed; brand behavior rotates
+
+The canonical symbol crop, authored `ACE DATA CLOUD`, clear space, and public URLs never change. The way the identity behaves in motion MUST change with the Creative Genome:
+
+- it may become an energy rail, mask edge, registration grid, spatial portal, light source, typographic cadence, object transition, or audio sting;
+- it may live on a sourced palette rather than forcing every scene to cyan/navy;
+- frame 0 needs immediate brand/product desire, but not a repeated static logo card;
+- the middle may use an active brand system rather than a tiny corner watermark;
+- CTA composition must fit this film's archetype, not reuse the same centered button every episode.
+
+Do not repeat the same brand entrance, corner placement, cyan frame, logo scale, CTA layout, or sound sting from the recent three films. Brand consistency is identity and craft—not template sameness.

--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -27,6 +27,17 @@ For workflow mode, prove every service edge from OpenAPI fields or an executed r
 
 Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`, `DOC_QUERY`, `MCP`, `PROMISE`, sales fields, `DEMOS`, `EVIDENCE`, `CREATIVE`, `LIMITS`.
 
+## Creative opportunity fields
+
+Every anchor below supplies product truth and sales angles, not a fixed film template. At planning time derive and record:
+
+- `VISUAL_WORLDS`: at least two product-derived worlds;
+- `FILM_ARCHETYPES`: at least two compatible structures;
+- `MATERIAL_OPPORTUNITIES`: real visual/audio/UI roles that can make the film rich;
+- `FORBIDDEN_REPETITION`: the recent visual grammar or lazy treatment that would make this topic feel generic.
+
+When a topic block has no explicit values, derive them from its promise, hero cases, evidence, and limits before eligibility scoring. A palette or voice swap alone never counts as a different creative treatment.
+
 ## TOPIC gpt-image-2-craft
 
 - FAMILY: ai-image
@@ -51,6 +62,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `gpt2-consistent-campaign`: edit one accepted hero into 2–3 placements while preserving product, typography, and brand geometry.
 - EVIDENCE: exact source(s), accepted full-resolution result, three-column before/after/change inventory, character/crop checklist, executed API path(s), accepted evidence URL(s), and authored API panel. `gpt2-faithful-composite` specifically requires `/openai/images/edits` in `EXECUTED_APIS` and its accepted output in `EVIDENCE_URLS`; the script, labels, and narration must all agree with the inventory.
 - CREATIVE: styles `editorial,vibrant,swiss`; layouts `kinetic-type,split-proof,comparison-field`; palettes must follow the chosen recipe; voices `energetic-male,bright-female,clean-female`.
+- VISUAL_WORLDS: editorial print lab; kinetic campaign wall.
+- FILM_ARCHETYPES: product reveal; kinetic manifesto; before/after case film.
+- MATERIAL_OPPORTUNITIES: full poster; type macro; source/edit comparison; campaign applications.
+- FORBIDDEN_REPETITION: generic prompt card→image→three proof labels.
 - LIMITS: maximum 3 image calls; typography failure gets one targeted replacement; never redraw the canonical logo.
 
 ## TOPIC nano-banana-consistency
@@ -76,6 +91,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `nano-character-continuity`: one non-real fictional character across four narrative beats with stable face, clothing, and proportions.
 - EVIDENCE: full 2×2 result; per-quadrant consistency matrix; exact request/result mapping.
 - CREATIVE: styles `editorial,warm,pastel`; layouts `comparison-field,full-bleed-case-study`; voices `warm-female,storyteller-male,clean-female`.
+- VISUAL_WORLDS: campaign world switcher; continuity control room.
+- FILM_ARCHETYPES: workflow transformation; multi-modal montage; before/after case film.
+- MATERIAL_OPPORTUNITIES: 2×2 consistency wall; subject crops; environment variants; edit lifecycle.
+- FORBIDDEN_REPETITION: four unrelated pretty images in a static grid.
 - LIMITS: reject if geometry or identity drifts; environments must differ visibly.
 
 ## TOPIC seedream-commercial-detail
@@ -101,6 +120,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `seedream-environmental-campaign`: a bright environmental product scene with useful copy space and precise material rendering.
 - EVIDENCE: full-resolution crop details plus full frame; exact model/size request.
 - CREATIVE: styles `luxury,warm,editorial`; layouts `full-bleed-case-study,split-proof`; voices `warm-female,calm-male,storyteller-male`.
+- VISUAL_WORLDS: tactile product atelier; luminous material gallery.
+- FILM_ARCHETYPES: product cinematic; luxury visual poem; sensorial reveal.
+- MATERIAL_OPPORTUNITIES: campaign full frame; macro crops; copy-space pan; material/light alternates.
+- FORBIDDEN_REPETITION: one still-life image stretched through the runtime.
 - LIMITS: do not reuse dark glass/prism studios; no fabricated brand marks.
 
 ## TOPIC minimax-h3-multimodal
@@ -127,6 +150,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `h3-cinematic-t2v`: a camera-specific text-to-video recipe with observable motion, not a static beauty shot.
 - EVIDENCE: actual input references, real accepted MP4, start/middle/end frames, request and task lifecycle.
 - CREATIVE: styles `cinematic,industrial,futuristic`; layouts `timeline,split-proof,full-bleed-case-study`; voices `energetic-male,deep-male,bright-female`.
+- VISUAL_WORLDS: cinematic transition chamber; performance stage.
+- FILM_ARCHETYPES: launch trailer; continuous-camera reveal; visual poem.
+- MATERIAL_OPPORTUNITIES: first frame; last frame; motion clip; reference audio/waveform; decoded beats.
+- FORBIDDEN_REPETITION: generic clip with no visible source→motion relationship.
 - LIMITS: one H3 generation plus one bounded replacement; video is mandatory evidence.
 
 ## TOPIC seedance-2-reference-control
@@ -154,6 +181,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `seedance-audio-reference`: pair a character image and safe reference audio; verify motion/audio result without identity claims about real people.
 - EVIDENCE: actual reference media at a provider-downloadable public HTTPS URL, accepted output MP4, frame/contact sheet, minimal multimodal request, task lifecycle. Remote video APIs must never receive `data:`, `blob:`, or local-file reference URLs; upload references first and verify HTTPS reachability.
 - CREATIVE: styles `cinematic,vibrant,futuristic`; layouts `timeline,comparison-field,full-bleed-case-study`; voices `bright-female,energetic-male,storyteller-male`.
+- VISUAL_WORLDS: camera-control launch bay; spatial UI world.
+- FILM_ARCHETYPES: cinematic UI demo; static→motion transformation; launch trailer.
+- MATERIAL_OPPORTUNITIES: approved reference; full motion clip; start/middle/end frames; structure comparison.
+- FORBIDDEN_REPETITION: replaying one five-second clip for most of the film.
 - LIMITS: never use private/celebrity identity; one generation plus one replacement; video required; reference media must be a public HTTPS URL and `return_last_frame` or other 2.5-only options require a Seedance 2.5 model.
 
 ## TOPIC acechat-agent-workspace
@@ -180,6 +211,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `acechat-realtime-workspace`: demonstrate the real realtime/voice connection and one supported tool interaction without fabricated UI.
 - EVIDENCE: faithful live UI capture, sanitized tool trace, public API/docs, real artifact or scheduled run metadata.
 - CREATIVE: styles `swiss,industrial,editorial`; layouts `ui-walkthrough,timeline,split-proof`; voices `clean-female,calm-male,anchor-female`.
+- VISUAL_WORLDS: living operations room; tool-to-artifact workspace.
+- FILM_ARCHETYPES: cinematic UI journey; workflow transformation; metric-to-human payoff.
+- MATERIAL_OPPORTUNITIES: real tool trace; artifact; schedule lifecycle; sanitized UI states.
+- FORBIDDEN_REPETITION: fake chat bubbles and feature-menu cards.
 - LIMITS: no account data, tokens, private memory, fake chat messages, or invented UI.
 
 ## TOPIC captcha-solving-lifecycle
@@ -206,6 +241,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `captcha-family-matrix`: compare hCaptcha/reCAPTCHA/Turnstile request shapes and one successful test result without targeting third-party accounts.
 - EVIDENCE: synthetic or owned challenge only, real task IDs redacted in public frames, terminal result, minimal request/lifecycle diagram.
 - CREATIVE: styles `industrial,swiss,futuristic`; layouts `timeline,comparison-field,ui-walkthrough`; voices `calm-male,clean-female,anchor-female`.
+- VISUAL_WORLDS: precision task relay; timed operations tunnel.
+- FILM_ARCHETYPES: precision-pulse explainer; blocked→completed case film.
+- MATERIAL_OPPORTUNITIES: owned challenge; timer/status states; result lifecycle; safe metrics.
+- FORBIDDEN_REPETITION: security-bypass framing or generic architecture diagram.
 - LIMITS: authorized test use only; no bypass of third-party controls, credential collection, or private site data.
 
 ## TOPIC maestro-agent-production
@@ -232,6 +271,10 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `maestro-remix`: use a safe prior task to demonstrate a targeted edit/remix with before/after evidence.
 - EVIDENCE: real sanitized progress, review frames, result manifest, final MP4, actual duration/codec; no self-referential fake process UI.
 - CREATIVE: styles `editorial,swiss,futuristic`; layouts `timeline,ui-walkthrough,comparison-field`; voices `storyteller-male,anchor-female,deep-male`.
+- VISUAL_WORLDS: director room; production pipeline stage.
+- FILM_ARCHETYPES: workflow transformation; behind-the-film brand piece; launch trailer.
+- MATERIAL_OPPORTUNITIES: brief; real assets; composition; review frames; final MP4.
+- FORBIDDEN_REPETITION: self-referential proof checklist without an emotional final film.
 - LIMITS: one parent Maestro task per Spotlight; avoid recursive unbounded video production.
 
 ## TOPIC platform-unified-api
@@ -257,4 +300,8 @@ Every anchor topic block keeps this schema: `TOPIC`, `FAMILY`, `SERVICE`, `APIS`
   - `platform-one-token-workflow`: explain one safe credential pattern across chat/image/video/search without showing private values.
 - EVIDENCE: live catalog responses, model modalities, public docs, authored architecture; no unsupported model-count claims.
 - CREATIVE: styles `swiss,editorial,industrial`; layouts `comparison-field,timeline,ui-walkthrough`; voices `anchor-female,calm-male,energetic-male`.
+- VISUAL_WORLDS: multi-modal launch system; one-token creative universe.
+- FILM_ARCHETYPES: brand anthem; multi-modal montage; workflow transformation.
+- MATERIAL_OPPORTUNITIES: at least three real results/surfaces; one motion role; platform payoff.
+- FORBIDDEN_REPETITION: catalog-card slideshow or repeated cyan dashboard.
 - LIMITS: use only live catalog facts; this is an occasional platform overview, not the default fallback.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -26,10 +26,13 @@ def test_skill_declares_runtime_and_series_evidence_contract() -> None:
         "FAMILY_ID",
         "TOPIC_ID",
         "DEMO_ID",
-        "STYLE_ID",
-        "LAYOUT_ID",
+        "FILM_ARCHETYPE",
+        "VISUAL_WORLD",
+        "SHOT_GRAMMAR",
+        "RHYTHM_PATTERN",
         "PALETTE_ID",
         "VOICE_ID",
+        "SOUND_WORLD",
         "ASSET_HASHES",
         "EXECUTED_APIS",
         "EVIDENCE_URLS",
@@ -37,16 +40,16 @@ def test_skill_declares_runtime_and_series_evidence_contract() -> None:
         assert key in body
     assert "ADC-SPOTLIGHT:v1" in body
     assert "unconstrained randomness" in body
-    assert "one primary capability" in body
-    assert "Async hero evidence" in body
-    assert "first capability-specific tool call MUST be that provider's" in body
+    assert "one **premium, product-specific sales film**" in body
+    assert "## 4. Reuse tasks before spending" in body
+    assert "first capability-specific call MUST be the provider's" in body
     assert "list_tasks" in body or "batch-list" in body
     assert "24-hour" in body
-    assert "Do not call generate/create before this lookup" in body
-    assert "reuse a matching completed task" in body
-    assert "do not call generate/create" in body
+    assert "Do not generate before this lookup" in body
+    assert "reuse a matching completed request" in body
+    assert "accepted public URL" in body
     assert "resume a matching pending task by ID" in body
-    assert "Do not poll once and give up" in body
+    assert "Poll according to the returned interval until terminal" in body
     assert "eight 15-second polls" in body
     assert "ADC-SPOTLIGHT-SOURCE:v1" in body
 
@@ -124,70 +127,55 @@ def test_registry_demonstrates_unique_capability_strengths() -> None:
     assert "video is mandatory evidence" in body
 
 
-def test_skill_rotates_voice_style_layout_and_keeps_review_bounded() -> None:
+def test_skill_rotates_creative_genome_and_keeps_review_bounded() -> None:
     body = text(SKILL)
-    for voice in ("energetic-male", "bright-female", "clean-female", "calm-male", "storyteller-male", "warm-female", "anchor-female", "deep-male"):
-        assert voice in body
-    assert "last 3 voice families and palettes" in body
-    assert "14 evidence frames" in body
-    assert "one concentrated same-project refinement" in body
-    assert "Never restart production routing" in body
-    assert "output/result.json" in body
-    assert "30-second Standard draft" in body
-    assert "may reduce only duration and SKU" in body
-    assert "MUST still use a real accepted capability output" in body
-    assert "Never disable inner review" in body
-    assert "actual accepted output URL/MP4" in body
-    assert 'extract decoded frame 0 explicitly at `-ss 0`' in body
-    assert "no black/near-black gap" in body
-    assert "summary itself" in body
-    assert "putting IDs only in tags does not satisfy" in body
-    assert "before any further inspection, waiting, polling, or narration" in body
-    assert "{'code': 'task_already_exists', 'task_id': '<same UUID>'}" in body
-    assert "do not generate another UUID" in body
-    assert "do not call `maestro_create_video` again" in body
-    assert "next and only allowed tool call is `publish_artifact`" in body
-    assert "The outer Producer must then end" in body
-    assert "sandbox-root-qualified project paths" in body
-    assert "Verify the manifest/contact sheet exists" in body
+    for archetype in (
+        "brand anthem",
+        "product reveal",
+        "workflow transformation",
+        "launch trailer",
+        "kinetic manifesto",
+        "cinematic UI demo",
+        "multi-modal montage",
+        "visual poem",
+    ):
+        assert archetype in body
+    assert "recent 3 transition-system, voice-family, sound-world, or palette-family" in body
+    assert "one concentrated pass" in body
     assert 'actual `Skill` call with `skill="visual-review"`' in body
-    assert "second actual `Skill` call" in body
-    assert "mandatory even when the initial review finds no blockers" in body
+    assert "second actual confirmation call" in body
+    assert "output/result.json" not in body  # worker-owned detail is not part of the outer planner
+    assert "before waiting or polling" in body
+    assert "task_already_exists" in body
+    assert "do not generate another UUID or resubmit" in body
+    assert "outer task ends after `recorded=true`" in body
 
 
 def test_skill_requires_sales_blueprint_before_maestro() -> None:
     body = text(SKILL)
-    assert "SPOTLIGHT-SALES-BLUEPRINT:v2" in body
+    assert "ACE-DATA-CLOUD-SALES-BLUEPRINT:v3" in body
     for field in (
         "CAMPAIGN_MODE",
         "PRODUCTS",
         "FINAL_OUTCOME",
         "AUDIENCE",
-        "ONE-LINE VALUE",
         "PAIN",
-        "HOOK",
-        "HERO CASE",
-        "UNIQUE ADVANTAGE",
+        "PROMISE",
+        "HERO_CASE",
+        "UNIQUE_ADVANTAGE",
+        "WORKFLOW",
         "PRICE",
         "OFFER",
         "CTA",
-        "TONE",
-        "VOICE",
+        "MATERIAL_MIX",
+        "QUALITY_GATES",
     ):
-        assert f"{field}:" in body
-    assert "Do not call Maestro until the complete blueprint passes" in body
-    assert "0–3 seconds" in body and "3–7 seconds" in body
-    assert "7–17 seconds" in body and "17–22 seconds" in body
-    assert "22–26 seconds" in body and "26–30 seconds" in body
-    assert "65–80 English words" in body
-    assert "accepted output" in body
-    assert "decoded-pixel proof" in body
-    assert "internal review language" in body
-    assert "ASSET 1 — PAIN / BEFORE" in body
-    assert "ASSET 2 — HERO ACCEPTED OUTPUT" in body
-    assert "ASSET 3 — DETAIL / COMPARISON" in body
-    assert "dynamic price cannot be evaluated" in body
-    assert "See live pricing" in body
+        assert field in body
+    assert "Before Maestro, write" in body
+    assert "fixed six-scene or fixed timestamp storyboard" in body
+    assert "who buys, what changes, why this product is distinctive" in body
+    assert "Integration/price appears only when it advances the sale" in body
+    assert "never place labels such as `accepted output`, `decoded proof`" in body
 
 
 def test_every_topic_has_a_service_specific_sales_playbook() -> None:
@@ -233,24 +221,20 @@ def test_skill_is_a_general_runtime_campaign_planner() -> None:
     assert "Single Capability" in body
     assert "Workflow Campaign" in body
     assert "Platform Story" in body
-    assert "at least one candidate in each mode" in body
-    assert "SPOTLIGHT-SALES-BLUEPRINT:v2" in body
-    for field in ("CAMPAIGN_MODE", "PRODUCTS", "FINAL_OUTCOME", "BASIC_INTRO", "WORKFLOW"):
-        assert f"{field}:" in body
-    assert "capability graph" in body
+    assert "at least one eligible candidate in every mode" in body
+    assert "ACE-DATA-CLOUD-SALES-BLUEPRINT:v3" in body
+    assert "runtime capability graph" in body
     assert "Node contract" in body
     assert "Edge contract" in body
     assert "2–4 services" in body
-    assert "OpenAPI" in body and "input/output" in body
+    assert "proved by OpenAPI or an executed request" in body
     assert "examples, not an allowlist" in body
-    assert "recent 6 `WORKFLOW_ID`" in body
-    assert "recent 4 `CAMPAIGN_MODE`, `HOOK_ID`, and climax grammar" in body
-    assert "dynamic `load_mcp_server`" in body
-    assert "2–4 MCP servers" in body
-    assert "No real hero evidence" in body
-    assert "exact Maestro prompt must begin with `ADC-SPOTLIGHT:v1` as its first line" in body
-    assert "no title, explanation, or Markdown fence before it" in body
-    assert "complete blueprint verbatim from the second line onward" in body
+    assert "recent 6 `FILM_ARCHETYPE`" in body
+    assert "recent 4 campaign-mode, climax-device, or rhythm-pattern" in body
+    assert "selected 2–4 MCP servers" in body
+    assert "real hero evidence" in body
+    assert "It MUST NOT contain `ADC-SPOTLIGHT:v1`" in body
+    assert "artifact summary—not the Maestro prompt" in body
 
 
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:
@@ -280,3 +264,91 @@ def test_public_copy_has_no_supplier_or_secret_leaks() -> None:
         "actual_api_key",
     ):
         assert forbidden not in combined
+
+
+def test_v4_routes_production_to_general_video_without_spotlight_renderer_marker() -> None:
+    body = text(SKILL)
+    assert 'metadata:\n  author: acedatacloud\n  version: "4.0"' in body
+    assert 'ACE-DATA-CLOUD-BRAND-FILM:v1' in body
+    assert 'route to `/general-video`' in body
+    assert '`scenario=auto`, `quality=pro`' in body
+    assert 'never use `spotlight_prepare.py`, `spotlight_renderer.py`' in body
+    assert 'MUST NOT contain `ADC-SPOTLIGHT:v1`' in body
+    assert 'artifact summary—not the Maestro prompt—begins' in body
+    assert '`ADC-SPOTLIGHT:v1 | BLUEPRINT=v3' in body
+
+
+def test_v4_uses_freeform_blueprint_and_structural_creative_genome() -> None:
+    body = text(SKILL)
+    assert 'ACE-DATA-CLOUD-SALES-BLUEPRINT:v3' in body
+    for field in (
+        'FILM_ARCHETYPE',
+        'VISUAL_WORLD',
+        'SHOT_GRAMMAR',
+        'RHYTHM_PATTERN',
+        'OPENING_DEVICE',
+        'CLIMAX_DEVICE',
+        'TRANSITION_SYSTEM',
+        'BRAND_BEHAVIOR',
+        'SOUND_WORLD',
+        'MATERIAL_MIX',
+    ):
+        assert field in body
+    assert 'Do **not** write a fixed six-scene or fixed timestamp storyboard' in body
+    for obsolete in ('0–3 seconds', '3–7 seconds', '7–17 seconds', '17–22 seconds', '22–26 seconds', '26–30 seconds'):
+        assert obsolete not in body
+    assert 'creative distance' in body
+    assert 'palette or labels' in body
+    assert 'generic cyan dashboard' in body
+
+
+def test_v4_requires_rich_materials_by_campaign_mode() -> None:
+    body = text(SKILL)
+    assert 'Require at least four useful visual roles' in body
+    assert 'Require 5–8 roles covering 2–4 real stages' in body
+    assert 'at least three distinct modalities or product surfaces and three real results' in body
+    assert 'catalog-only slideshow is forbidden' in body
+    assert 'One unchanged still may not be stretched through the film' in body
+    assert 'audio-reactive visual world' in body
+    assert 'never fake chat bubbles' in body
+
+
+def test_v4_general_video_professional_director_contract() -> None:
+    body = text(SKILL)
+    for phrase in (
+        'house-style.md',
+        'video-composition.md',
+        'one-sentence concept angle',
+        'embedded font pairing',
+        'foreground-density plan',
+        'prompt expansion',
+        'modular sub-compositions',
+        'Fish narration timing',
+        'actual `Skill` call with `skill="visual-review"`',
+        'second actual confirmation call',
+    ):
+        assert phrase in body
+    assert 'Formal production uses **Pro**, never Standard' in body
+    assert 'Reviewer receives the Blueprint, Creative Genome' in body
+
+
+def test_anchor_topics_supply_multiple_creative_opportunities() -> None:
+    for block in topic_blocks():
+        for marker in (
+            '- VISUAL_WORLDS:',
+            '- FILM_ARCHETYPES:',
+            '- MATERIAL_OPPORTUNITIES:',
+            '- FORBIDDEN_REPETITION:',
+        ):
+            assert marker in block, (block.splitlines()[0], marker)
+    body = text(TOPICS)
+    assert 'Creative opportunity fields' in body
+    assert 'palette or voice swap alone never counts' in body
+
+
+def test_brand_identity_is_stable_but_behavior_must_rotate() -> None:
+    body = text(BRAND)
+    assert 'Identity stays fixed; brand behavior rotates' in body
+    assert 'energy rail, mask edge, registration grid, spatial portal' in body
+    assert 'Do not repeat the same brand entrance' in body
+    assert 'Brand consistency is identity and craft—not template sameness' in body


### PR DESCRIPTION
## Summary
- route formal Capability Spotlight productions through Maestro Pro `/general-video` instead of the fixed Spotlight renderer
- add Sales Blueprint v3 and a structural Creative Genome across archetype, visual world, shot grammar, rhythm, transitions, sound, brand behavior, and materials
- enforce mode-specific material richness so thin assets cannot be stretched into repetitive films
- keep `ADC-SPOTLIGHT:v1` in artifact history only; production uses the non-routing brand-film contract
- expand anchor topics with visual worlds, compatible archetypes, material opportunities, and forbidden repetition

## Verification
- `pytest -q tests/test_capability_spotlight_video.py` — 18 passed
- public Skill/reference sourcing-language audit passed

## Scope
Prompt, Skill, references, and contract tests only. No Maestro implementation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)