### PR TITLE
feat: add Spotlight ad effectiveness contract

### DIFF
--- a/skills/capability-spotlight-video/SKILL.md
+++ b/skills/capability-spotlight-video/SKILL.md
@@ -4,7 +4,7 @@ description: Plan and submit a recurring series of diverse, premium Ace Data Clo
 license: Apache-2.0
 metadata:
   author: acedatacloud
-  version: "5.0"
+  version: "6.0"
 connections: [acedatacloud/acedatacloud]
 compatibility: Requires the AceDataCloud connector, Maestro MCP, and only the capability MCPs authorized for the selected campaign.
 ---
@@ -169,33 +169,56 @@ Do **not** write a fixed six-scene or fixed timestamp storyboard. Describe emoti
 
 The Blueprint must still answer: who buys, what changes, why this product is distinctive, which real result proves it, what it costs, and what to do next. Narration length follows the selected format and must finish before the CTA hold.
 
-Immediately after Blueprint v3, write:
+Immediately after Blueprint v3, write the complete private truth record:
 
 ```text
-ACE-DATA-CLOUD-CONTENT-COVERAGE:v1
+ACE-DATA-CLOUD-TRUTH-LEDGER:v2
+MANDATORY_LANE: <server-authoritative lane>
 PRIMARY_FOCUS: <server-authoritative id>
 SECONDARY_FOCUS: <server-authoritative id>
-BUYER_PAIN: <specific buyer and visible current-state pain>
-PROMISED_EFFECT: <observable buyer result>
-PROOF_ASSET: <real result that substantiates the effect>
-INTEGRATION_ANCHOR: <exact public endpoint plus action/lifecycle>
-VALUE_ANCHOR: <payload-bound Credits plus concrete outcome purchased>
-MECHANISM: <why this input becomes this output>
-CTA: <action plus destination>
-SEMANTIC_BEATS: <flexible content beats, not a fixed timestamp or scene template>
+BUYER_CONTEXT: <verified buyer and job>
+BUYER_PAIN: <verified current-state pain>
+PROMISED_EFFECT: <observable result>
+PROOF_ASSET: <real accepted result>
+MECHANISM: <verified reason the input produces the result>
+API_TRUTH: <exact endpoint, safe request, lifecycle, terminal result>
+PRICE_TRUTH: <payload dimensions, live Credits, concrete outcome>
+CTA_DESTINATION: <verified action and public destination>
+CLAIM_EVIDENCE: <claim→source/asset mapping>
+DISPLAY_DECISION: <which verified truths enter the customer film and why>
 ```
 
-Every film must communicate buyer/pain, promise/effect, real proof, one exact integration anchor, one payload-bound value anchor, and CTA through caption, narration, or unmistakable final-byte visual evidence. The primary focus receives one complete explanatory beat; the secondary focus receives one supporting beat; remaining anchors stay concise. Reject a candidate when this cannot fit legibly in the selected duration. Do not restore a fixed timestamp storyboard.
+Every factual dimension is always verified in the private Truth Ledger. Facts that remain off-screen are still available to the Reviewer and artifact provenance. The Ledger is evidence, not customer copy: never turn its rows into a checklist, card wall, chapter sequence, narration list, or equal-weight layout.
+
+Then write the customer-facing creative hierarchy:
+
+```text
+ACE-DATA-CLOUD-CREATIVE-PROMISE:v1
+ONE_BIG_IDEA: <one non-compound buyer proposition>
+HERO_FIRST: <accepted result and how it leads the film>
+PROOF_1: <what it made or did>
+PROOF_2: <why the result is credible or controlled>
+PROOF_3: <why it is worth acting on now>
+SECONDARY_FOCUS_FOLD: <proof 1|2|3>
+CTA: <one action plus one destination>
+MATERIAL_PALETTE: <available roles, including unused provenance assets>
+DISPLAYED_API_POLICY: <full|compact|absent>
+DISPLAYED_PRICE_POLICY: <full|compact|absent>
+```
+
+The film sells exactly one `ONE_BIG_IDEA`, opens on the accepted hero result before explanation, and uses exactly three materially distinct proofs that support that same idea. The secondary focus must fold into exactly one proof; it cannot create a parallel storyline or fourth proof. Use exactly one CTA.
+
+API and price remain fully verified in the Ledger. When primary they receive a compelling customer-facing treatment; when secondary they receive one compact cue inside a proof; otherwise they may be absent from the MP4. Any fact that does appear must exactly match the Ledger. No truth dimension earns a standalone scene, card, caption, or narration sentence merely because it was verified.
 
 The five focus treatments are:
 
