### PR TITLE
fix: enforce Spotlight final media gates

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -214,10 +214,11 @@ Follow it with the complete Blueprint and role→asset provenance. The outer tas
 The Blueprint defines archetype-specific gates plus these invariants:
 
 - decoded frame 0 contains clear brand or product desire—not blank/loading/disclaimer;
-- real hero material is visually dominant, not reduced to evidence cards;
+- for a 30-second format, final-byte `ffprobe` duration is 29.95–30.05 seconds; any other requested format uses the same ±0.05-second tolerance;
+- the selected real hero occupies a visually primary region for at least 40% of runtime, including one near-full-frame hold of at least 3 continuous seconds; authored type/UI may support it but never substitute for it;
 - composition variety and pacing match this run's genome;
 - no static material is dragged beyond the limit appropriate to the archetype;
 - customer copy contains no internal review language, private sourcing facts or invented claims;
 - narration/audio are complete and the CTA is readable.
 
-Make an actual `Skill` call with `skill="visual-review"` against complete initial evidence. Fix blockers in one concentrated pass. Rebuild evidence from the exact final MP4 bytes and make a second actual confirmation call even when no initial blocker exists. The Reviewer receives the Blueprint, Creative Genome, role map, and evidence and judges whether this film fulfilled **its chosen director language**, not whether it resembles previous episodes.
+Make an actual `Skill` call with `skill="visual-review"` against complete initial evidence. Fix blockers in one concentrated pass. Rebuild evidence from the exact final MP4 bytes, measure duration with `ffprobe`, verify hero runtime from the final contact sheet, and make a second actual confirmation call even when no initial blocker exists. If duration, hero-share, audio, CTA, or either review fails, Maestro MUST NOT return an accepted submission. The Reviewer receives the Blueprint, Creative Genome, role map, and evidence and judges whether this film fulfilled **its chosen director language**, not whether it resembles previous episodes.

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -235,6 +235,10 @@ def test_skill_is_a_general_runtime_campaign_planner() -> None:
     assert "real hero evidence" in body
     assert "It MUST NOT contain `ADC-SPOTLIGHT:v1`" in body
     assert "artifact summary—not the Maestro prompt" in body
+    assert "29.95–30.05 seconds" in body
+    assert "at least 40% of runtime" in body
+    assert "near-full-frame hold of at least 3 continuous seconds" in body
+    assert "MUST NOT return an accepted submission" in body
 
 
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:


### PR DESCRIPTION
## Summary
- make final-byte duration a measurable Capability Spotlight quality gate
- require real hero material to dominate at least 40% of runtime and receive a continuous near-full-frame hold
- prohibit accepted submissions when media facts, hero visibility, audio, CTA, or review fail

## Verification
- `pytest -q tests/test_capability_spotlight_video.py` (21 passed)
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)