### PR TITLE
fix: lock Spotlight selection to breadth lane

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -75,7 +75,16 @@ Use `run_count` to select one mandatory breadth lane before candidate scoring (`
 7. platform brand anthem with three real surfaces/modalities;
 8. deployment / bot / operational lifecycle with sanitized real status evidence.
 
-If the mandatory lane is ineligible, record `LANE_BLOCKED=<reason>` in Creative History and choose the highest-scoring candidate from the least-recent eligible family. Never silently collapse back to image. The recent-history exclusions still apply inside each lane.
+The mandatory lane is a hard selection lock, not a score bonus. Candidate A/B/C labels are not a global ranking: first identify the lane candidate, then compare creative treatments inside that lane. A higher score from another lane cannot override it.
+
+Before final output, run this mechanical lane preflight:
+
+- write `MANDATORY_LANE=<1-8>:<lane-name>` in Creative History;
+- if the selected topic belongs to it, write `LANE_RESULT=selected`;
+- otherwise the entire lane must be ineligible, write `LANE_RESULT=blocked` and `LANE_BLOCKED=<specific live-truth/material reason>`, then select the least-recent eligible family;
+- never emit a selected topic from another lane with `LANE_RESULT=selected`.
+
+The completion marker repeats `lane=<1-8> | lane_result=selected|blocked`. Never silently collapse back to image. Recent-history exclusions still apply inside each lane.
 
 Use `date_iso:run_count` only as a deterministic tiebreaker; do not use unconstrained randomness. `creative_policy` influences scoring but never becomes a fixed shot template:
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -378,5 +378,17 @@ def test_run_count_enforces_eight_breadth_lanes() -> None:
         "deployment / bot / operational lifecycle",
     ):
         assert lane in body
-    assert "LANE_BLOCKED=<reason>" in body
+    assert "LANE_BLOCKED=<specific live-truth/material reason>" in body
     assert "Never silently collapse back to image" in body
+
+
+
+def test_lane_selection_is_a_mechanical_lock_not_a_score_bonus() -> None:
+    body = text(SKILL)
+    assert "hard selection lock, not a score bonus" in body
+    assert "A higher score from another lane cannot override it" in body
+    assert "MANDATORY_LANE=<1-8>:<lane-name>" in body
+    assert "LANE_RESULT=selected" in body
+    assert "LANE_RESULT=blocked" in body
+    assert "completion marker repeats `lane=<1-8>" in body
+    assert "never emit a selected topic from another lane" in body


### PR DESCRIPTION
## Dry-run finding
The lane-1 output explicitly recognized “image craft / typography / edit fidelity” and produced a fitting GPT Image 2 candidate, but the final marker selected a Seedance platform candidate. This proves the breadth lane was treated as a score bonus, not a selection constraint.

## Fix
- make the mandatory lane a hard lock before scoring
- compare creative treatments inside the lane rather than globally overriding it
- require `MANDATORY_LANE` and `LANE_RESULT=selected|blocked` in Creative History
- require a specific `LANE_BLOCKED` reason before selecting another family
- repeat lane/result in the completion marker for mechanical validation

## Verification
- Skill contract tests: 21 passed
- no Maestro changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)