-- `effect-proof`: establish a relevant current state, show the accepted result, state the visible change, and connect it to the buyer outcome. A beauty shot without before/change/outcome fails. It may compress but never omit integration and value anchors.
-- `api-integration`: show the exact public endpoint, a 4–7-line safe request using `$ACEDATACLOUD_API_KEY`, input/action, sync/async lifecycle and polling/retrieval when applicable, and the real terminal result. Explain how the request produces the buyer outcome; never show a raw provenance dump.
-- `price-value`: show the payload/model/size/duration/count/reference dimensions that determine live payload-bound Credits and the concrete outcome purchased in the same composition for at least 2 continuous seconds. A detached price card, unqualified “from” price, or unproved fiat/savings claim fails. Final review must supply targeted final-byte frames at the start, midpoint, and end of that continuous range; Blueprint text, narration alone, or an artifact summary cannot prove this focus.
-- `workflow-mechanism`: show ordered input→operation→result, legal proved edges and lifecycle. A single-service film explains real controls rather than inventing a workflow; a multi-service film explains why every stage is necessary and sells one outcome.
-- `buyer-transformation`: name the buyer/context, recognizable pain, changed working state, real proof, distinctive advantage, and a specific reason to act. Generic “work smarter” language fails.
+- `effect-proof`: dramatize the accepted result, visible change, and buyer outcome. API/price stay subordinate unless selected as the secondary proof.
+- `api-integration`: make endpoint→request→lifecycle→terminal result the drama, using a 4–7-line safe request with `$ACEDATACLOUD_API_KEY`, not a compliance insert.
+- `price-value`: make payload dimensions→Credits→purchased outcome the singular value argument, integrated with the result rather than detached as a rate card.
+- `workflow-mechanism`: dramatize ordered input→necessary operation→result; compress supporting steps into proof, never a logo parade or feature menu.
+- `buyer-transformation`: dramatize one concrete changed working state and the real result that makes it believable; generic “work smarter” language fails.
 
-Palette, voice, format, or archetype changes cannot satisfy a content focus. Focus is a hard treatment lock inside the mandatory lane and does not replace existing Creative Genome distance rules.
+Material-role minimums establish an editorial palette, not a display obligation. Use only materials that strengthen the One Big Idea and three proofs; unused roles remain provenance. Palette, voice, format, or archetype changes cannot satisfy a focus. Do not restore a fixed timestamp storyboard.
 
 ## 7. Choose a professional, product-derived creative world
 
@@ -251,19 +274,21 @@ The Blueprint defines archetype-specific gates plus these invariants:
 - customer copy contains no internal review language, private sourcing facts or invented claims;
 - narration/audio are complete and the CTA is readable.
 
-For both initial and final-byte review, create this matrix from the rendered MP4—not from planning prose:
+For both initial and final-byte review, create this cold-review record from the rendered MP4:
 
 ```text
-FINAL-BYTE-COVERAGE:v1
-| Dimension | Treatment | Status | Timestamp/range | Caption | Narration | Visual/result |
-| buyer-pain | base/primary/secondary | pass|na|fail | ... | ... | ... | ... |
-| effect-proof | base/primary/secondary | pass|na|fail | ... | ... | ... | ... |
-| api-integration | base/primary/secondary | pass|na|fail | ... | ... | ... | ... |
-| price-value | base/primary/secondary | pass|na|fail | ... | ... | ... | ... |
-| workflow-mechanism | base/primary/secondary | pass|na|fail | ... | ... | ... | ... |
-| CTA | base | pass|fail | ... | ... | ... | ... |
+FINAL-BYTE-AD-EFFECTIVENESS:v1
+ONE_LINE_RECALL: <one idea recalled from MP4 alone>
+HERO_FIRST: <pass|fail + first-substantive-visual evidence>
+THREE_DISTINCT_PROOFS: <pass|fail + proof 1/2/3 evidence>
+FOCUS_HIERARCHY: <pass|fail + primary dominance and secondary fold>
+CLUTTER_REPETITION: <pass|fail + simultaneous claims/repeated copy/composition evidence>
+API_PRICE_CONSISTENCY: <pass|fail|na + Ledger comparison>
+ONE_CTA: <pass|fail + action/destination/final-frame evidence>
+TECHNICAL_DELIVERY: <pass|fail + duration/codecs/audio/hero share>
+VERDICT: <accepted|blocked>
 ```
 
