### PR TITLE
fix: bound Spotlight production turns

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -201,6 +201,8 @@ It MUST NOT contain `ADC-SPOTLIGHT:v1`; that marker is reserved for the outer ar
 
 Formal production uses **Pro**, never Standard as a quality proxy. Choose format from `{{format}}`; `auto-diverse` must also avoid the recent three formats and fit the content/channel.
 
+Treat Pro turns as a delivery budget, not an invitation to explore: finish the initial render by turn 140; use only `check` plus a contact sheet and at most six targeted frames for each review; Do not run deprecated `validate` or `inspect`. The visual-review call MUST NOT launch an Agent or recursively inventory evidence—read the manifest, contact sheet, and targeted frames directly. Consolidate all blockers into one repair, run one final `check`, one final render, one final-byte review, and confirm delivery by turn 240. Stop optional inspection when any milestone is at risk.
+
 Immediately after Maestro accepts the unique UUID task, call `publish_artifact` before waiting or polling. Exact-ID `task_already_exists` is a successful idempotent replay: do not generate another UUID or resubmit.
 
 The artifact summary—not the Maestro prompt—begins:

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -243,6 +243,10 @@ def test_skill_is_a_general_runtime_campaign_planner() -> None:
     assert "decode at full resolution" in body
     assert "semantic fit to `HERO_CASE`" in body
     assert "metadata, filename, URL, or task status alone never proves" in body
+    assert "initial render by turn 140" in body
+    assert "MUST NOT launch an Agent" in body
+    assert "Do not run deprecated `validate` or `inspect`" in body
+    assert "confirm delivery by turn 240" in body
 
 
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:


### PR DESCRIPTION
## Summary
- treat Pro turns as a delivery budget with initial/final milestones
- constrain visual review evidence and forbid recursive review agents
- replace deprecated validation loops with one check per production phase

## Verification
- `pytest -q tests/test_capability_spotlight_video.py` (21 passed)
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)