### PR TITLE
fix(npm): publish with rotated package token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for trusted publishing
         run: npm install --global npm@^11.5.1
@@ -70,10 +71,10 @@ jobs:
       - name: Set version
         run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
-      - name: Publish with npm trusted publishing
-        run: |
-          unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
-          npm publish --access public --registry=https://registry.npmjs.org
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Context

The organization `NPM_TOKEN` was rotated at 2026-09-05 02:17 UTC after package publication began returning permission-masking 404s. OIDC diagnostics confirmed the GitHub id-token environment but npm did not match the configured trusted publisher and returned ENEEDAUTH.

## Change

Use the newly rotated organization token for the publish step while retaining Node 24/npm 11 and the OIDC-ready workflow baseline. Token value is never logged.

## Validation

- Workflow YAML parsed successfully.
- Registry and secret references validated.
- Latest main contains all prior OIDC and concurrent Skills changes.
- `git diff --check` passed.

## Rollout

Merge after CI, verify a new `@acedatacloud/skills` version and matching GitHub release, then close issue #1075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)