-A `pass` needs a final-MP4 timestamp/range plus caption, narration (or explicit `none`), and visible result evidence where applicable. A primary `price-value` pass additionally needs one ≥2-second range and start/mid/end decoded frames where payload, Credits, and purchased outcome are simultaneously legible. `na` may waive only a genuinely inapplicable focus enhancement; it cannot waive base integration or value anchors. Provenance or Blueprint text that never reached the MP4 does not count. Base sales coverage, primary and secondary focus depth, and CTA must all pass; contradictions between captions, narration, API/price truth, and visible results are blockers.
+The independent Reviewer first watches the decoded film without reading the Blueprint or Truth Ledger. It must state the one-line recall, judge whether the accepted result earns attention in the first second, verify the silent first three seconds still communicate the product advantage, identify exactly three distinct proofs, and reject equal-weight cards, simultaneous independent claims, synonymous headlines, repeated compositions, compliance inserts, or multiple CTAs. Each beat has one semantic focal point; visual density may add craft and atmosphere, never more sales propositions.
 
-Make an actual `Skill` call with `skill="visual-review"` against complete initial evidence. Fix blockers in one concentrated pass. Rebuild evidence from the exact final MP4 bytes, measure duration with `ffprobe`, verify hero runtime and the coverage matrix from the final contact sheet/transcript, and make a second actual confirmation call even when no initial blocker exists. If duration, hero-share, audio, CTA, final-byte coverage, primary/secondary focus depth, or either review fails, Maestro MUST NOT return an accepted submission. The Reviewer receives the Blueprint, Content Coverage contract, Creative Genome, role map, and evidence and judges both sales clarity and **its chosen director language**, not whether it resembles previous episodes.
+Only after that cold pass may the Reviewer compare every visible or spoken API, price, payload, result, and CTA against the Ledger. A non-primary API or price may be absent; unsupported or contradictory claims fail. Make an actual `Skill` call with `skill="visual-review"` against complete initial evidence. Fix blockers in one concentrated pass. Rebuild evidence from the exact final MP4 bytes, measure duration with `ffprobe`, verify hero runtime and ad-effectiveness evidence from the final contact sheet/transcript, and make a second actual confirmation call even when no initial blocker exists. If recall, hero-first, proof distinctness, focus hierarchy, clutter/repetition, truth consistency, duration, hero-share, audio, one CTA, or either review fails, Maestro MUST NOT return an accepted submission. The Reviewer receives the Ledger only after its blind assessment.

--- a/skills/capability-spotlight-video/references/topic-registry.md
+++ b/skills/capability-spotlight-video/references/topic-registry.md
@@ -18,7 +18,9 @@ For an unlisted capability, derive and verify all of the following from the live
 - payload dimensions that determine Credits and the concrete outcome bought;
 - focus-specific treatment opportunities plus any genuinely inapplicable focus enhancement.
 
-For every selected topic derive compact `API_FOCUS`, `PRICE_FOCUS`, and `EFFECT_FOCUS` notes before Blueprint approval. API focus names endpoint/request/lifecycle/result; price focus binds payload→Credits→outcome; effect focus names current state→accepted result→visible change. These are runtime derivations, so unlisted topics remain eligible.
+For every selected topic derive compact `API_FOCUS`, `PRICE_FOCUS`, and `EFFECT_FOCUS` notes before Blueprint approval. API focus names endpoint/request/lifecycle/result; price focus binds payload→Credits→outcome; effect focus names current state→accepted result→visible change. These always feed the private Truth Ledger; they enter the MP4 fully only when primary, as one compact proof cue when secondary, and may remain absent otherwise.
+
+Also derive `ONE_BIG_IDEA`, `HERO_FIRST`, a three-item `PROOF_PALETTE`, API/price `DISPLAY_POLICY`, and `ANTI_REPETITION`. The three proofs must support one proposition rather than become three feature labels. Material opportunities are an editorial palette, not a requirement to display every source, stage, or alternate. These are runtime derivations, so unlisted topics remain eligible.
 
 Run the portability test: if the value proposition could be copied unchanged onto another AI service, it is not distinctive enough—derive a sharper angle or reject the candidate.
 
