### PR TITLE
fix(npm): verify trusted publisher identity

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install --global npm@^11.5.1
 
+      - name: Verify trusted publishing runtime
+        run: |
+          node --version
+          npm --version
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+
       - name: Generate date-based version
         id: version
         run: |

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AceDataCloud/Skills.git"
+    "url": "https://github.com/AceDataCloud/Skills.git"
   },
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
## Evidence

After clearing the setup-node token placeholder, npm changed from permission-masking E404 to ENEEDAUTH: https://github.com/AceDataCloud/Skills/actions/runs/33937380471. This proves token auth is gone but npm is not matching the workflow to the configured Trusted Publisher.

## Change

- Assert the GitHub OIDC request environment exists without logging either token variable.
- Print only Node/npm versions for compatibility evidence.
- Normalize `repository.url` to the exact public GitHub HTTPS URL expected by npm.

## Validation

- Workflow YAML parsed.
- `id-token: write` retained.
- package repository URL validated.
- `git diff --check` passed.

If publishing still returns ENEEDAUTH with the OIDC variables present, the npm package-side Trusted Publisher entry must be corrected to exact case-sensitive values and direct `npm publish` must be allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)