### PR TITLE
fix: validate Spotlight source assets

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -116,7 +116,7 @@ For generated hero media, the first capability-specific call MUST be the provide
 
 Poll according to the returned interval until terminal. For activation/source preparation, reserve up to two minutes (for example eight 15-second polls). If still pending, record one `ADC-SPOTLIGHT-SOURCE:v1` draft artifact with task ID and fingerprint, make no completion claim, and end without Maestro.
 
-Inspect every selected asset at full resolution. Generated media MUST use a real accepted result. Product/Agent/deployment stories use faithful, sanitized screenshots or lifecycle evidence. Full request JSON is evidence-only; customer-facing frames never contain internal review or provenance language.
+Inspect every selected asset at full resolution. Before Blueprint approval, perform a complete body download for every selected URL, require non-zero bytes, decode at full resolution, and inspect pixel-level semantic fit to `HERO_CASE` and its assigned material role. A metadata, filename, URL, or task status alone never proves availability, visual content, or semantic relevance. A failed download, decode, or semantic-fit check makes that asset ineligible: choose another asset or candidate and do not submit Maestro. Generated media MUST use a real accepted result. Product/Agent/deployment stories use faithful, sanitized screenshots or lifecycle evidence. Full request JSON is evidence-only; customer-facing frames never contain internal review or provenance language.
 
 ## 5. Require a rich material plan
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -239,6 +239,10 @@ def test_skill_is_a_general_runtime_campaign_planner() -> None:
     assert "at least 40% of runtime" in body
     assert "near-full-frame hold of at least 3 continuous seconds" in body
     assert "MUST NOT return an accepted submission" in body
+    assert "complete body download" in body
+    assert "decode at full resolution" in body
+    assert "semantic fit to `HERO_CASE`" in body
+    assert "metadata, filename, URL, or task status alone never proves" in body
 
 
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:


### PR DESCRIPTION
## Summary
- require complete non-zero downloads before Blueprint approval
- decode every selected asset at full resolution and inspect semantic fit to its hero/material role
- make unavailable or unrelated historical outputs ineligible rather than trusting task metadata

## Verification
- `pytest -q tests/test_capability_spotlight_video.py` (21 passed)
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)