@@ -172,7 +174,7 @@ When a topic block has no explicit values, derive them from its promise, hero ca
 - APIS: `/seedance/videos`, `/seedance/tasks`
 - DOC_QUERY: `Seedance 2.0 reference image audio video character consistency`
 - MCP: Seedance
-- PROMISE: Seedance 2.0 preserves a referenced person/character and can follow audio/video references at high resolution.
+- PROMISE: Seedance 2.0 turns a verified approved reference frame into controlled motion while preserving the visual structure proven by the selected accepted result.
 - AUDIENCE: product, campaign, and creative-development teams turning approved frames into controlled motion.
 - PAIN: turning a static design into video often loses the structure, text treatment, subject, or visual language already approved.
 - BASIC_INTRO: Seedance adds cinematic movement while using image, video, or audio references to control what must remain recognizable.
@@ -193,7 +195,11 @@ When a topic block has no explicit values, derive them from its promise, hero ca
 - VISUAL_WORLDS: camera-control launch bay; spatial UI world.
 - FILM_ARCHETYPES: cinematic UI demo; static→motion transformation; launch trailer.
 - MATERIAL_OPPORTUNITIES: approved reference; full motion clip; start/middle/end frames; structure comparison.
-- FORBIDDEN_REPETITION: replaying one five-second clip for most of the film.
+- ONE_BIG_IDEA: `This controlled five-second result cost 8.4 Credits.` when the verified 720p/5s/reference payload and accepted result still match live truth.
+- HERO_FIRST: open on the accepted moving result already in motion; never begin with a duplicated workflow board, approval card, guides, or explanatory setup.
+- PROOF_PALETTE: accepted motion result; compact `Seedance 2.0 · 720p · 5s · first-frame reference · 8.4 Credits` value cue; source-reference→recognizable-motion comparison.
+- DISPLAY_POLICY: price may lead only for `price-value`; API stays one compact payload cue unless `api-integration` is primary. Use one `RUN SEEDANCE` CTA and one verified destination.
+- FORBIDDEN_REPETITION: replaying one five-second clip for most of the film; duplicated before/after boards; separate chapters that rename “controlled”, “recognizable”, or “coherent”; detached price cards.
 - LIMITS: never use private/celebrity identity; one generation plus one replacement; video required; reference media must be a public HTTPS URL and `return_last_frame` or other 2.5-only options require a Seedance 2.5 model.
 
 ## TOPIC acechat-agent-workspace
@@ -203,14 +209,14 @@ When a topic block has no explicit values, derive them from its promise, hero ca
 - APIS: `/aichat2/conversations`, `/aichat2/mcp-servers`, `/aichat2/skills`, `/aichat2/memories`, `/aichat2/artifacts`, `/aichat2/scheduled-tasks`, `/aichat2/realtime`
 - DOC_QUERY: `AceChat aichat2 MCP Skills Memory Scheduled Tasks Realtime`
 - MCP: AceDataCloud
-- PROMISE: a stateful agent workspace combines conversations, tools, MCP, Skills, Memory, Artifacts, schedules, and realtime voice.
+- PROMISE: a stateful agent workspace lets the next run begin with usable context and deliver another reviewable artifact instead of restarting from zero.
 - AUDIENCE: developers and operators who need an agent to execute repeatable work, not merely answer a chat message.
 - PAIN: A chat box answers; it does not remember the workflow, call the right systems, deliver an artifact, and run again tomorrow.
 - BASIC_INTRO: AceChat is a stateful agent workspace that combines live tools, MCP, Skills, Memory, Artifacts, Scheduled Tasks, and realtime voice.
 - HERO_CASES: one real tool trace that produces an artifact; memory→schedule→completed run lifecycle with sanitized evidence.
 - UNIQUE_ADVANTAGES: real MCP/Skill execution; persistent context and memory; artifacts and scheduled automation in one workspace.
 - PRICE_SCENARIOS: show the actual model/tool call Credits when returned; otherwise use `See live pricing` and never invent a flat workspace price.
-- HOOKS: `A chat box answers. A workspace gets the work done.`; `If the work repeats tomorrow, the agent should remember.`
+- HOOKS: `CONTEXT SHOULDN'T RESET.`; `The next run starts with what the last run learned.`
 - CTA: `OPEN ACECHAT` → `studio.acedata.cloud`.
 - TONE: sharp technical confidence; rapid tool expansion, satisfying artifact result, calm automation proof, decisive CTA.
 - FORBIDDEN_GENERIC_CASES: fake chat bubbles; feature-list narration; invented UI; private memory or token; tool trace without a result.
