### PR TITLE
feat: add Qwen Image and Wan 3 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,8 @@
         "./skills/happyhorse-video",
         "./skills/seedance-video",
         "./skills/maestro-video",
-        "./skills/wan-video"
+        "./skills/wan-video",
+        "./skills/qwen-image"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Compatible with **30+ AI coding agents** via the [agentskills.io](https://agents
 | Skill | Description |
 |-------|-------------|
 | [flux-image](skills/flux-image/) | Generate and edit images with Flux (Black Forest Labs) |
+| [qwen-image](skills/qwen-image/) | Generate and edit images with Qwen Image 3 |
 | [seedream-image](skills/seedream-image/) | Generate and edit images with ByteDance Seedream |
 | [nano-banana-image](skills/nano-banana-image/) | Generate and edit images with Google Gemini (NanoBanana) |
 
@@ -211,6 +212,7 @@ Skills provide **knowledge** (when to use, parameters, gotchas). MCP servers pro
 | luma-video | [mcp-luma](https://pypi.org/project/mcp-luma/) | `pip install mcp-luma` | `https://luma.mcp.acedata.cloud/mcp` |
 | sora-video | [mcp-sora](https://pypi.org/project/mcp-sora/) | `pip install mcp-sora` | `https://sora.mcp.acedata.cloud/mcp` |
 | veo-video | [mcp-veo](https://pypi.org/project/mcp-veo/) | `pip install mcp-veo` | `https://veo.mcp.acedata.cloud/mcp` |
+| qwen-image | [mcp-qwen-image](https://pypi.org/project/mcp-qwen-image/) | `pip install mcp-qwen-image` | `https://qwen-image.mcp.acedata.cloud/mcp` |
 | seedream-image | [mcp-seedream](https://pypi.org/project/mcp-seedream/) | `pip install mcp-seedream` | `https://seedream.mcp.acedata.cloud/mcp` |
 | seedance-video | [mcp-seedance](https://pypi.org/project/mcp-seedance/) | `pip install mcp-seedance` | `https://seedance.mcp.acedata.cloud/mcp` |
 | happyhorse-video | [mcp-happyhorse](https://pypi.org/project/mcp-happyhorse/) | `pip install mcp-happyhorse` | `https://happyhorse.mcp.acedata.cloud/mcp` |

--- a/skills/qwen-image/SKILL.md
+++ b/skills/qwen-image/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: qwen-image
+description: Generate and edit images with Qwen Image 3 via Ace Data Cloud. Use for text-to-image, 1-3 reference-image editing, batch output, precise text rendering, or asynchronous image tasks.
+license: Apache-2.0
+metadata:
+  author: acedatacloud
+  version: "1.0"
+compatibility: Requires ACEDATACLOUD_API_TOKEN. Optionally pair with mcp-qwen-image.
+---
+
+# Qwen Image 3
+
+Use `POST https://api.acedata.cloud/qwen-image/images` for generation and editing.
+
+## Models
+
+| Model | Best for |
+|---|---|
+| `qwen-image-3.0` | Value, throughput, batch production |
+| `qwen-image-3.0-pro` | Complex layouts, small text, fine detail |
+
+## Generate
+
+```bash
+curl -X POST https://api.acedata.cloud/qwen-image/images \
+  -H "Authorization: Bearer $ACEDATACLOUD_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen-image-3.0","prompt":"A clean bilingual product poster","size":"1024*1024","n":1}'
+```
+
+## Edit with references
+
+```json
+{
+  "model": "qwen-image-3.0-pro",
+  "prompt": "Keep the subject and change the scene to a cinematic city at night",
+  "image_urls": ["https://cdn.acedata.cloud/r9vsv9.png"],
+  "size": "2048*2048",
+  "n": 1,
+  "prompt_extend": true,
+  "enable_thinking": true,
+  "watermark": false
+}
+```
+
+Use 1–3 reference images. `prompt_extend_mode=agent` is text-to-image only. `n` supports 1–6. Output size uses `WIDTH*HEIGHT`, with pixel area between 512×512 and 2048×2048 and aspect ratio between 1:8 and 8:1.
+
+## Async tasks
+
+Set `async: true` or provide `callback_url`. Poll the returned task with:
+
+```json
+POST /qwen-image/tasks
+{"action":"retrieve","id":"TASK_ID"}
+```
+
+Task retrieval is free. Keep polling every 15 seconds until the response is terminal.
+
+> **MCP:** `pip install mcp-qwen-image` | Hosted: `https://qwen-image.mcp.acedata.cloud/mcp`

--- a/skills/wan-video/SKILL.md
+++ b/skills/wan-video/SKILL.md
@@ -32,6 +32,7 @@ curl -X POST https://api.acedata.cloud/wan/videos \
 | `wan2.6-i2v` | Image-to-Video | Animating a still image into video |
 | `wan2.6-r2v` | Reference Video-to-Video | Character extraction and transfer from reference video |
 | `wan2.6-i2v-flash` | Image-to-Video (Fast) | Quick image-to-video generation |
+| `wan3.0-video` | All-in-One | Text, frames, reference media, files, and public links |
 
 ## Workflows
 
@@ -150,3 +151,24 @@ POST /wan/videos
 - `shot_type: "multi"` produces multi-cut edits rather than a single continuous shot
 
 > **MCP:** `pip install mcp-wan` | Hosted: `https://wan.mcp.acedata.cloud/mcp` | See [all MCP servers](../_shared/mcp-servers.md)
+
+
+## Wan 3 All-in-One
+
+`wan3.0-video` infers the workflow from `media`. Supported types are `first_frame`, `last_frame`, `reference_image` (up to 10), `reference_video` (up to 5, 15 seconds total), `reference_audio` (up to 5, 15 seconds total), `file`, and `link`. Frame mode cannot be mixed with reference/file/link mode.
+
+```json
+POST /wan/videos
+{
+  "model": "wan3.0-video",
+  "prompt": "Use image 1 to create a cinematic product video",
+  "media": [{"type":"reference_image","url":"https://cdn.acedata.cloud/r9vsv9.png"}],
+  "resolution": "720P",
+  "ratio": "16:9",
+  "duration": 5,
+  "audio": true,
+  "async": true
+}
+```
+
+Wan 3 supports 2–30 seconds or `-1` automatic duration. Poll with the existing `/wan/tasks` endpoint.


### PR DESCRIPTION
Adds canonical `qwen-image` skill and extends `wan-video` with the Wan 3 all-in-one media contract. Marketplace JSON is valid and 86 repository tests pass. Public examples use Ace Data Cloud paths and do not expose internal routing. Depends on PlatformBackend PR 1600.

Adversarial review was not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)