### PR TITLE
ci(npm): migrate to trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -23,8 +24,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.14.0
           registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global npm@^11.5.1
 
       - name: Generate date-based version
         id: version
@@ -60,10 +64,8 @@ jobs:
       - name: Set version
         run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
-      - name: Publish
+      - name: Publish with npm trusted publishing
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Blocked until npm package configuration is complete

Before marking this PR ready or merging, an npm package owner must configure a GitHub Actions Trusted Publisher for `@acedatacloud/skills`:

- Organization/user: `AceDataCloud`
- Repository: `Skills`
- Workflow filename: `npm-publish.yml`
- Environment: none
- Allowed action: direct `npm publish`

Package settings: https://www.npmjs.com/package/@acedatacloud/skills/access
Official docs: https://docs.npmjs.com/trusted-publishers/

## Change

- Grants `id-token: write` for OIDC.
- Uses Node 22.14 and npm 11.5.1+.
- Removes the stale long-lived `NPM_TOKEN` from the publish step.
- Keeps the existing date-based version and GitHub release flow.

## Validation

- Workflow YAML parsed successfully.
- `package.json` repository URL exactly matches `AceDataCloud/Skills`.
- `git diff --check` passed.

## Rollout

After the npm-side trusted publisher is configured, mark ready, merge, verify npm publish and the matching GitHub release, then retire the unused organization `NPM_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)