@@ -223,8 +229,12 @@ When a topic block has no explicit values, derive them from its promise, hero ca
 - VISUAL_WORLDS: living operations room; tool-to-artifact workspace.
 - FILM_ARCHETYPES: cinematic UI journey; workflow transformation; metric-to-human payoff.
 - MATERIAL_OPPORTUNITIES: real tool trace; artifact; schedule lifecycle; sanitized UI states.
-- FORBIDDEN_REPETITION: fake chat bubbles and feature-menu cards.
-- LIMITS: no account data, tokens, private memory, fake chat messages, or invented UI.
+- ONE_BIG_IDEA: `CONTEXT SHOULDN'T RESET.`
+- HERO_FIRST: open on a glowing real delivered artifact connecting immediately to `RUN AGAIN`; do not reveal the full workspace architecture first.
+- PROOF_PALETTE: sanitized real artifact; retained usable-context evidence; completed scheduled-run metadata returning to the next run. Tool, Skill, catalog, and trace may appear only as a fast montage inside these proofs.
+- DISPLAY_POLICY: omit GPT/base-model pricing unless price-value is primary; `RUN AGAIN` is product proof, never a second CTA. End only with `OPEN ACECHAT` and `studio.acedata.cloud`.
+- FORBIDDEN_REPETITION: fake chat bubbles; feature-menu cards; permanent five-card workspace walls; a headline for every tool/Skill/catalog/schedule step; synonymous “workspace gets work done” claims; token-pricing chapters.
+- LIMITS: no account data, tokens, private memory, fake chat messages, invented UI, or flat workspace price.
 
 ## TOPIC captcha-solving-lifecycle
 

--- a/tests/test_capability_spotlight_video.py
+++ b/tests/test_capability_spotlight_video.py
@@ -174,59 +174,65 @@ def test_skill_requires_sales_blueprint_before_maestro() -> None:
     assert "Before Maestro, write" in body
     assert "fixed six-scene or fixed timestamp storyboard" in body
     assert "who buys, what changes, why this product is distinctive" in body
-    assert "one exact integration anchor" in body
-    assert "one payload-bound value anchor" in body
+    assert "always verified in the private Truth Ledger" in body
     assert "never place labels such as `accepted output`, `decoded proof`" in body
 
 
-def test_skill_requires_content_focus_and_final_byte_coverage() -> None:
+def test_skill_separates_truth_from_advertising_expression() -> None:
     body = text(SKILL)
-    assert "ACE-DATA-CLOUD-CONTENT-COVERAGE:v1" in body
-    for focus in (
-        "effect-proof",
-        "api-integration",
-        "price-value",
-        "workflow-mechanism",
-        "buyer-transformation",
-    ):
-        assert focus in body
+    assert "ACE-DATA-CLOUD-TRUTH-LEDGER:v2" in body
     for field in (
+        "BUYER_CONTEXT",
         "BUYER_PAIN",
         "PROMISED_EFFECT",
         "PROOF_ASSET",
-        "INTEGRATION_ANCHOR",
-        "VALUE_ANCHOR",
         "MECHANISM",
-        "SEMANTIC_BEATS",
+        "API_TRUTH",
+        "PRICE_TRUTH",
+        "CTA_DESTINATION",
+        "CLAIM_EVIDENCE",
+        "DISPLAY_DECISION",
     ):
         assert field in body
