### PR TITLE
fix(npm): let trusted publishing use OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,10 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
-          registry-url: https://registry.npmjs.org
+          node-version: 24
 
       - name: Upgrade npm for trusted publishing
         run: npm install --global npm@^11.5.1
@@ -65,7 +64,9 @@ jobs:
         run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Publish with npm trusted publishing
-        run: npm publish --access public
+        run: |
+          unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
+          npm publish --access public --registry=https://registry.npmjs.org
 
   create-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Root cause

The first trusted-publishing run still inherited `NODE_AUTH_TOKEN=XXXXX...` and the temporary `.npmrc` written by setup-node. npm therefore attempted legacy token auth and returned the same permission-masking 404 instead of using OIDC.

Failed run: https://github.com/AceDataCloud/Skills/actions/runs/33937066961

## Fix

- Use the current official setup-node v6 / Node 24 baseline.
- Do not generate a token-backed `.npmrc`.
- Explicitly clear inherited token/userconfig variables before `npm publish`.
- Keep npm 11.5.1+ and `id-token: write`.

## Validation

- Workflow YAML parsed successfully.
- OIDC permissions and runtime versions asserted.
- Token-backed registry configuration is absent from the publish environment.
- `git diff --check` passed.

## Rollout

Merge after CI; verify npm publishes `@acedatacloud/skills`, creates a matching GitHub release, and then close issue https://github.com/AceDataCloud/Skills/issues/1075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)