-    assert "PRIMARY_FOCUS" in body
-    assert "SECONDARY_FOCUS" in body
-    assert "mandatory lane" in body
-    assert "fixed timestamp" in body
-    assert "exact public endpoint" in body
-    assert "4–7-line safe request" in body
-    assert "sync/async lifecycle" in body
-    assert "payload-bound Credits" in body
-    assert "concrete outcome purchased" in body
-    assert "same composition for at least 2 continuous seconds" in body
-    assert "targeted final-byte frames at the start, midpoint, and end" in body
-    assert "integration and value anchors" in body
-
-    assert "FINAL-BYTE-COVERAGE:v1" in body
-    for column in (
-        "Dimension",
-        "Treatment",
-        "Status",
-        "Timestamp/range",
-        "Caption",
-        "Narration",
-        "Visual/result",
+    assert "ACE-DATA-CLOUD-CREATIVE-PROMISE:v1" in body
+    for field in (
+        "ONE_BIG_IDEA",
+        "HERO_FIRST",
+        "PROOF_1",
+        "PROOF_2",
+        "PROOF_3",
+        "SECONDARY_FOCUS_FOLD",
+        "MATERIAL_PALETTE",
+        "DISPLAYED_API_POLICY",
+        "DISPLAYED_PRICE_POLICY",
     ):
-        assert column in body
-    assert "pass|na|fail" in body
-    assert "Provenance or Blueprint text that never reached the MP4 does not count" in body
-    assert "primary and secondary focus depth" in body
+        assert field in body
+    assert "exactly three materially distinct proofs" in body
+    assert "secondary focus must fold into exactly one proof" in body
+    assert "may be absent from the MP4" in body
+    assert "editorial palette, not a display obligation" in body
+    assert "No truth dimension earns a standalone scene" in body
+
+
+def test_skill_uses_cold_ad_effectiveness_review() -> None:
+    body = text(SKILL)
+    assert "FINAL-BYTE-AD-EFFECTIVENESS:v1" in body
+    for field in (
+        "ONE_LINE_RECALL",
+        "HERO_FIRST",
+        "THREE_DISTINCT_PROOFS",
+        "FOCUS_HIERARCHY",
+        "CLUTTER_REPETITION",
+        "API_PRICE_CONSISTENCY",
+        "ONE_CTA",
+        "TECHNICAL_DELIVERY",
+        "VERDICT",
+    ):
+        assert field in body
+    assert "without reading the Blueprint or Truth Ledger" in body
+    assert "first second" in body
+    assert "silent first three seconds" in body
+    assert "one semantic focal point" in body
     assert "MUST NOT return an accepted submission" in body
 
 
@@ -319,6 +325,20 @@ def test_registry_derives_api_price_and_effect_focus_evidence() -> None:
     assert "EFFECT_FOCUS" in body
 
 
+def test_registry_has_seedance_and_acechat_ad_rebuild_guards() -> None:
+    body = text(TOPICS)
+    for phrase in (
+        "This controlled five-second result cost 8.4 Credits.",
+        "open on the accepted moving result already in motion",
+        "RUN SEEDANCE",
+        "CONTEXT SHOULDN'T RESET.",
+        "glowing real delivered artifact",
+        "omit GPT/base-model pricing",
+        "RUN AGAIN` is product proof, never a second CTA",
+    ):
+        assert phrase in body
+
+
 def test_registry_is_an_anchor_library_not_a_closed_catalog() -> None:
     body = text(TOPICS)
     assert "Anchor library — examples, not an allowlist" in body
@@ -348,9 +368,9 @@ def test_public_copy_has_no_supplier_or_secret_leaks() -> None:
         assert forbidden not in combined
 
 
-def test_v5_routes_production_to_general_video_without_spotlight_renderer_marker() -> None:
+def test_v6_routes_production_to_general_video_without_spotlight_renderer_marker() -> None:
     body = text(SKILL)
-    assert 'metadata:\n  author: acedatacloud\n  version: "5.0"' in body
+    assert 'metadata:\n  author: acedatacloud\n  version: "6.0"' in body
     assert 'ACE-DATA-CLOUD-BRAND-FILM:v1' in body
     assert 'route to `/general-video`' in body
     assert '`scenario=auto`, `quality=pro`' in body
@@ -411,7 +431,7 @@ def test_v4_general_video_professional_director_contract() -> None:
     ):
         assert phrase in body
     assert 'Formal production uses **Pro**, never Standard' in body
-    assert 'Reviewer receives the Blueprint, Content Coverage contract, Creative Genome' in body
+    assert 'Reviewer receives the Ledger only after its blind assessment' in body
 
 
 def test_anchor_topics_supply_multiple_creative_opportunities() -> None:


### PR DESCRIPTION
## Summary
- separate private factual Truth Ledger v2 from customer-facing Creative Promise v1
- require one big idea, hero first, exactly three proofs, one CTA, and subordinate secondary focus
- replace row-based coverage review with blind final-byte ad-effectiveness recall/hierarchy/clutter review
- add Seedance and AceChat anti-regression creative fixtures

## Root cause
v6 rewarded one visible card/label/mini-scene per verified fact, producing polished explainers rather than memorable advertisements.

## Verification
- full Skills suite: 113 passed
- diff check

🤖 Generated with [Claude Code](https://claude.com/claude-code)